### PR TITLE
Make Insight Chat teardown safe and recoverable

### DIFF
--- a/src/agent/internal/engine/lens_prepare.go
+++ b/src/agent/internal/engine/lens_prepare.go
@@ -452,6 +452,18 @@ func (e *Engine) runLensKsCleanup(ctx context.Context, p Payload) (string, map[s
 	defer cancel()
 	removed := false
 	alreadyRetired := false
+	workspaceQuarantined := false
+	tombstoneState := ""
+	cleanupResult := func(purgeComplete bool) map[string]any {
+		return map[string]any{
+			"path":                  paths.Workspace,
+			"removed":               removed,
+			"workspace_uid":         identity.WorkspaceUID,
+			"workspace_quarantined": workspaceQuarantined,
+			"purge_complete":        purgeComplete,
+			"tombstone_state":       tombstoneState,
+		}
+	}
 	err = withLensWorkspaceLock(lockContext, paths.Lock, func() error {
 		workspaceMissing := pathMissing(paths.Workspace)
 		trashMissing := pathMissing(paths.Trash)
@@ -467,6 +479,8 @@ func (e *Engine) runLensKsCleanup(ctx context.Context, p Payload) (string, map[s
 					return errors.New("retired managed workspace has unexpected artifacts")
 				}
 				alreadyRetired = true
+				workspaceQuarantined = true
+				tombstoneState = lensWorkspaceTombstoneRetired
 				return nil
 			}
 			if tombstone.State != lensWorkspaceTombstoneRetiring {
@@ -493,6 +507,7 @@ func (e *Engine) runLensKsCleanup(ctx context.Context, p Payload) (string, map[s
 		if err := writeLensWorkspaceTombstone(paths.Tombstone, retiring); err != nil {
 			return err
 		}
+		tombstoneState = lensWorkspaceTombstoneRetiring
 
 		workspaceExists := !workspaceMissing
 		trashExists := !trashMissing
@@ -514,14 +529,17 @@ func (e *Engine) runLensKsCleanup(ctx context.Context, p Payload) (string, map[s
 			}
 			trashExists = true
 		}
+		// Once the retiring tombstone is durable and the live workspace no
+		// longer exists, late prepare work cannot recreate or write this UID.
+		workspaceQuarantined = true
 		removed = workspaceExists || trashExists
 		return nil
 	})
 	if err != nil {
-		return "failed", nil, err.Error()
+		return "failed", cleanupResult(false), err.Error()
 	}
 	if alreadyRetired {
-		return "success", map[string]any{"path": paths.Workspace, "removed": false}, ""
+		return "success", cleanupResult(true), ""
 	}
 	// Removing a potentially large workspace must not hold the lifecycle lock.
 	// The retiring tombstone already prevents every late prepare from claiming it.
@@ -529,7 +547,7 @@ func (e *Engine) runLensKsCleanup(ctx context.Context, p Payload) (string, map[s
 		if err := removeLensWorkspaceTrash(paths.Trash); err != nil {
 			// Identity and the retiring tombstone survive partial deletion so a
 			// retry can safely finish removing the quarantined workspace.
-			return "failed", nil, err.Error()
+			return "failed", cleanupResult(false), err.Error()
 		}
 	}
 	finalLockContext, finalCancel := context.WithTimeout(ctx, lensWorkspaceLockTimeout)
@@ -566,9 +584,10 @@ func (e *Engine) runLensKsCleanup(ctx context.Context, p Payload) (string, map[s
 		return writeLensWorkspaceTombstone(paths.Tombstone, retiredTombstone)
 	})
 	if err != nil {
-		return "failed", nil, err.Error()
+		return "failed", cleanupResult(true), err.Error()
 	}
-	return "success", map[string]any{"path": paths.Workspace, "removed": removed}, ""
+	tombstoneState = lensWorkspaceTombstoneRetired
+	return "success", cleanupResult(true), ""
 }
 
 func pathMissing(path string) bool {

--- a/src/agent/internal/engine/lens_prepare_test.go
+++ b/src/agent/internal/engine/lens_prepare_test.go
@@ -476,10 +476,13 @@ func TestRunLensKsCleanupRetriesAfterPartialTrashRemoval(t *testing.T) {
 		}
 		return errors.New("injected partial removal")
 	}
-	status, _, _ := engine.runLensKsCleanup(context.Background(), payload)
+	status, result, _ := engine.runLensKsCleanup(context.Background(), payload)
 	removeLensWorkspaceTrash = originalRemove
 	if status != "failed" {
 		t.Fatalf("expected injected failure, got %q", status)
+	}
+	if result["workspace_quarantined"] != true || result["purge_complete"] != false || result["tombstone_state"] != lensWorkspaceTombstoneRetiring {
+		t.Fatalf("partial cleanup evidence=%#v", result)
 	}
 	tombstone, err := readLensWorkspaceTombstone(testTombstonePath(root, testWorkspaceUID))
 	if err != nil || tombstone.State != lensWorkspaceTombstoneRetiring {
@@ -491,9 +494,12 @@ func TestRunLensKsCleanupRetriesAfterPartialTrashRemoval(t *testing.T) {
 	if _, err := os.Stat(testIdentityPath(root, testWorkspaceUID)); err != nil {
 		t.Fatalf("identity must survive partial removal: %v", err)
 	}
-	status, _, errMsg := engine.runLensKsCleanup(context.Background(), payload)
+	status, result, errMsg := engine.runLensKsCleanup(context.Background(), payload)
 	if status != "success" {
 		t.Fatalf("retry status=%q err=%q", status, errMsg)
+	}
+	if result["workspace_quarantined"] != true || result["purge_complete"] != true || result["tombstone_state"] != lensWorkspaceTombstoneRetired {
+		t.Fatalf("completed cleanup evidence=%#v", result)
 	}
 	if _, err := os.Stat(testIdentityPath(root, testWorkspaceUID)); !os.IsNotExist(err) {
 		t.Fatalf("identity should be removed last, err=%v", err)

--- a/src/agent/internal/infra/database/tasks.go
+++ b/src/agent/internal/infra/database/tasks.go
@@ -270,6 +270,48 @@ WHERE id=? AND status IN (?, ?)
 	return rows == 1, err
 }
 
+// SealCancelledExecutorResult attaches evidence produced after a cancelled
+// task's execution goroutine has actually returned. Cancellation is persisted
+// before the subprocess exits so reconnects never resurrect work as running;
+// this narrow terminal update lets managed workspace cleanup distinguish that
+// control-plane state from an executor that has finished shutting down.
+func (r *TaskRepo) SealCancelledExecutorResult(
+	ctx context.Context,
+	taskID string,
+	result map[string]any,
+	errMsg string,
+) (bool, error) {
+	if taskID == "" {
+		return false, fmt.Errorf("empty task id")
+	}
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return false, err
+	}
+	now := time.Now().UTC()
+	execResult, err := r.db.conn.ExecContext(ctx, `
+UPDATE tasks SET
+  result=?,
+  error=?,
+  finished_at=COALESCE(finished_at, ?),
+  updated_at=?,
+  result_reported=0
+WHERE id=? AND status=?
+`,
+		string(resultJSON),
+		errMsg,
+		formatTime(now),
+		formatTime(now),
+		taskID,
+		string(model.TaskStatusCancelled),
+	)
+	if err != nil {
+		return false, err
+	}
+	rows, err := execResult.RowsAffected()
+	return rows == 1, err
+}
+
 // MarkCancelledIfActive cancels pending/running work without overwriting a
 // terminal result that may still be awaiting control-plane acknowledgement.
 func (r *TaskRepo) MarkCancelledIfActive(

--- a/src/agent/internal/infra/database/tasks_test.go
+++ b/src/agent/internal/infra/database/tasks_test.go
@@ -418,3 +418,86 @@ func TestTaskRepoFinishIfActiveDoesNotOverwriteTerminalResult(t *testing.T) {
 		t.Fatalf("terminal result changed: %#v", task)
 	}
 }
+
+func TestTaskRepoSealCancelledExecutorResultRequeuesTerminalEvidence(t *testing.T) {
+	ctx := t.Context()
+	db, err := Open(ctx, filepath.Join(t.TempDir(), "agent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewTaskRepo(db)
+	if err := repo.RecordCommand(ctx, RecordInput{TaskID: "restore-cancelled", Kind: "restore.run"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, changed, err := repo.MarkCancelledIfActive(ctx, "restore-cancelled"); err != nil || !changed {
+		t.Fatalf("cancel changed=%v err=%v", changed, err)
+	}
+	if err := repo.MarkResultReported(ctx, "restore-cancelled"); err != nil {
+		t.Fatal(err)
+	}
+
+	stored, err := repo.SealCancelledExecutorResult(
+		ctx,
+		"restore-cancelled",
+		map[string]any{
+			"executor_finished": true,
+			"completion_source": "agent_executor",
+		},
+		"canceled",
+	)
+	if err != nil || !stored {
+		t.Fatalf("seal stored=%v err=%v", stored, err)
+	}
+	task, err := repo.Get(ctx, "restore-cancelled")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Status != model.TaskStatusCancelled || task.ResultReported {
+		t.Fatalf("sealed task status=%q reported=%v", task.Status, task.ResultReported)
+	}
+	if task.Result["executor_finished"] != true || task.Result["completion_source"] != "agent_executor" {
+		t.Fatalf("sealed result=%#v", task.Result)
+	}
+}
+
+func TestTaskRepoSealCancelledExecutorResultDoesNotOverwriteSuccess(t *testing.T) {
+	ctx := t.Context()
+	db, err := Open(ctx, filepath.Join(t.TempDir(), "agent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	repo := NewTaskRepo(db)
+	if err := repo.RecordCommand(ctx, RecordInput{TaskID: "restore-success", Kind: "restore.run"}); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := repo.FinishIfActive(
+		ctx,
+		"restore-success",
+		model.TaskStatusSucceeded,
+		map[string]any{"restored": true},
+		"",
+	)
+	if err != nil || !stored {
+		t.Fatalf("finish stored=%v err=%v", stored, err)
+	}
+	stored, err = repo.SealCancelledExecutorResult(
+		ctx,
+		"restore-success",
+		map[string]any{"executor_finished": true},
+		"canceled",
+	)
+	if err != nil || stored {
+		t.Fatalf("seal stored=%v err=%v", stored, err)
+	}
+	task, err := repo.Get(ctx, "restore-success")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.Status != model.TaskStatusSucceeded || task.Result["restored"] != true {
+		t.Fatalf("successful terminal result changed: %#v", task)
+	}
+}

--- a/src/agent/internal/wire/handler.go
+++ b/src/agent/internal/wire/handler.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -362,6 +363,18 @@ func (h *Handler) runTask(ctx context.Context, sink Sender, cmd *TaskCommand) {
 	}
 	h.tracker.Register(task, cancel)
 	defer h.tracker.Unregister(cmd.TaskID)
+	if h.tasks != nil {
+		persisted, err := h.tasks.Get(taskCtx, cmd.TaskID)
+		if err != nil {
+			slog.Warn("load accepted task before execution failed", "task_id", cmd.TaskID, "err", err)
+		} else if persisted.Status == model.TaskStatusCancelled {
+			// task.cancel can arrive after the durable command acceptance but
+			// before this goroutine registers with the in-memory tracker. Close
+			// that window before entering Engine.Run; later cancels are handled
+			// by Tracker.Cancel as usual.
+			cancel()
+		}
+	}
 
 	aliveDone := make(chan struct{})
 	go h.aliveLoop(taskCtx, sink, cmd.TaskID, aliveDone)
@@ -462,6 +475,18 @@ func (h *Handler) runTask(ctx context.Context, sink Sender, cmd *TaskCommand) {
 		Payload: cmd.Payload,
 		Source:  engine.SourceWebSocket,
 	}, wsSink)
+	managedWorkspaceRestore := isManagedWorkspaceRestoreCommand(cmd)
+	if managedWorkspaceRestore {
+		if out.Result == nil {
+			out.Result = map[string]any{}
+		}
+		// Engine.Run returns only after the Kopia process group has been waited
+		// for. This is intentionally stronger evidence than the local cancelled
+		// state persisted when task.cancel first arrives.
+		out.Result["executor_finished"] = true
+		out.Result["completion_source"] = "agent_executor"
+		out.Result["executor_finished_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+	}
 
 	status := out.Status
 	result, resultStats := boundTaskResult(out.Result)
@@ -507,7 +532,20 @@ func (h *Handler) runTask(ctx context.Context, sink Sender, cmd *TaskCommand) {
 			slog.Warn("persist task result failed", "task_id", cmd.TaskID, "err", err)
 			return
 		}
-		if !stored {
+		initiallyStored := stored
+		if !stored && managedWorkspaceRestore {
+			stored, err = h.tasks.SealCancelledExecutorResult(
+				persistCtx,
+				cmd.TaskID,
+				result,
+				errMsg,
+			)
+			if err != nil {
+				slog.Warn("persist cancelled executor result failed", "task_id", cmd.TaskID, "err", err)
+				return
+			}
+		}
+		if !initiallyStored || localStatus == model.TaskStatusCancelled {
 			persisted, getErr := h.tasks.Get(persistCtx, cmd.TaskID)
 			if getErr != nil {
 				slog.Warn("load competing terminal task result failed", "task_id", cmd.TaskID, "err", getErr)
@@ -527,6 +565,28 @@ func (h *Handler) runTask(ctx context.Context, sink Sender, cmd *TaskCommand) {
 	if err := h.sendLiveTaskResult(persistCtx, sink, cmd.TaskID, status, result, errMsg); err != nil {
 		slog.Warn("send task.result failed", "task_id", cmd.TaskID, "err", err)
 	}
+}
+
+func isManagedWorkspaceRestoreCommand(cmd *TaskCommand) bool {
+	if cmd == nil || engine.NormalizeKind(cmd.Kind) != "restore" || cmd.Payload == nil {
+		return false
+	}
+	payload := engine.ParsePayload(cmd.Payload)
+	return payloadString(cmd.Payload["workspace_kind"]) == "managed_restore" &&
+		payloadString(cmd.Payload["workspace_uid"]) != "" &&
+		payloadString(cmd.Payload["managed_workspace_path"]) != "" &&
+		payload.Path != ""
+}
+
+func payloadString(value any) string {
+	if value == nil {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(text)
 }
 
 func (h *Handler) progressLoop(ctx context.Context, sink Sender, taskID string, done <-chan struct{}) {

--- a/src/agent/internal/wire/handler_managed_restore_test.go
+++ b/src/agent/internal/wire/handler_managed_restore_test.go
@@ -1,0 +1,76 @@
+package wire
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"hyperfilelens/agent/internal/controller"
+	"hyperfilelens/agent/internal/infra/database"
+	"hyperfilelens/agent/internal/model"
+)
+
+func TestIsManagedWorkspaceRestoreCommand(t *testing.T) {
+	managed := &TaskCommand{
+		Kind: "restore.run",
+		Payload: map[string]any{
+			"path":                   "/workspace/org-1/data/ks-1",
+			"workspace_kind":         "managed_restore",
+			"workspace_uid":          "8f65d43a-09fd-4ae7-b5f1-159352838a23",
+			"managed_workspace_path": "/workspace/org-1/data/ks-1",
+		},
+	}
+	if !isManagedWorkspaceRestoreCommand(managed) {
+		t.Fatal("managed workspace restore was not recognized")
+	}
+
+	ordinary := *managed
+	ordinary.Payload = map[string]any{"path": "/restore", "workspace_kind": "user_data"}
+	if isManagedWorkspaceRestoreCommand(&ordinary) {
+		t.Fatal("ordinary restore must not receive managed executor evidence")
+	}
+}
+
+func TestManagedRestoreCancelledBeforeTrackerRegistrationDoesNotExecute(t *testing.T) {
+	ctx := t.Context()
+	db, err := database.Open(ctx, filepath.Join(t.TempDir(), "agent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	repo := database.NewTaskRepo(db)
+	cmd := &TaskCommand{
+		TaskID: "managed-restore-pre-cancelled",
+		Kind:   "restore.run",
+		Payload: map[string]any{
+			"path":                   "/workspace/org-1/data/ks-1",
+			"workspace_kind":         "managed_restore",
+			"workspace_uid":          "8f65d43a-09fd-4ae7-b5f1-159352838a23",
+			"managed_workspace_path": "/workspace/org-1/data/ks-1",
+		},
+	}
+	if err := repo.RecordCommand(ctx, database.RecordInput{
+		TaskID:  cmd.TaskID,
+		Kind:    cmd.Kind,
+		Payload: cmd.Payload,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if status, changed, err := repo.MarkCancelledIfActive(ctx, cmd.TaskID); err != nil || !changed || status != model.TaskStatusCancelled {
+		t.Fatalf("pre-cancel status=%q changed=%v err=%v", status, changed, err)
+	}
+
+	handler := NewHandler(nil, controller.NewTracker(), repo)
+	handler.runTask(context.Background(), &captureSender{}, cmd)
+
+	persisted, err := repo.Get(ctx, cmd.TaskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Status != model.TaskStatusCancelled {
+		t.Fatalf("task status=%q, want cancelled", persisted.Status)
+	}
+	if persisted.Result["executor_finished"] != true || persisted.Result["completion_source"] != "agent_executor" {
+		t.Fatalf("executor stop evidence=%#v", persisted.Result)
+	}
+}

--- a/src/agent/internal/wire/result_bounds.go
+++ b/src/agent/internal/wire/result_bounds.go
@@ -33,6 +33,9 @@ var essentialResultKeys = map[string]struct{}{
 	"failed_count": {}, "created": {}, "deleted_count": {},
 	"selected_paths": {}, "stats": {}, "restore": {}, "restore_results": {},
 	"results": {}, "entries": {}, "snapshot_browse": {}, "snapshot_download": {},
+	"executor_finished": {}, "executor_finished_at": {}, "completion_source": {},
+	"workspace_uid": {}, "workspace_quarantined": {}, "purge_complete": {},
+	"tombstone_state": {},
 }
 
 func boundTaskResult(result map[string]any) (map[string]any, resultBoundStats) {

--- a/src/agent/internal/wire/result_bounds_test.go
+++ b/src/agent/internal/wire/result_bounds_test.go
@@ -77,3 +77,35 @@ func TestTaskResultFrameStaysWithinWireLimit(t *testing.T) {
 		t.Fatalf("task.result frame bytes=%d, want <=%d", len(encoded), maxTaskResultFrameBytes)
 	}
 }
+
+func TestBoundTaskResultKeepsWorkspaceSafetyEvidence(t *testing.T) {
+	result := map[string]any{
+		"executor_finished":     true,
+		"executor_finished_at":  "2026-08-31T14:00:00Z",
+		"completion_source":     "agent_executor",
+		"workspace_uid":         "8f65d43a-09fd-4ae7-b5f1-159352838a23",
+		"workspace_quarantined": true,
+		"purge_complete":        false,
+		"tombstone_state":       "retiring",
+		"other":                 strings.Repeat("x", maxTaskResultBytes),
+	}
+
+	bounded, stats := boundTaskResult(result)
+
+	if !stats.Truncated {
+		t.Fatal("expected oversized diagnostic data to be truncated")
+	}
+	for key, expected := range map[string]any{
+		"executor_finished":     true,
+		"executor_finished_at":  "2026-08-31T14:00:00Z",
+		"completion_source":     "agent_executor",
+		"workspace_uid":         "8f65d43a-09fd-4ae7-b5f1-159352838a23",
+		"workspace_quarantined": true,
+		"purge_complete":        false,
+		"tombstone_state":       "retiring",
+	} {
+		if bounded[key] != expected {
+			t.Fatalf("safety evidence %q=%#v, want %#v", key, bounded[key], expected)
+		}
+	}
+}

--- a/src/backend/apps/lens_bridge/management/commands/resume_blocked_chat_cleanup.py
+++ b/src/backend/apps/lens_bridge/management/commands/resume_blocked_chat_cleanup.py
@@ -13,10 +13,24 @@ from apps.lens_bridge.services import sl_client, teardown_blocking
 
 
 def _conversion_blocked(blocking: dict[str, object]) -> bool:
+    reason = str(blocking.get("reason") or "")
     return bool(
-        str(blocking.get("reason") or "") == "conversion_stop_unconfirmed"
-        or str(blocking.get("task_id") or "").strip()
+        reason == "conversion_stop_unconfirmed"
+        or (
+            str(blocking.get("task_id") or "").strip()
+            and not _restore_blocked(blocking)
+        )
     )
+
+
+def _restore_blocked(blocking: dict[str, object]) -> bool:
+    return str(blocking.get("reason") or "") in {
+        "restore_executor_still_stopping",
+        "restore_dispatch_still_stopping",
+        "restore_node_task_missing",
+        "restore_node_task_identity_mismatch",
+        "restore_task_missing",
+    }
 
 
 def _require_matching_blocked_task(
@@ -25,9 +39,25 @@ def _require_matching_blocked_task(
 ) -> None:
     blocked_task_id = str(blocking.get("task_id") or "").strip()
     if blocked_task_id and blocked_task_id != task_id:
-        raise CommandError(
-            "SourceLens task id does not match the recorded blocking condition."
-        )
+        raise CommandError("Task id does not match the recorded blocking condition.")
+
+
+def _record_cleanup_confirmation(
+    teardown_state: dict,
+    *,
+    confirmation_key: str,
+    confirmation: dict,
+    restore_task_id: str,
+) -> None:
+    """Record one confirmation while preserving prior restore task evidence."""
+
+    teardown_state[confirmation_key] = confirmation
+    if not restore_task_id:
+        return
+    confirmations = teardown_state.get("manual_restore_stop_confirmations")
+    confirmations = dict(confirmations) if isinstance(confirmations, dict) else {}
+    confirmations[restore_task_id] = confirmation
+    teardown_state["manual_restore_stop_confirmations"] = confirmations
 
 
 class Command(BaseCommand):
@@ -41,6 +71,7 @@ class Command(BaseCommand):
         target.add_argument("--session-id", type=int)
         target.add_argument("--knowledge-source-id", type=int)
         parser.add_argument("--source-lens-task-id")
+        parser.add_argument("--restore-task-id")
         parser.add_argument("--reason", required=True)
         parser.add_argument(
             "--confirm-executor-stopped",
@@ -57,16 +88,21 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        task_id = str(options["source_lens_task_id"] or "").strip()
+        task_id = str(options.get("source_lens_task_id") or "").strip()
+        restore_task_id = str(options.get("restore_task_id") or "").strip()
+        if task_id and restore_task_id:
+            raise CommandError(
+                "Use either --source-lens-task-id or --restore-task-id, not both."
+            )
         reason = str(options["reason"] or "").strip()
         if not reason:
             raise CommandError("Reason is required.")
-        if task_id:
+        if task_id or restore_task_id:
             if not options["confirm_executor_stopped"]:
                 raise CommandError(
-                    "Refusing to resume cleanup without "
-                    "--confirm-executor-stopped."
+                    "Refusing to resume cleanup without --confirm-executor-stopped."
                 )
+        if task_id:
             remote_task = sl_client.get_task_by_id(task_id)
             if remote_task is None:
                 raise CommandError(
@@ -82,16 +118,21 @@ class Command(BaseCommand):
                 raise CommandError(
                     f"SourceLens task is {remote_status or 'UNKNOWN'}, not terminal."
                 )
+        elif restore_task_id:
+            remote_status = "OPERATOR_CONFIRMED"
         else:
             if not options.get("confirm_retry"):
                 raise CommandError(
-                    "Refusing to resume non-conversion cleanup without "
-                    "--confirm-retry."
+                    "Refusing to resume non-conversion cleanup without --confirm-retry."
                 )
             remote_status = ""
 
         knowledge_source_id = options.get("knowledge_source_id")
         if knowledge_source_id is not None:
+            if restore_task_id:
+                raise CommandError(
+                    "Restore executor confirmation must target the owning Chat session."
+                )
             self._resume_knowledge_source_cleanup(
                 knowledge_source_id=int(knowledge_source_id),
                 task_id=task_id,
@@ -118,13 +159,14 @@ class Command(BaseCommand):
             blocking = teardown_state.get("blocking")
             blocking = blocking if isinstance(blocking, dict) else {}
             session_conversion_blocked = _conversion_blocked(blocking)
+            session_restore_blocked = _restore_blocked(blocking)
             if not task_id and session_conversion_blocked:
                 raise CommandError(
                     "Conversion cleanup requires --source-lens-task-id and "
                     "--confirm-executor-stopped."
                 )
             knowledge_source_id = session.knowledge_source_id
-            if task_id and knowledge_source_id is None:
+            if (task_id or restore_task_id) and knowledge_source_id is None:
                 raise CommandError("Blocked Chat has no Knowledge Source.")
 
             knowledge_source = None
@@ -134,7 +176,7 @@ class Command(BaseCommand):
                     .filter(pk=knowledge_source_id)
                     .first()
                 )
-            if task_id and knowledge_source is None:
+            if (task_id or restore_task_id) and knowledge_source is None:
                 raise CommandError("Blocked Chat Knowledge Source was not found.")
             if (
                 knowledge_source is not None
@@ -150,16 +192,19 @@ class Command(BaseCommand):
                 )
                 candidate_blocking = knowledge_source_state.get("blocking")
                 knowledge_source_blocking = (
-                    candidate_blocking
-                    if isinstance(candidate_blocking, dict)
-                    else {}
+                    candidate_blocking if isinstance(candidate_blocking, dict) else {}
                 )
             knowledge_source_conversion_blocked = _conversion_blocked(
                 knowledge_source_blocking
             )
+            knowledge_source_restore_blocked = _restore_blocked(
+                knowledge_source_blocking
+            )
             conversion_blocked = (
-                session_conversion_blocked
-                or knowledge_source_conversion_blocked
+                session_conversion_blocked or knowledge_source_conversion_blocked
+            )
+            restore_blocked = (
+                session_restore_blocked or knowledge_source_restore_blocked
             )
             if task_id:
                 if not conversion_blocked:
@@ -176,10 +221,25 @@ class Command(BaseCommand):
                     "Conversion cleanup requires --source-lens-task-id and "
                     "--confirm-executor-stopped."
                 )
+            if restore_task_id:
+                if not restore_blocked:
+                    raise CommandError(
+                        "Cleanup is not blocked on a Chat workspace restore."
+                    )
+                _require_matching_blocked_task(blocking, restore_task_id)
+                _require_matching_blocked_task(
+                    knowledge_source_blocking,
+                    restore_task_id,
+                )
+            elif restore_blocked:
+                raise CommandError(
+                    "Restore cleanup requires --restore-task-id and "
+                    "--confirm-executor-stopped."
+                )
 
             confirmation = {
                 "confirmed": True,
-                "task_id": task_id,
+                "task_id": task_id or restore_task_id,
                 "remote_status": remote_status,
                 "operator": getpass.getuser(),
                 "reason": reason[:1000],
@@ -188,11 +248,13 @@ class Command(BaseCommand):
             }
             if knowledge_source is not None and (
                 task_id
+                or restore_task_id
                 or "blocking" in (knowledge_source.teardown_state_json or {})
             ):
                 self._resume_locked_knowledge_source(
                     knowledge_source,
                     task_id=task_id,
+                    restore_task_id=restore_task_id,
                     confirmation=confirmation,
                 )
 
@@ -200,9 +262,18 @@ class Command(BaseCommand):
             confirmation_key = (
                 "manual_stop_confirmation"
                 if task_id
-                else "manual_cleanup_confirmation"
+                else (
+                    "manual_restore_stop_confirmation"
+                    if restore_task_id
+                    else "manual_cleanup_confirmation"
+                )
             )
-            teardown_state[confirmation_key] = confirmation
+            _record_cleanup_confirmation(
+                teardown_state,
+                confirmation_key=confirmation_key,
+                confirmation=confirmation,
+                restore_task_id=restore_task_id,
+            )
             session.teardown_state_json = teardown_state
             session.cleanup_status = LensSessionLink.CleanupStatus.PENDING
             session.teardown_attempts = 0
@@ -225,9 +296,7 @@ class Command(BaseCommand):
                 _queue_teardown_or_record_error,
             )
 
-            transaction.on_commit(
-                lambda: _queue_teardown_or_record_error(session.id)
-            )
+            transaction.on_commit(lambda: _queue_teardown_or_record_error(session.id))
 
         self.stdout.write(
             self.style.SUCCESS(
@@ -266,9 +335,7 @@ class Command(BaseCommand):
                     "cleanup by session id."
                 )
 
-            teardown_state = dict(
-                knowledge_source.teardown_state_json or {}
-            )
+            teardown_state = dict(knowledge_source.teardown_state_json or {})
             blocking = teardown_state.get("blocking")
             blocking = blocking if isinstance(blocking, dict) else {}
             conversion_blocked = _conversion_blocked(blocking)
@@ -285,8 +352,7 @@ class Command(BaseCommand):
                 )
             elif not teardown_blocking.intervention_required(teardown_state):
                 raise CommandError(
-                    "Knowledge Source cleanup does not require operator "
-                    "intervention."
+                    "Knowledge Source cleanup does not require operator intervention."
                 )
 
             confirmation = {
@@ -301,6 +367,7 @@ class Command(BaseCommand):
             self._resume_locked_knowledge_source(
                 knowledge_source,
                 task_id=task_id,
+                restore_task_id="",
                 confirmation=confirmation,
             )
 
@@ -308,9 +375,7 @@ class Command(BaseCommand):
                 _queue_teardown,
             )
 
-            transaction.on_commit(
-                lambda: _queue_teardown(knowledge_source.id)
-            )
+            transaction.on_commit(lambda: _queue_teardown(knowledge_source.id))
 
         self.stdout.write(
             self.style.SUCCESS(
@@ -324,6 +389,7 @@ class Command(BaseCommand):
         knowledge_source: LensKnowledgeSource,
         *,
         task_id: str,
+        restore_task_id: str,
         confirmation: dict,
     ) -> None:
         """Reset one locked KS after its blocking condition was confirmed."""
@@ -345,9 +411,18 @@ class Command(BaseCommand):
         confirmation_key = (
             "manual_stop_confirmation"
             if task_id
-            else "manual_cleanup_confirmation"
+            else (
+                "manual_restore_stop_confirmation"
+                if restore_task_id
+                else "manual_cleanup_confirmation"
+            )
         )
-        teardown_state[confirmation_key] = confirmation
+        _record_cleanup_confirmation(
+            teardown_state,
+            confirmation_key=confirmation_key,
+            confirmation=confirmation,
+            restore_task_id=restore_task_id,
+        )
         knowledge_source.teardown_state_json = teardown_state
         knowledge_source.teardown_attempts = 0
         knowledge_source.teardown_claim_token = None
@@ -356,7 +431,11 @@ class Command(BaseCommand):
         knowledge_source.status_detail = (
             "Conversion stop was confirmed; cleanup is queued."
             if task_id
-            else "Cleanup recovery was confirmed and queued."
+            else (
+                "Restore executor stop was confirmed; cleanup is queued."
+                if restore_task_id
+                else "Cleanup recovery was confirmed and queued."
+            )
         )
         knowledge_source.save(
             update_fields=[

--- a/src/backend/apps/lens_bridge/services/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/services/chat_lifecycle.py
@@ -566,9 +566,7 @@ def create_copilot_chat(
             )
             link = _create_session_link()
             link.gateway_queue_entered_at = timezone.now()
-            link.save(
-                update_fields=["gateway_queue_entered_at", "updated_at"]
-            )
+            link.save(update_fields=["gateway_queue_entered_at", "updated_at"])
     except IntegrityError:
         link = LensSessionLink.objects.filter(
             organization=org,
@@ -593,15 +591,12 @@ def request_copilot_chat_teardown(link: LensSessionLink) -> LensSessionLink:
     if locked.lifecycle_status == LensSessionLink.LifecycleStatus.DELETED:
         return locked
 
-    legacy_teardown_intent = str(
-        (locked.teardown_state_json or {}).get("intent") or ""
-    )
+    legacy_teardown_intent = str((locked.teardown_state_json or {}).get("intent") or "")
     delete_intent_already_active = (
         locked.lifecycle_status == LensSessionLink.LifecycleStatus.DELETING
         and (
             (
-                locked.cleanup_intent
-                == LensSessionLink.CleanupIntent.DELETE_SESSION
+                locked.cleanup_intent == LensSessionLink.CleanupIntent.DELETE_SESSION
                 and locked.cleanup_status
                 in {
                     LensSessionLink.CleanupStatus.PENDING,
@@ -612,7 +607,55 @@ def request_copilot_chat_teardown(link: LensSessionLink) -> LensSessionLink:
             or legacy_teardown_intent == _TEARDOWN_INTENT_DELETE
         )
     )
-    if not delete_intent_already_active:
+    if (
+        delete_intent_already_active
+        and locked.cleanup_status == LensSessionLink.CleanupStatus.BLOCKED
+    ):
+        # An explicit retry never bypasses a safety fence. It only resets the
+        # bounded retry journal so the same Restore, SourceLens, and Workspace
+        # checks can observe an externally resolved condition immediately.
+        locked.cleanup_status = LensSessionLink.CleanupStatus.PENDING
+        locked.teardown_attempts = 0
+        locked.teardown_claim_token = None
+        locked.teardown_claimed_at = None
+        locked.teardown_next_retry_at = None
+        locked.teardown_state_json = teardown_blocking.clear_blocking(
+            dict(locked.teardown_state_json or {})
+        )
+        locked.provision_detail = "Retrying chat cleanup."
+        locked.save(
+            update_fields=[
+                "cleanup_status",
+                "teardown_attempts",
+                "teardown_claim_token",
+                "teardown_claimed_at",
+                "teardown_next_retry_at",
+                "teardown_state_json",
+                "provision_detail",
+                "updated_at",
+            ]
+        )
+        if locked.knowledge_source_id is not None:
+            knowledge_source = (
+                LensKnowledgeSource.all_objects.select_for_update()
+                .filter(pk=locked.knowledge_source_id)
+                .first()
+            )
+            if knowledge_source is not None:
+                knowledge_source.teardown_state_json = teardown_blocking.clear_blocking(
+                    dict(knowledge_source.teardown_state_json or {})
+                )
+                knowledge_source.teardown_attempts = 0
+                knowledge_source.teardown_next_retry_at = None
+                knowledge_source.save(
+                    update_fields=[
+                        "teardown_state_json",
+                        "teardown_attempts",
+                        "teardown_next_retry_at",
+                        "updated_at",
+                    ]
+                )
+    elif not delete_intent_already_active:
         locked.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
         locked.provision_phase = LensSessionLink.ProvisionPhase.DELETING
         locked.provision_detail = "Deleting chat resources."
@@ -689,10 +732,9 @@ def _claim_copilot_chat_provision(
                 return None, "stale"
         elif expected_generation is None or expected_poll_sequence is None:
             return None, "stale"
-        elif (
-            link.provision_generation != int(expected_generation)
-            or link.provision_poll_sequence != int(expected_poll_sequence)
-        ):
+        elif link.provision_generation != int(
+            expected_generation
+        ) or link.provision_poll_sequence != int(expected_poll_sequence):
             return None, "stale"
         if link.provision_claimed_at and link.provision_claimed_at > now - timedelta(
             seconds=PROVISION_CLAIM_TTL_SECONDS
@@ -743,7 +785,9 @@ def run_copilot_chat_provision(
             claim_token=claim_token,
         )
         if result.get("status") == "waiting":
-            sync_result = result.get("sync") if isinstance(result.get("sync"), dict) else {}
+            sync_result = (
+                result.get("sync") if isinstance(result.get("sync"), dict) else {}
+            )
             retry_after_seconds = int(
                 result.get("retry_after_seconds")
                 or sync_result.get("retry_after_seconds")
@@ -1455,7 +1499,9 @@ def _defer_provision_poll(
     )
     if link is None:
         raise ChatProvisionLeaseLostError("Chat provisioning lease was lost.")
-    delay = max(1, min(int(retry_after_seconds), _PROVISION_TRANSIENT_RETRY_MAX_SECONDS))
+    delay = max(
+        1, min(int(retry_after_seconds), _PROVISION_TRANSIENT_RETRY_MAX_SECONDS)
+    )
     link.provision_poll_sequence += 1
     link.provision_claim_token = None
     link.provision_claimed_at = None
@@ -1958,9 +2004,7 @@ def _orphan_knowledge_source_needs_enqueue(knowledge_source_id: int) -> bool:
         return False
     if knowledge_source.lifecycle_status == LensKnowledgeSource.LifecycleStatus.DELETED:
         return False
-    if teardown_blocking.intervention_required(
-        knowledge_source.teardown_state_json
-    ):
+    if teardown_blocking.intervention_required(knowledge_source.teardown_state_json):
         return False
     if (
         knowledge_source.teardown_claimed_at
@@ -2448,6 +2492,7 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     cleanup_waiting_for_conversion_stop = False
     workspace_intervention_required = False
     workspace_blocking: dict[str, Any] = {}
+    prepare_slot_release_safe = False
     assistant_uuids: set[uuid_lib.UUID] = set()
     if session_cleanup_complete:
         try:
@@ -2577,15 +2622,26 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
                 if isinstance(candidate_blocking, dict):
                     workspace_blocking = candidate_blocking
                 workspace_intervention_required = (
-                    teardown_blocking.intervention_required(
-                        latest_ks_teardown_state
-                    )
+                    teardown_blocking.intervention_required(latest_ks_teardown_state)
+                )
+                restore_stop = latest_ks_teardown_state.get("cancel_chat_restore")
+                conversion_stop = latest_ks_teardown_state.get("cancel_conversion")
+                workspace_safety = latest_ks_teardown_state.get(
+                    "workspace_cleanup_safety"
+                )
+                prepare_slot_release_safe = bool(
+                    isinstance(restore_stop, dict)
+                    and restore_stop.get("status") == "success"
+                    and isinstance(conversion_stop, dict)
+                    and conversion_stop.get("status") == "success"
+                    and isinstance(workspace_safety, dict)
+                    and workspace_safety.get("workspace_quarantined") is True
                 )
             cleanup_waiting_for_conversion_stop = bool(
                 isinstance(latest_ks_teardown_state, dict)
-                and (
-                    latest_ks_teardown_state.get("cancel_conversion") or {}
-                ).get("status")
+                and (latest_ks_teardown_state.get("cancel_conversion") or {}).get(
+                    "status"
+                )
                 == "waiting"
             )
             _teardown_step(
@@ -2611,13 +2667,10 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     if critical_errors:
         if workspace_blocking:
             blocking_reason = str(
-                workspace_blocking.get("reason")
-                or "conversion_stop_unconfirmed"
+                workspace_blocking.get("reason") or "conversion_stop_unconfirmed"
             )
             blocking_task_id = str(workspace_blocking.get("task_id") or "")
-            blocking_remote_status = str(
-                workspace_blocking.get("remote_status") or ""
-            )
+            blocking_remote_status = str(workspace_blocking.get("remote_status") or "")
             blocking_stop_source = str(
                 workspace_blocking.get("stop_confirmation_source") or ""
             )
@@ -2643,10 +2696,24 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
             )
     else:
         teardown_state = teardown_blocking.clear_blocking(teardown_state)
-    intervention_required = bool(blocking.get("intervention_required"))
-    cleanup_blocked = (
-        cleanup_waiting_for_conversion_stop or intervention_required
+    slot_generation = (
+        LensGatewayChatSlot.objects.filter(session_link_id=link.id)
+        .values_list("session_generation", flat=True)
+        .first()
     )
+    if prepare_slot_release_safe:
+        teardown_state["prepare_slot_release_barrier"] = {
+            "status": "satisfied",
+            "reason": "workspace_quarantined",
+            "session_generation": int(
+                slot_generation
+                if slot_generation is not None
+                else link.provision_generation
+            ),
+            "updated_at": timezone.now().isoformat(),
+        }
+    intervention_required = bool(blocking.get("intervention_required"))
+    cleanup_blocked = cleanup_waiting_for_conversion_stop or intervention_required
     if critical_errors:
         link.lifecycle_status = (
             LensSessionLink.LifecycleStatus.FAILED
@@ -2714,11 +2781,6 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
         )
     else:
         link.teardown_next_retry_at = None
-    slot_generation = (
-        LensGatewayChatSlot.objects.filter(session_link_id=link.id)
-        .values_list("session_generation", flat=True)
-        .first()
-    )
     final_query = LensSessionLink.objects.filter(
         pk=link.id,
         teardown_claim_token=claim_token,
@@ -2753,6 +2815,11 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     )
     if updated != 1:
         raise ChatTeardownIncompleteError("Chat teardown lease was lost.")
+    if slot_generation is not None and prepare_slot_release_safe:
+        gateway_chat_queue.release_chat_prepare_slot(
+            session_link_id=link.id,
+            expected_generation=int(slot_generation),
+        )
     if critical_errors:
         logger.warning(
             "chat teardown blocked chat_id=%s knowledge_source_id=%s "
@@ -2768,7 +2835,7 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
             intervention_required,
         )
         raise ChatTeardownIncompleteError("; ".join(critical_errors))
-    if slot_generation is not None:
+    if slot_generation is not None and not prepare_slot_release_safe:
         gateway_chat_queue.release_chat_prepare_slot(
             session_link_id=link.id,
             expected_generation=int(slot_generation),
@@ -2920,8 +2987,7 @@ def _assert_retry_public_gateway_capacity(*, session: LensSessionLink) -> None:
         session.capacity_reservation_status
         == LensSessionLink.CapacityReservationStatus.RESERVED
         and (
-            session.lifecycle_status
-            == LensSessionLink.LifecycleStatus.PROVISIONING
+            session.lifecycle_status == LensSessionLink.LifecycleStatus.PROVISIONING
             or session.knowledge_source_id is not None
         )
     ):
@@ -3133,16 +3199,13 @@ def _queue_teardown_or_record_error(session_link_id: int) -> None:
                 LensSessionLink.CleanupStatus.BLOCKED,
             ),
         )
-        cleanup_intent = cleanup_query.values_list(
-            "cleanup_intent", flat=True
-        ).first()
+        cleanup_intent = cleanup_query.values_list("cleanup_intent", flat=True).first()
         cleanup_query.update(
             lifecycle_error=("Teardown queue unavailable: " + str(exc))[:2000],
             lifecycle_error_state_json=error_state,
             provision_detail=(
                 "Recovery cleanup is waiting for the worker queue."
-                if cleanup_intent
-                == LensSessionLink.CleanupIntent.RESET_FOR_RETRY
+                if cleanup_intent == LensSessionLink.CleanupIntent.RESET_FOR_RETRY
                 else "Deletion is waiting for the worker queue."
             ),
             updated_at=timezone.now(),

--- a/src/backend/apps/lens_bridge/services/gateway_chat_queue.py
+++ b/src/backend/apps/lens_bridge/services/gateway_chat_queue.py
@@ -68,8 +68,7 @@ def normalize_chat_workload_settings(
         )
     if not 0 <= queue_capacity <= MAX_CHAT_QUEUE_CAPACITY:
         raise ValueError(
-            "chat_queue_capacity must be between 0 and "
-            f"{MAX_CHAT_QUEUE_CAPACITY}"
+            f"chat_queue_capacity must be between 0 and {MAX_CHAT_QUEUE_CAPACITY}"
         )
     return concurrency, queue_capacity
 
@@ -140,10 +139,15 @@ def chat_queue_position(*, session: LensSessionLink) -> int:
     ):
         return 0
     entered_at = session.gateway_queue_entered_at or session.created_at
-    return _schedulable_sessions(session.gateway_link_id).filter(
-        Q(queue_order_at__lt=entered_at)
-        | Q(queue_order_at=entered_at, id__lt=session.id)
-    ).count() + 1
+    return (
+        _schedulable_sessions(session.gateway_link_id)
+        .filter(
+            Q(queue_order_at__lt=entered_at)
+            | Q(queue_order_at=entered_at, id__lt=session.id)
+        )
+        .count()
+        + 1
+    )
 
 
 def chat_queue_ahead(
@@ -257,18 +261,41 @@ def _cleanup_releasable_slots(*, gateway_link_id: int) -> None:
     """Recover slots whose owning lifecycle has durably finished.
 
     A deleting or failed Chat may still be waiting for SourceLens to confirm
-    conversion shutdown. Those slots intentionally remain occupied until the
-    teardown path marks cleanup complete and releases them explicitly.
+    conversion shutdown. Those slots remain occupied until teardown completes
+    or persists a matching workspace-quarantine release barrier.
     """
 
-    LensGatewayChatSlot.objects.filter(gateway_link_id=gateway_link_id).filter(
+    slots = LensGatewayChatSlot.objects.filter(gateway_link_id=gateway_link_id)
+    terminal_lifecycle = (
         Q(session_link__lifecycle_status=LensSessionLink.LifecycleStatus.READY)
         | Q(session_link__lifecycle_status=LensSessionLink.LifecycleStatus.DELETED)
         | Q(
             session_link__lifecycle_status=LensSessionLink.LifecycleStatus.FAILED,
             session_link__cleanup_status=LensSessionLink.CleanupStatus.COMPLETE,
         )
-    ).delete()
+    )
+    barrier_releasable_ids: list[int] = []
+    for slot in slots.select_related("session_link").filter(
+        session_link__lifecycle_status__in=(
+            LensSessionLink.LifecycleStatus.DELETING,
+            LensSessionLink.LifecycleStatus.FAILED,
+        )
+    ):
+        teardown_state = slot.session_link.teardown_state_json
+        barrier = (
+            teardown_state.get("prepare_slot_release_barrier")
+            if isinstance(teardown_state, dict)
+            else None
+        )
+        if not isinstance(barrier, dict) or barrier.get("status") != "satisfied":
+            continue
+        try:
+            barrier_generation = int(barrier.get("session_generation"))
+        except (TypeError, ValueError):
+            continue
+        if barrier_generation == slot.session_generation:
+            barrier_releasable_ids.append(slot.id)
+    slots.filter(terminal_lifecycle | Q(pk__in=barrier_releasable_ids)).delete()
 
 
 @transaction.atomic
@@ -278,9 +305,7 @@ def try_acquire_chat_prepare_slot(
     expected_generation: int,
 ) -> ChatSlotResult:
     session = (
-        LensSessionLink.objects.select_for_update()
-        .filter(pk=session_link_id)
-        .first()
+        LensSessionLink.objects.select_for_update().filter(pk=session_link_id).first()
     )
     if (
         session is None
@@ -329,8 +354,9 @@ def try_acquire_chat_prepare_slot(
     if available <= 0:
         return ChatSlotResult(acquired=False, position=position)
     eligible_ids = set(
-        _ordered_schedulable_sessions(gateway.id)
-        .values_list("id", flat=True)[:available]
+        _ordered_schedulable_sessions(gateway.id).values_list("id", flat=True)[
+            :available
+        ]
     )
     if session.id not in eligible_ids:
         return ChatSlotResult(acquired=False, position=position)
@@ -392,8 +418,9 @@ def wake_gateway_queue(gateway_link_id: int) -> None:
     if available <= 0:
         return
     candidates = list(
-        _ordered_schedulable_sessions(gateway.id)
-        .values_list("id", flat=True)[:available]
+        _ordered_schedulable_sessions(gateway.id).values_list("id", flat=True)[
+            :available
+        ]
     )
     if not candidates:
         return

--- a/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
+++ b/src/backend/apps/lens_bridge/services/knowledge_source_sync.py
@@ -54,9 +54,7 @@ _PHASE_LABELS = {
 }
 
 _RESTORE_POLL_SECONDS = 5
-SYNC_CLAIM_TTL_SECONDS = int(
-    getattr(settings, "LENS_KS_SYNC_TIME_LIMIT", 7200)
-) + 300
+SYNC_CLAIM_TTL_SECONDS = int(getattr(settings, "LENS_KS_SYNC_TIME_LIMIT", 7200)) + 300
 _TERMINAL_TASK_STATUSES = frozenset(
     {
         Task.Status.SUCCESS,
@@ -74,7 +72,9 @@ class KnowledgeSourceSyncError(Exception):
 class KnowledgeSourceSyncPending(Exception):
     """External restore work is active; persist state and resume later."""
 
-    def __init__(self, detail: str, *, retry_after_seconds: int = _RESTORE_POLL_SECONDS):
+    def __init__(
+        self, detail: str, *, retry_after_seconds: int = _RESTORE_POLL_SECONDS
+    ):
         super().__init__(detail)
         self.retry_after_seconds = max(1, int(retry_after_seconds))
 
@@ -162,10 +162,7 @@ def managed_conversion_enabled(
     policy = ingest_policy.normalize_ingest_policy(
         ks.ingest_policy_json,
     )
-    return any(
-        bool(policy.get(key))
-        for key in ("document", "image", "embedded_image")
-    )
+    return any(bool(policy.get(key)) for key in ("document", "image", "embedded_image"))
 
 
 def scope_entries(ks: LensKnowledgeSource) -> list[dict[str, Any]]:
@@ -207,20 +204,26 @@ def _common_path_parts(paths: list[str]) -> list[str]:
 def _relative_scope_path(*, ancestor_path: str, scope_path: str) -> str:
     ancestor = _path_parts(ancestor_path)
     child = _path_parts(scope_path)
-    if len(child) < len(ancestor) or [part.lower() for part in child[: len(ancestor)]] != [
-        part.lower() for part in ancestor
-    ]:
+    if len(child) < len(ancestor) or [
+        part.lower() for part in child[: len(ancestor)]
+    ] != [part.lower() for part in ancestor]:
         return "/".join(child)
     relative = child[len(ancestor) :]
     return "/".join(relative)
 
 
-def _restore_selected_paths(*, directory_source_path: str, scope_path: str) -> list[str]:
-    relative = _relative_scope_path(ancestor_path=directory_source_path, scope_path=scope_path)
+def _restore_selected_paths(
+    *, directory_source_path: str, scope_path: str
+) -> list[str]:
+    relative = _relative_scope_path(
+        ancestor_path=directory_source_path, scope_path=scope_path
+    )
     return [] if not relative else [relative]
 
 
-def map_scope_to_workspace(*, workspace_root: str, scope_paths: list[str], scope_path: str) -> str:
+def map_scope_to_workspace(
+    *, workspace_root: str, scope_paths: list[str], scope_path: str
+) -> str:
     root = workspace_root.rstrip("/") or "/"
     normalized = [str(path).strip() for path in scope_paths if str(path).strip()]
     scope_parts = _path_parts(scope_path)
@@ -243,7 +246,10 @@ def map_scope_to_workspace(*, workspace_root: str, scope_paths: list[str], scope
 
 def indexed_dir_paths(ks: LensKnowledgeSource) -> list[str]:
     if is_gateway_local_ks(ks):
-        return [str(item.get("source_path") or ks.source_path).strip() for item in scope_entries(ks)]
+        return [
+            str(item.get("source_path") or ks.source_path).strip()
+            for item in scope_entries(ks)
+        ]
     workspace = (ks.workspace_path_on_lensnode or "").strip()
     if not workspace:
         raise KnowledgeSourceSyncError("Knowledge source workspace path is not set.")
@@ -280,7 +286,9 @@ def resolve_snapshot_id_for_sync(*, ks: LensKnowledgeSource) -> int:
     return int(latest.id if latest else base_snapshot.id)
 
 
-def should_run_restore_phase(*, ks: LensKnowledgeSource, sync_state: dict[str, Any]) -> bool:
+def should_run_restore_phase(
+    *, ks: LensKnowledgeSource, sync_state: dict[str, Any]
+) -> bool:
     if is_gateway_local_ks(ks):
         return False
     snapshot_id = resolve_snapshot_id_for_sync(ks=ks)
@@ -288,7 +296,10 @@ def should_run_restore_phase(*, ks: LensKnowledgeSource, sync_state: dict[str, A
     completed = set(sync_state.get("completed_phases") or [])
     if "restore_snapshot" not in completed:
         return True
-    if ks.linked_version_mode == LensKnowledgeSource.LinkedVersionMode.LATEST and used != snapshot_id:
+    if (
+        ks.linked_version_mode == LensKnowledgeSource.LinkedVersionMode.LATEST
+        and used != snapshot_id
+    ):
         return True
     restore_record_id = sync_state.get("restore_record_id")
     if restore_record_id and not _restore_record_succeeded(
@@ -324,9 +335,13 @@ def request_knowledge_source_sync(
     mode: str = "resume",
 ) -> LensKnowledgeSource:
     if ks.lifecycle_status != LensKnowledgeSource.LifecycleStatus.READY:
-        raise ValidationError({"lifecycle_status": "Knowledge source is being deleted."})
+        raise ValidationError(
+            {"lifecycle_status": "Knowledge source is being deleted."}
+        )
     if ks.status == LensKnowledgeSource.Status.SYNCING:
-        raise ValidationError({"status": "Knowledge source sync is already in progress."})
+        raise ValidationError(
+            {"status": "Knowledge source sync is already in progress."}
+        )
 
     execution = context_for_knowledge_source(
         tenant_organization=org,
@@ -352,14 +367,18 @@ def request_knowledge_source_sync(
         org=execution.execution_organization,
         node=execution.gateway,
     ):
-        raise ValidationError({"gateway": "Data gateway lifecycle operation is in progress."})
+        raise ValidationError(
+            {"gateway": "Data gateway lifecycle operation is in progress."}
+        )
 
     gateway_link = execution.gateway_link
     if gateway_link.sidecar_status in {
         LensGatewayLink.SidecarStatus.UPGRADING,
         LensGatewayLink.SidecarStatus.REMOVING,
     }:
-        raise ValidationError({"gateway": "Gateway AI engine is busy (upgrade or removal in progress)."})
+        raise ValidationError(
+            {"gateway": "Gateway AI engine is busy (upgrade or removal in progress)."}
+        )
     gateway_readiness.require_hfl_usable_gateway(gateway_link, field="gateway")
 
     sync_state = dict(ks.sync_state_json or {})
@@ -392,11 +411,9 @@ def request_knowledge_source_sync(
         )
         sync_state["completed_phases"] = list(completed)
     conversion_state = sync_state.get("conversion")
-    if (
-        isinstance(conversion_state, dict)
-        and str(conversion_state.get("status") or "")
-        in {"FAILURE", "REVOKED"}
-    ):
+    if isinstance(conversion_state, dict) and str(
+        conversion_state.get("status") or ""
+    ) in {"FAILURE", "REVOKED"}:
         if not managed_datasource.conversion_stop_confirmed(ks):
             raise ValidationError(
                 {
@@ -407,13 +424,9 @@ def request_knowledge_source_sync(
                 }
             )
         sync_state.pop("conversion", None)
-        completed.difference_update(
-            {"convert_documents", "push_assistant", "finalize"}
-        )
+        completed.difference_update({"convert_documents", "push_assistant", "finalize"})
         sync_state["completed_phases"] = list(completed)
-    start_new_cycle = mode == "full" or set(SYNC_PHASES).issubset(
-        completed
-    )
+    start_new_cycle = mode == "full" or set(SYNC_PHASES).issubset(completed)
     effective_mode = "full" if start_new_cycle else mode
     if start_new_cycle:
         next_generation = max(1, int(sync_state.get("restore_generation") or 0) + 1)
@@ -477,16 +490,20 @@ def run_knowledge_source_sync(
             "status": claim_status,
         }
 
-    ks = LensKnowledgeSource.objects.select_related(
-        "gateway",
-        "gateway_link",
-        "gateway_link__gateway",
-        "gateway_link__organization",
-        "workspace_binding",
-    ).filter(
-        organization_id=organization_id,
-        pk=knowledge_source_id,
-    ).first()
+    ks = (
+        LensKnowledgeSource.objects.select_related(
+            "gateway",
+            "gateway_link",
+            "gateway_link__gateway",
+            "gateway_link__organization",
+            "workspace_binding",
+        )
+        .filter(
+            organization_id=organization_id,
+            pk=knowledge_source_id,
+        )
+        .first()
+    )
     if ks is None:
         _release_sync_claim(
             knowledge_source_id=knowledge_source_id,
@@ -536,10 +553,7 @@ def run_knowledge_source_sync(
         _release_sync_claim(
             knowledge_source_id=knowledge_source_id,
             claim_token=claim_token,
-            next_poll_at=(
-                timezone.now()
-                + timedelta(seconds=retry_after_seconds)
-            ),
+            next_poll_at=(timezone.now() + timedelta(seconds=retry_after_seconds)),
         )
         return {
             "knowledge_source_id": ks.id,
@@ -548,7 +562,9 @@ def run_knowledge_source_sync(
             "retry_after_seconds": retry_after_seconds,
         }
     except sl_client.LensBridgeUnavailable as exc:
-        retry_after_seconds = managed_datasource.CONVERSION_TRANSIENT_RETRY_MAX_SECONDS // 10
+        retry_after_seconds = (
+            managed_datasource.CONVERSION_TRANSIENT_RETRY_MAX_SECONDS // 10
+        )
         sync_state = dict(ks.sync_state_json or {})
         transient = dict(sync_state.get("source_lens_transient") or {})
         transient_count = int(transient.get("count") or 0) + 1
@@ -562,7 +578,9 @@ def run_knowledge_source_sync(
         }
         ks.sync_state_json = sync_state
         ks.status = LensKnowledgeSource.Status.SYNCING
-        ks.status_detail = "SourceLens is temporarily unavailable. Retrying automatically."
+        ks.status_detail = (
+            "SourceLens is temporarily unavailable. Retrying automatically."
+        )
         ks.save(
             update_fields=["sync_state_json", "status", "status_detail", "updated_at"]
         )
@@ -638,8 +656,7 @@ def _run_sync_pipeline(
         else ""
     )
     conversion_in_progress = bool(
-        conversion_state
-        and conversion_status not in {"SUCCESS", "FAILURE", "REVOKED"}
+        conversion_state and conversion_status not in {"SUCCESS", "FAILURE", "REVOKED"}
     )
     restore_required = (
         False
@@ -683,16 +700,9 @@ def _run_sync_pipeline(
         if isinstance(conversion_state, dict)
         else ""
     )
-    current_fingerprint = managed_datasource.conversion_policy_fingerprint(
-        conversion
-    )
-    if (
-        "convert_documents" in completed
-        and recorded_fingerprint != current_fingerprint
-    ):
-        completed.difference_update(
-            {"convert_documents", "push_assistant", "finalize"}
-        )
+    current_fingerprint = managed_datasource.conversion_policy_fingerprint(conversion)
+    if "convert_documents" in completed and recorded_fingerprint != current_fingerprint:
+        completed.difference_update({"convert_documents", "push_assistant", "finalize"})
         sync_state["completed_phases"] = list(completed)
         sync_state.pop("conversion", None)
         ks.sync_state_json = sync_state
@@ -728,9 +738,7 @@ def _run_sync_pipeline(
             ks.sync_state_json = sync_state
             ks.save(update_fields=["sync_state_json", "updated_at"])
     else:
-        completed.update(
-            {"ensure_managed_datasource", "convert_documents"}
-        )
+        completed.update({"ensure_managed_datasource", "convert_documents"})
         sync_state["completed_phases"] = list(completed)
         ks.sync_state_json = sync_state
         ks.save(update_fields=["sync_state_json", "updated_at"])
@@ -779,8 +787,13 @@ def _run_phase_prepare_workspace(
         ) from exc
 
     if is_gateway_local_ks(ks):
-        if workspace_binding.workspace_kind != LensWorkspaceBinding.WorkspaceKind.GATEWAY_LOCAL:
-            raise KnowledgeSourceSyncError("Gateway-local knowledge source binding is inconsistent.")
+        if (
+            workspace_binding.workspace_kind
+            != LensWorkspaceBinding.WorkspaceKind.GATEWAY_LOCAL
+        ):
+            raise KnowledgeSourceSyncError(
+                "Gateway-local knowledge source binding is inconsistent."
+            )
         from apps.node.services.internal.agent_task import run_agent_task_sync
 
         for scope in scope_entries(ks):
@@ -799,22 +812,41 @@ def _run_phase_prepare_workspace(
                 wait_timeout_seconds=30,
             )
             if not outcome.ok:
-                detail = outcome.task.last_error or "Gateway directory validation failed."
+                detail = (
+                    outcome.task.last_error or "Gateway directory validation failed."
+                )
                 raise KnowledgeSourceSyncError(detail)
         ks.workspace_path_on_lensnode = ks.source_path
         ks.mount_path_on_gateway = ks.source_path
-        ks.save(update_fields=["workspace_path_on_lensnode", "mount_path_on_gateway", "updated_at"])
+        ks.save(
+            update_fields=[
+                "workspace_path_on_lensnode",
+                "mount_path_on_gateway",
+                "updated_at",
+            ]
+        )
         if workspace_binding.state != LensWorkspaceBinding.State.READY:
             workspace_binding.state = LensWorkspaceBinding.State.READY
             workspace_binding.last_error = ""
             workspace_binding.save(update_fields=["state", "last_error", "updated_at"])
     else:
-        if workspace_binding.workspace_kind != LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE:
-            raise KnowledgeSourceSyncError("Managed knowledge source binding is inconsistent.")
+        if (
+            workspace_binding.workspace_kind
+            != LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE
+        ):
+            raise KnowledgeSourceSyncError(
+                "Managed knowledge source binding is inconsistent."
+            )
         workspace_path = workspace_binding.resolved_path()
         ks.workspace_path_on_lensnode = workspace_path
         ks.mount_path_on_gateway = workspace_path
-        ks.save(update_fields=["workspace_path_on_lensnode", "mount_path_on_gateway", "updated_at"])
+        ks.save(
+            update_fields=[
+                "workspace_path_on_lensnode",
+                "mount_path_on_gateway",
+                "updated_at",
+            ]
+        )
         provisioning.ensure_ks_workspace_on_gateway(
             org=org,
             gateway=gateway,
@@ -825,6 +857,53 @@ def _run_phase_prepare_workspace(
             workspace_binding.state = LensWorkspaceBinding.State.READY
             workspace_binding.last_error = ""
             workspace_binding.save(update_fields=["state", "last_error", "updated_at"])
+
+
+def _create_and_publish_workspace_restore(
+    *,
+    org: Organization,
+    ks: LensKnowledgeSource,
+    restore_data: dict[str, Any],
+    sync_state: dict[str, Any],
+    snapshot_id: int,
+    restore_scope_status: dict[str, str],
+) -> RestoreRecord:
+    """Atomically bind a restore before its on-commit Agent delivery."""
+
+    with transaction.atomic():
+        Organization.objects.select_for_update().only("id").get(pk=org.id)
+        locked_ks = LensKnowledgeSource.all_objects.select_for_update().get(
+            pk=ks.id,
+            organization_id=org.id,
+        )
+        if locked_ks.lifecycle_status != LensKnowledgeSource.LifecycleStatus.READY:
+            raise KnowledgeSourceSyncError("Knowledge source deletion was requested.")
+        try:
+            workspace_binding = locked_ks.workspace_binding
+        except LensWorkspaceBinding.DoesNotExist as exc:
+            raise KnowledgeSourceSyncError(
+                "Knowledge source has no authoritative workspace binding."
+            ) from exc
+        record = restore_services.create_lens_workspace_restore_record(
+            organization_id=org.id,
+            workspace_binding_id=workspace_binding.id,
+            data=restore_data,
+        )
+        sync_state["restore_record_id"] = record.id
+        sync_state["snapshot_id_used"] = snapshot_id
+        sync_state["restore_scope_status"] = restore_scope_status
+        locked_ks.last_restore_record_id = record.id
+        locked_ks.sync_state_json = sync_state
+        locked_ks.save(
+            update_fields=[
+                "last_restore_record_id",
+                "sync_state_json",
+                "updated_at",
+            ]
+        )
+    ks.last_restore_record_id = record.id
+    ks.sync_state_json = sync_state
+    return record
 
 
 def _run_phase_restore_snapshot(
@@ -866,27 +945,37 @@ def _run_phase_restore_snapshot(
         status__in=restore_services.RESTORABLE_SNAPSHOT_STATUSES,
     ).first()
     if snapshot is None:
-        raise KnowledgeSourceSyncError("No restorable snapshot found for knowledge source.")
+        raise KnowledgeSourceSyncError(
+            "No restorable snapshot found for knowledge source."
+        )
 
     workspace = ks.workspace_path_on_lensnode
     items: list[dict[str, Any]] = []
-    restore_scope_status: dict[str, str] = dict(sync_state.get("restore_scope_status") or {})
+    restore_scope_status: dict[str, str] = dict(
+        sync_state.get("restore_scope_status") or {}
+    )
 
     for index, entry in enumerate(scope_entries(ks)):
         key = str(index)
         if restore_scope_status.get(key) == "done":
             continue
         scope_path = str(entry.get("source_path") or "").strip()
-        directory_id = entry.get("backup_snapshot_directory_id") or ks.backup_snapshot_directory_id
+        directory_id = (
+            entry.get("backup_snapshot_directory_id") or ks.backup_snapshot_directory_id
+        )
         if not directory_id:
-            raise KnowledgeSourceSyncError(f"Index scope {index + 1} is missing snapshot directory id.")
+            raise KnowledgeSourceSyncError(
+                f"Index scope {index + 1} is missing snapshot directory id."
+            )
         directory = BackupSourceSnapshotDirectory.objects.filter(
             organization_id=org.id,
             source_snapshot=snapshot,
             pk=int(directory_id),
         ).first()
         if directory is None:
-            raise KnowledgeSourceSyncError(f"Snapshot directory {directory_id} not found for restore.")
+            raise KnowledgeSourceSyncError(
+                f"Snapshot directory {directory_id} not found for restore."
+            )
         items.append(
             {
                 "source_snapshot_directory_id": int(directory_id),
@@ -907,10 +996,10 @@ def _run_phase_restore_snapshot(
         ks.save(update_fields=["sync_state_json", "updated_at"])
         return
 
-    record = restore_services.create_lens_workspace_restore_record(
-        organization_id=org.id,
-        workspace_binding_id=ks.workspace_binding.id,
-        data={
+    record = _create_and_publish_workspace_restore(
+        org=org,
+        ks=ks,
+        restore_data={
             "source_type": snapshot.source_type,
             "source_ref_id": snapshot.source_ref_id,
             "target_type": "agent",
@@ -924,13 +1013,10 @@ def _run_phase_restore_snapshot(
                 f"lens-workspace:{ks.id}:generation:{generation}:snapshot:{snapshot_id}"
             ),
         },
+        sync_state=sync_state,
+        snapshot_id=snapshot_id,
+        restore_scope_status=restore_scope_status,
     )
-    ks.last_restore_record_id = record.id
-    sync_state["restore_record_id"] = record.id
-    sync_state["snapshot_id_used"] = snapshot_id
-    sync_state["restore_scope_status"] = restore_scope_status
-    ks.sync_state_json = sync_state
-    ks.save(update_fields=["last_restore_record_id", "sync_state_json", "updated_at"])
 
     if _restore_record_failed(record_id=record.id, organization_id=org.id):
         task = Task.objects.filter(
@@ -1074,24 +1160,32 @@ def _is_degraded(*, ks: LensKnowledgeSource, sync_state: dict[str, Any]) -> bool
 
 
 def _restore_record_succeeded(*, record_id: int, organization_id: int) -> bool:
-    record = RestoreRecord.objects.filter(pk=record_id, organization_id=organization_id).first()
+    record = RestoreRecord.objects.filter(
+        pk=record_id, organization_id=organization_id
+    ).first()
     if record is None:
         return False
     statuses = list(record.items.values_list("status", flat=True))
     if not statuses:
-        task = Task.objects.filter(organization_id=organization_id, task_uuid=record.task_uuid).first()
+        task = Task.objects.filter(
+            organization_id=organization_id, task_uuid=record.task_uuid
+        ).first()
         return task is not None and task.status == Task.Status.SUCCESS
     return all(status == RestoreRecordItem.Status.SUCCESS for status in statuses)
 
 
 def _restore_record_failed(*, record_id: int, organization_id: int) -> bool:
-    record = RestoreRecord.objects.filter(pk=record_id, organization_id=organization_id).first()
+    record = RestoreRecord.objects.filter(
+        pk=record_id, organization_id=organization_id
+    ).first()
     if record is None:
         return False
     statuses = list(record.items.values_list("status", flat=True))
     if any(status == RestoreRecordItem.Status.FAILED for status in statuses):
         return True
-    task = Task.objects.filter(organization_id=organization_id, task_uuid=record.task_uuid).first()
+    task = Task.objects.filter(
+        organization_id=organization_id, task_uuid=record.task_uuid
+    ).first()
     return task is not None and task.status in {
         Task.Status.FAILED,
         Task.Status.CANCELLED,
@@ -1166,7 +1260,9 @@ def maybe_refresh_degraded_status(*, ks: LensKnowledgeSource) -> LensKnowledgeSo
     return ks
 
 
-def prepare_new_knowledge_source(*, org: Organization, ks: LensKnowledgeSource) -> LensKnowledgeSource:
+def prepare_new_knowledge_source(
+    *, org: Organization, ks: LensKnowledgeSource
+) -> LensKnowledgeSource:
     """Allocate workspace paths and mark the row syncing before async pipeline starts."""
     from apps.lens_bridge.services.gateway_execution import create_workspace_binding
 

--- a/src/backend/apps/lens_bridge/services/knowledge_source_teardown.py
+++ b/src/backend/apps/lens_bridge/services/knowledge_source_teardown.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import logging
 import uuid
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
 from django.db import transaction
+from django.db.models import Q
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
@@ -36,7 +38,303 @@ class KnowledgeSourceTeardownBusyError(RuntimeError):
     """Raised when another worker owns the Knowledge Source lease."""
 
 
+class WorkspaceCleanupIncompleteError(RuntimeError):
+    """Workspace cleanup failed after returning structured safety evidence."""
+
+    def __init__(self, message: str, *, evidence: dict[str, Any] | None = None):
+        super().__init__(message)
+        self.evidence = dict(evidence or {})
+
+
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ChatRestoreStopAssessment:
+    """Safety assessment for the one restore that owns a Chat workspace."""
+
+    confirmed: bool
+    reason: str = ""
+    task_id: str = ""
+    node_task_ids: tuple[str, ...] = ()
+
+
+def _node_task_has_executor_stop_evidence(node_task) -> bool:
+    """Return whether a dispatched workspace writer can no longer mutate data."""
+
+    from apps.node.models import NodeTask
+
+    if node_task.status == NodeTask.Status.SUCCESS:
+        return True
+    if (
+        node_task.status == NodeTask.Status.CANCELED
+        and node_task.dispatched_at is None
+        and node_task.accepted_at is None
+    ):
+        # A pending command cancelled before Agent acceptance never had an
+        # executor that could write the workspace.
+        return True
+    result = node_task.result if isinstance(node_task.result, dict) else {}
+    return (
+        node_task.status in {NodeTask.Status.CANCELED, NodeTask.Status.FAILED}
+        and result.get("executor_finished") is True
+        and str(result.get("completion_source") or "") == "agent_executor"
+    )
+
+
+def _assess_chat_restore_record_stop(
+    *,
+    record,
+    binding: LensWorkspaceBinding,
+    manual_confirmation: object,
+    request_cancel: bool,
+) -> ChatRestoreStopAssessment:
+    """Apply the existing executor-stop barrier to one binding-owned restore."""
+
+    from apps.node.models import NodeTask
+    from apps.restore.models import RestoreRecordItem
+    from apps.restore.services import interface as restore_services
+    from apps.task.models import Task
+
+    if (
+        isinstance(manual_confirmation, dict)
+        and manual_confirmation.get("confirmed") is True
+        and str(manual_confirmation.get("task_id") or "") == str(record.task_uuid)
+    ):
+        return ChatRestoreStopAssessment(
+            confirmed=True,
+            reason="manual_executor_stop_confirmation",
+            task_id=str(record.task_uuid),
+        )
+    product_task = Task.objects.filter(
+        pk=record.task_id,
+        organization_id=record.organization_id,
+        task_uuid=record.task_uuid,
+    ).first()
+    if product_task is None:
+        return ChatRestoreStopAssessment(
+            confirmed=False,
+            reason="restore_task_missing",
+            task_id=str(record.task_uuid),
+        )
+    product_task_was_terminal = product_task.status in {
+        Task.Status.SUCCESS,
+        Task.Status.FAILED,
+        Task.Status.CANCELLED,
+        Task.Status.TIMEOUT,
+    }
+    if request_cancel and product_task.status not in {
+        Task.Status.SUCCESS,
+        Task.Status.FAILED,
+        Task.Status.CANCELLED,
+        Task.Status.TIMEOUT,
+    }:
+        restore_services.cancel_restore(
+            organization_id=record.organization_id,
+            task_uuid=str(record.task_uuid),
+            reason="Chat deletion requested",
+        )
+
+    items = list(
+        RestoreRecordItem.objects.filter(restore_record=record).only(
+            "id", "status", "node_task_id"
+        )
+    )
+    node_task_ids = {item.node_task_id for item in items if item.node_task_id}
+    execution_org_ids = {
+        record.organization_id,
+        record.target_execution_organization_id,
+    }
+    node_tasks = list(
+        NodeTask.objects.filter(
+            Q(pk__in=node_task_ids)
+            | Q(
+                correlation_id=str(record.task_uuid),
+                kind__in=("restore.run", "kopia.restore"),
+            ),
+            organization_id__in=execution_org_ids,
+        ).only(
+            "id",
+            "node_id",
+            "status",
+            "dispatched_at",
+            "accepted_at",
+            "correlation_type",
+            "correlation_id",
+            "payload",
+            "result",
+        )
+    )
+    tasks_by_id = {task.id: task for task in node_tasks}
+    missing_task_ids = {
+        str(item.node_task_id)
+        for item in items
+        if item.node_task_id and item.node_task_id not in tasks_by_id
+    }
+    if missing_task_ids:
+        return ChatRestoreStopAssessment(
+            confirmed=False,
+            reason="restore_node_task_missing",
+            task_id=str(record.task_uuid),
+            node_task_ids=tuple(sorted(missing_task_ids)),
+        )
+    expected_workspace_uid = str(binding.workspace_uid)
+    expected_workspace_path = binding.resolved_path()
+    identity_mismatches = [
+        task
+        for task in node_tasks
+        if task.node_id != record.target_execution_node_id
+        or task.correlation_type != "restore.record"
+        or task.correlation_id != str(record.task_uuid)
+        or not isinstance(task.payload, dict)
+        or task.payload.get("workspace_kind") != "managed_restore"
+        or str(task.payload.get("workspace_uid") or "") != expected_workspace_uid
+        or str(task.payload.get("managed_workspace_path") or "")
+        != expected_workspace_path
+    ]
+    if identity_mismatches:
+        return ChatRestoreStopAssessment(
+            confirmed=False,
+            reason="restore_node_task_identity_mismatch",
+            task_id=str(record.task_uuid),
+            node_task_ids=tuple(sorted(str(task.id) for task in identity_mismatches)),
+        )
+    if request_cancel and product_task_was_terminal:
+        # A prior product-level cancellation may have become terminal even if
+        # its Agent cancel downlink failed. Retry only identity-verified active
+        # writers for this workspace; unrelated Gateway work is untouched.
+        from apps.node.services.interface import cancel_agent_task
+
+        for task in node_tasks:
+            if task.status not in {NodeTask.Status.PENDING, NodeTask.Status.RUNNING}:
+                continue
+            try:
+                cancel_agent_task(
+                    task_id=task.id,
+                    reason="Chat deletion requested",
+                )
+            except Exception:
+                logger.exception(
+                    "failed to retry Chat workspace restore cancellation "
+                    "knowledge_source_id=%s restore_task_uuid=%s node_task_id=%s",
+                    binding.knowledge_source_id,
+                    record.task_uuid,
+                    task.id,
+                )
+            task.refresh_from_db(
+                fields=["status", "dispatched_at", "accepted_at", "result"]
+            )
+    unsafe_tasks = [
+        task for task in node_tasks if not _node_task_has_executor_stop_evidence(task)
+    ]
+    if unsafe_tasks:
+        return ChatRestoreStopAssessment(
+            confirmed=False,
+            reason="restore_executor_still_stopping",
+            task_id=str(record.task_uuid),
+            node_task_ids=tuple(sorted(str(task.id) for task in unsafe_tasks)),
+        )
+    undispatched_active_items = [
+        item
+        for item in items
+        if item.node_task_id is None
+        and item.status
+        in {RestoreRecordItem.Status.PENDING, RestoreRecordItem.Status.RUNNING}
+    ]
+    if undispatched_active_items:
+        return ChatRestoreStopAssessment(
+            confirmed=False,
+            reason="restore_dispatch_still_stopping",
+            task_id=str(record.task_uuid),
+        )
+    return ChatRestoreStopAssessment(
+        confirmed=True,
+        reason="executor_stopped",
+        task_id=str(record.task_uuid),
+        node_task_ids=tuple(sorted(str(task.id) for task in node_tasks)),
+    )
+
+
+def assess_chat_restore_stop(
+    knowledge_source: LensKnowledgeSource,
+    *,
+    request_cancel: bool = True,
+) -> ChatRestoreStopAssessment:
+    """Cancel and fence only the canonical restore for this Chat workspace.
+
+    This deliberately does not inspect unrelated work on the same Data
+    Gateway. Standalone Knowledge Source deletion retains its existing global
+    workload fence below.
+    """
+
+    from apps.restore.models import RestoreRecord
+
+    try:
+        binding = knowledge_source.workspace_binding
+    except LensWorkspaceBinding.DoesNotExist:
+        return ChatRestoreStopAssessment(
+            confirmed=False,
+            reason="workspace_binding_missing",
+        )
+    binding_records = RestoreRecord.objects.filter(
+        organization_id=knowledge_source.organization_id,
+        purpose=RestoreRecord.Purpose.LENS_WORKSPACE,
+        workspace_binding_id=binding.id,
+        target_execution_organization_id=binding.execution_organization_id,
+        target_execution_node_id=binding.execution_node_id,
+    )
+    restore_record_id = knowledge_source.last_restore_record_id
+    if restore_record_id is not None:
+        if not binding_records.filter(pk=restore_record_id).exists():
+            return ChatRestoreStopAssessment(
+                confirmed=False,
+                reason="canonical_restore_mismatch",
+            )
+    # Every restore bound to this Workspace UID is a potential writer. A stale
+    # older Agent command must not become invisible merely because a newer
+    # record replaced the Knowledge Source's convenience pointer.
+    records = list(binding_records.order_by("id"))
+    if not records:
+        return ChatRestoreStopAssessment(
+            confirmed=True,
+            reason="not_dispatched",
+        )
+    teardown_state = knowledge_source.teardown_state_json or {}
+    legacy_manual_confirmation = teardown_state.get("manual_restore_stop_confirmation")
+    manual_confirmations = teardown_state.get("manual_restore_stop_confirmations")
+    manual_confirmations = (
+        manual_confirmations if isinstance(manual_confirmations, dict) else {}
+    )
+    assessments = [
+        _assess_chat_restore_record_stop(
+            record=record,
+            binding=binding,
+            manual_confirmation=(
+                manual_confirmations.get(str(record.task_uuid))
+                or legacy_manual_confirmation
+            ),
+            request_cancel=request_cancel,
+        )
+        for record in records
+    ]
+    for assessment in reversed(assessments):
+        if not assessment.confirmed:
+            return assessment
+    node_task_ids = tuple(
+        sorted(
+            {
+                node_task_id
+                for assessment in assessments
+                for node_task_id in assessment.node_task_ids
+            }
+        )
+    )
+    return ChatRestoreStopAssessment(
+        confirmed=True,
+        reason="executor_stopped",
+        task_id=assessments[-1].task_id,
+        node_task_ids=node_task_ids,
+    )
 
 
 def _session_links_blocking_ks_teardown(
@@ -89,9 +387,9 @@ def _queue_teardown(knowledge_source_id: int) -> None:
         queue_knowledge_source_teardown(knowledge_source_id=knowledge_source_id)
     except Exception as exc:
         LensKnowledgeSource.all_objects.filter(pk=knowledge_source_id).update(
-            status_detail=(
-                "Deletion is waiting for the worker queue: " + str(exc)
-            )[:300],
+            status_detail=("Deletion is waiting for the worker queue: " + str(exc))[
+                :300
+            ],
             updated_at=timezone.now(),
         )
 
@@ -105,7 +403,9 @@ def request_knowledge_source_teardown(
     locked = LensKnowledgeSource.objects.select_for_update().get(pk=knowledge_source.pk)
     if _session_links_blocking_ks_teardown(locked).exists():
         raise ValidationError(
-            {"knowledge_source": "Delete the owning Chat before deleting this knowledge source."}
+            {
+                "knowledge_source": "Delete the owning Chat before deleting this knowledge source."
+            }
         )
     if locked.lifecycle_status == LensKnowledgeSource.LifecycleStatus.DELETED:
         return locked
@@ -126,7 +426,10 @@ def _claim(knowledge_source_id: int) -> tuple[str | None, str]:
         )
         if knowledge_source is None:
             return None, "missing"
-        if knowledge_source.lifecycle_status == LensKnowledgeSource.LifecycleStatus.DELETED:
+        if (
+            knowledge_source.lifecycle_status
+            == LensKnowledgeSource.LifecycleStatus.DELETED
+        ):
             return None, "deleted"
         if teardown_blocking.intervention_required(
             knowledge_source.teardown_state_json
@@ -209,7 +512,10 @@ def cleanup_knowledge_source_workspace(
             {"workspace": "Knowledge source has no workspace binding."}
         ) from exc
     sync_state["teardown_workspace_path"] = workspace_binding.resolved_path()
-    if workspace_binding.workspace_kind == LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE:
+    if (
+        workspace_binding.workspace_kind
+        == LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE
+    ):
         from apps.lens_bridge.services.gateway_execution import (
             context_for_workspace_binding,
             workspace_identity_payload,
@@ -256,7 +562,24 @@ def cleanup_knowledge_source_workspace(
             )
             workspace_binding.last_error = detail
             workspace_binding.save(update_fields=["last_error", "updated_at"])
-            raise ValidationError({"workspace": detail})
+            result = (
+                dict(outcome.task.result)
+                if isinstance(outcome.task.result, dict)
+                else {}
+            )
+            expected_uid = str(workspace_binding.workspace_uid)
+            reported_uid = str(result.get("workspace_uid") or "")
+            evidence = {
+                "workspace_uid": reported_uid,
+                "workspace_quarantined": bool(
+                    result.get("workspace_quarantined") is True
+                    and reported_uid == expected_uid
+                ),
+                "purge_complete": bool(result.get("purge_complete") is True),
+                "tombstone_state": str(result.get("tombstone_state") or ""),
+                "node_task_id": str(outcome.task.id),
+            }
+            raise WorkspaceCleanupIncompleteError(detail, evidence=evidence)
     workspace_binding.state = LensWorkspaceBinding.State.DELETED
     workspace_binding.last_error = ""
     workspace_binding.save(update_fields=["state", "last_error", "updated_at"])
@@ -288,23 +611,62 @@ def run_knowledge_source_teardown(
         return {"knowledge_source_id": knowledge_source_id, "status": "missing"}
     state = dict(knowledge_source.teardown_state_json or {})
     stop_assessment: managed_datasource.ConversionStopAssessment | None = None
+    restore_stop_assessment: ChatRestoreStopAssessment | None = None
     blocking_step = "validate_gateway_workload"
     try:
-        from apps.node.services.internal.node_workload import (
-            get_node_workload_blockers,
-        )
-
-        if get_node_workload_blockers(node=knowledge_source.gateway):
-            raise ValidationError(
-                {"knowledge_source": "Data gateway restore work is still stopping."}
+        if owner_session_link_id is None:
+            from apps.node.services.internal.node_workload import (
+                get_node_workload_blockers,
             )
+
+            if get_node_workload_blockers(node=knowledge_source.gateway):
+                raise ValidationError(
+                    {
+                        "knowledge_source": (
+                            "Data gateway restore work is still stopping."
+                        )
+                    }
+                )
+        else:
+            blocking_step = "cancel_chat_restore"
+            if not LensSessionLink.objects.filter(
+                pk=owner_session_link_id,
+                knowledge_source_id=knowledge_source.id,
+            ).exists():
+                raise ValidationError(
+                    {
+                        "knowledge_source": (
+                            "Chat cleanup does not own this Knowledge Source."
+                        )
+                    }
+                )
+            restore_stop = assess_chat_restore_stop(knowledge_source)
+            restore_stop_assessment = restore_stop
+            state["cancel_chat_restore"] = {
+                "status": "success" if restore_stop.confirmed else "waiting",
+                "reason": restore_stop.reason,
+                "task_id": restore_stop.task_id,
+                "node_task_ids": list(restore_stop.node_task_ids),
+                "updated_at": timezone.now().isoformat(),
+            }
+            _claimed_update(
+                knowledge_source.id,
+                claim_token,
+                teardown_state_json=state,
+            )
+            if not restore_stop.confirmed:
+                raise KnowledgeSourceTeardownIncompleteError(
+                    "Waiting for the Chat workspace restore executor to stop."
+                )
         blocking_step = "validate_chat_ownership"
         if _session_links_blocking_ks_teardown(
             knowledge_source,
             owner_session_link_id=owner_session_link_id,
         ).exists():
             raise ValidationError(
-                {"knowledge_source": "Knowledge source still belongs to an active Chat."}
+                {
+                    "knowledge_source": "Knowledge source still belongs to an active Chat."
+                }
             )
 
         if knowledge_source.sl_datasource_uuid:
@@ -418,6 +780,16 @@ def run_knowledge_source_teardown(
             )
         return {"knowledge_source_id": knowledge_source.id, "status": "deleted"}
     except Exception as exc:
+        if isinstance(exc, WorkspaceCleanupIncompleteError):
+            state["workspace_cleanup_safety"] = {
+                **exc.evidence,
+                "updated_at": timezone.now().isoformat(),
+            }
+            _claimed_update(
+                knowledge_source.id,
+                claim_token,
+                teardown_state_json=state,
+            )
         _save_step(
             knowledge_source.id,
             claim_token,
@@ -426,13 +798,19 @@ def run_knowledge_source_teardown(
             status="retry",
             error=str(exc),
         )
-        if stop_assessment is not None and not stop_assessment.confirmed:
+        if (
+            restore_stop_assessment is not None
+            and not restore_stop_assessment.confirmed
+        ):
+            blocking_reason = restore_stop_assessment.reason
+            task_id = restore_stop_assessment.task_id
+            remote_status = "stopping"
+            stop_confirmation_source = ""
+        elif stop_assessment is not None and not stop_assessment.confirmed:
             blocking_reason = "conversion_stop_unconfirmed"
             task_id = stop_assessment.task_id
             remote_status = stop_assessment.remote_status
-            stop_confirmation_source = (
-                stop_assessment.stop_confirmation_source
-            )
+            stop_confirmation_source = stop_assessment.stop_confirmation_source
         else:
             # The stage is stable across retries but changes when teardown
             # makes substantive progress. Full exception details remain in

--- a/src/backend/apps/lens_bridge/tests/test_chat_restore_stop.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_restore_stop.py
@@ -1,0 +1,349 @@
+import uuid
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.iam.models import Organization
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensWorkspaceBinding,
+)
+from apps.lens_bridge.services.knowledge_source_teardown import (
+    assess_chat_restore_stop,
+)
+from apps.node.models import Node, NodeTask
+from apps.restore.models import RestoreRecord, RestoreRecordItem
+from apps.task.models import Task
+
+
+class ChatRestoreStopAssessmentTests(TestCase):
+    def setUp(self):
+        self.tenant = Organization.objects.create(
+            key="chat-restore-stop-tenant",
+            name="Chat Restore Stop Tenant",
+        )
+        self.execution_org = Organization.objects.create(
+            key="chat-restore-stop-execution",
+            name="Chat Restore Stop Execution",
+        )
+        self.user = get_user_model().objects.create_user(
+            username="chat-restore-stop@example.test",
+            email="chat-restore-stop@example.test",
+        )
+        self.gateway = Node.objects.create(
+            organization=self.execution_org,
+            name="chat-restore-stop-gateway",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.gateway_link = LensGatewayLink.objects.create(
+            organization=self.execution_org,
+            gateway=self.gateway,
+            scope=LensGatewayLink.GatewayScope.PLATFORM,
+            origin=LensGatewayLink.Origin.PLATFORM,
+            workspace_root="/workspace/platform/data",
+        )
+        self.knowledge_source = LensKnowledgeSource.objects.create(
+            organization=self.tenant,
+            name="Chat workspace",
+            gateway=self.gateway,
+            gateway_link=self.gateway_link,
+            source_path="/data",
+            status=LensKnowledgeSource.Status.SYNCING,
+            created_by=self.user,
+        )
+        self.binding = LensWorkspaceBinding.objects.create(
+            organization=self.tenant,
+            knowledge_source=self.knowledge_source,
+            gateway_link=self.gateway_link,
+            execution_organization_id=self.execution_org.id,
+            execution_node_id=self.gateway.id,
+            workspace_kind=LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
+            workspace_root="/workspace/platform/data",
+            relative_path="tenants/1/knowledge-sources/1",
+            state=LensWorkspaceBinding.State.PREPARING,
+            identity_status=LensWorkspaceBinding.IdentityStatus.READY,
+        )
+
+    def _create_restore(self, *, node_status: str, node_result=None):
+        product_task = Task.objects.create(
+            organization_id=self.tenant.id,
+            task_type=Task.Type.INSIGHT_WORKSPACE_RESTORE,
+            display_name="Insight workspace restore",
+            status=Task.Status.CANCELLED,
+        )
+        record = RestoreRecord.objects.create(
+            organization_id=self.tenant.id,
+            requesting_organization_id=self.tenant.id,
+            target_execution_organization_id=self.execution_org.id,
+            target_execution_node_id=self.gateway.id,
+            purpose=RestoreRecord.Purpose.LENS_WORKSPACE,
+            idempotency_key=f"chat-restore-stop-{uuid.uuid4()}",
+            workspace_binding_id=self.binding.id,
+            restore_uid=f"rst-{uuid.uuid4().hex[:16]}",
+            source_mode=RestoreRecord.SourceMode.MANUAL,
+            task_id=product_task.id,
+            task_uuid=product_task.task_uuid,
+            source_type=RestoreRecord.EndpointType.AGENT,
+            source_ref_id=1,
+            source_snapshot_id=1,
+            target_type=RestoreRecord.EndpointType.AGENT,
+            target_ref_id=self.gateway.id,
+            target_path=self.binding.resolved_path(),
+            scope=RestoreRecord.Scope.PATHS,
+            conflict_mode=RestoreRecord.ConflictMode.OVERWRITE,
+        )
+        node_task = NodeTask.objects.create(
+            organization=self.execution_org,
+            requesting_organization_id=self.tenant.id,
+            node=self.gateway,
+            correlation_type="restore.record",
+            correlation_id=str(record.task_uuid),
+            kind="restore.run",
+            payload={
+                "workspace_kind": "managed_restore",
+                "workspace_uid": str(self.binding.workspace_uid),
+                "managed_workspace_path": self.binding.resolved_path(),
+                "path": self.binding.resolved_path(),
+            },
+            result=dict(node_result or {}),
+            status=node_status,
+            accepted_at=timezone.now(),
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+        )
+        RestoreRecordItem.objects.create(
+            organization_id=self.tenant.id,
+            restore_record=record,
+            source_snapshot_directory_id=1,
+            backup_config_dir_id=1,
+            repository_id=1,
+            kopia_snapshot_id="snapshot-1",
+            source_path="/data",
+            selected_paths=["/data"],
+            target_path=self.binding.resolved_path(),
+            conflict_mode=RestoreRecordItem.ConflictMode.OVERWRITE,
+            status=RestoreRecordItem.Status.CANCELLED,
+            node_task_id=node_task.id,
+        )
+        self.knowledge_source.last_restore_record_id = record.id
+        self.knowledge_source.save(
+            update_fields=["last_restore_record_id", "updated_at"]
+        )
+        return record, node_task
+
+    def test_no_dispatched_restore_is_safe_without_gateway_global_checks(self):
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertTrue(assessment.confirmed)
+        self.assertEqual(assessment.reason, "not_dispatched")
+
+    def test_binding_restore_is_checked_when_canonical_pointer_is_missing(self):
+        _, node_task = self._create_restore(
+            node_status=NodeTask.Status.CANCELED,
+            node_result={"cancel_finalized_by": "grace_timeout"},
+        )
+        self.knowledge_source.last_restore_record_id = None
+        self.knowledge_source.save(
+            update_fields=["last_restore_record_id", "updated_at"]
+        )
+
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertFalse(assessment.confirmed)
+        self.assertEqual(assessment.reason, "restore_executor_still_stopping")
+        self.assertEqual(assessment.node_task_ids, (str(node_task.id),))
+
+    def test_newer_binding_restore_is_checked_when_pointer_is_stale(self):
+        old_record, _ = self._create_restore(
+            node_status=NodeTask.Status.SUCCESS,
+        )
+        newer_record, newer_node_task = self._create_restore(
+            node_status=NodeTask.Status.CANCELED,
+            node_result={"cancel_finalized_by": "grace_timeout"},
+        )
+        self.knowledge_source.last_restore_record_id = old_record.id
+        self.knowledge_source.save(
+            update_fields=["last_restore_record_id", "updated_at"]
+        )
+
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertFalse(assessment.confirmed)
+        self.assertEqual(assessment.reason, "restore_executor_still_stopping")
+        self.assertEqual(assessment.task_id, str(newer_record.task_uuid))
+        self.assertEqual(assessment.node_task_ids, (str(newer_node_task.id),))
+
+    @patch("apps.node.services.interface.cancel_agent_task")
+    def test_older_active_restore_is_checked_when_pointer_is_newer(
+        self,
+        cancel_agent_task,
+    ):
+        old_record, old_node_task = self._create_restore(
+            node_status=NodeTask.Status.RUNNING,
+        )
+        newer_record, _ = self._create_restore(
+            node_status=NodeTask.Status.SUCCESS,
+        )
+        self.assertEqual(self.knowledge_source.last_restore_record_id, newer_record.id)
+
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertFalse(assessment.confirmed)
+        self.assertEqual(assessment.reason, "restore_executor_still_stopping")
+        self.assertEqual(assessment.task_id, str(old_record.task_uuid))
+        self.assertEqual(assessment.node_task_ids, (str(old_node_task.id),))
+        cancel_agent_task.assert_called_once_with(
+            task_id=old_node_task.id,
+            reason="Chat deletion requested",
+        )
+
+    def test_manual_confirmations_cover_multiple_legacy_restore_records(self):
+        old_record, _ = self._create_restore(
+            node_status=NodeTask.Status.CANCELED,
+            node_result={"cancel_finalized_by": "grace_timeout"},
+        )
+        newer_record, _ = self._create_restore(
+            node_status=NodeTask.Status.CANCELED,
+            node_result={"cancel_finalized_by": "grace_timeout"},
+        )
+        self.knowledge_source.last_restore_record_id = old_record.id
+        self.knowledge_source.teardown_state_json = {
+            "manual_restore_stop_confirmations": {
+                str(old_record.task_uuid): {
+                    "confirmed": True,
+                    "task_id": str(old_record.task_uuid),
+                },
+                str(newer_record.task_uuid): {
+                    "confirmed": True,
+                    "task_id": str(newer_record.task_uuid),
+                },
+            }
+        }
+        self.knowledge_source.save(
+            update_fields=[
+                "last_restore_record_id",
+                "teardown_state_json",
+                "updated_at",
+            ]
+        )
+
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertTrue(assessment.confirmed)
+        self.assertEqual(assessment.reason, "executor_stopped")
+
+    def test_control_plane_cancel_does_not_prove_executor_exit(self):
+        _, node_task = self._create_restore(
+            node_status=NodeTask.Status.CANCELED,
+            node_result={"cancel_finalized_by": "grace_timeout"},
+        )
+
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertFalse(assessment.confirmed)
+        self.assertEqual(assessment.reason, "restore_executor_still_stopping")
+        self.assertEqual(assessment.node_task_ids, (str(node_task.id),))
+
+    @patch(
+        "apps.restore.services.interface.cancel_restore",
+        return_value={"status": "cancelled"},
+    )
+    def test_active_canonical_restore_receives_existing_cancel_request(
+        self,
+        cancel_restore,
+    ):
+        record, _ = self._create_restore(
+            node_status=NodeTask.Status.RUNNING,
+        )
+        Task.objects.filter(pk=record.task_id).update(status=Task.Status.RUNNING)
+
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertFalse(assessment.confirmed)
+        cancel_restore.assert_called_once_with(
+            organization_id=self.tenant.id,
+            task_uuid=str(record.task_uuid),
+            reason="Chat deletion requested",
+        )
+
+    @patch("apps.node.services.interface.cancel_agent_task")
+    def test_terminal_product_restore_retries_active_executor_cancel(
+        self,
+        cancel_agent_task,
+    ):
+        _, node_task = self._create_restore(
+            node_status=NodeTask.Status.RUNNING,
+        )
+
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertFalse(assessment.confirmed)
+        self.assertEqual(assessment.reason, "restore_executor_still_stopping")
+        cancel_agent_task.assert_called_once_with(
+            task_id=node_task.id,
+            reason="Chat deletion requested",
+        )
+
+    def test_agent_executor_stop_evidence_satisfies_restore_barrier(self):
+        _, node_task = self._create_restore(
+            node_status=NodeTask.Status.CANCELED,
+            node_result={
+                "executor_finished": True,
+                "completion_source": "agent_executor",
+            },
+        )
+
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertTrue(assessment.confirmed)
+        self.assertEqual(assessment.reason, "executor_stopped")
+        self.assertEqual(assessment.node_task_ids, (str(node_task.id),))
+
+    def test_node_task_workspace_identity_mismatch_fails_closed(self):
+        _, node_task = self._create_restore(
+            node_status=NodeTask.Status.SUCCESS,
+        )
+        node_task.payload = {
+            **node_task.payload,
+            "workspace_uid": str(uuid.uuid4()),
+        }
+        node_task.save(update_fields=["payload", "updated_at"])
+
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertFalse(assessment.confirmed)
+        self.assertEqual(
+            assessment.reason,
+            "restore_node_task_identity_mismatch",
+        )
+
+    def test_node_task_restore_identity_mismatch_fails_closed(self):
+        _, node_task = self._create_restore(
+            node_status=NodeTask.Status.SUCCESS,
+        )
+        node_task.correlation_id = str(uuid.uuid4())
+        node_task.save(update_fields=["correlation_id", "updated_at"])
+
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertFalse(assessment.confirmed)
+        self.assertEqual(
+            assessment.reason,
+            "restore_node_task_identity_mismatch",
+        )
+
+    def test_canonical_restore_identity_mismatch_fails_closed(self):
+        record, _ = self._create_restore(
+            node_status=NodeTask.Status.SUCCESS,
+        )
+        record.workspace_binding_id = self.binding.id + 1000
+        record.save(update_fields=["workspace_binding_id", "updated_at"])
+
+        assessment = assess_chat_restore_stop(self.knowledge_source)
+
+        self.assertFalse(assessment.confirmed)
+        self.assertEqual(assessment.reason, "canonical_restore_mismatch")

--- a/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
@@ -47,7 +47,8 @@ class CopilotChatTeardownTests(TestCase):
             organization=self.platform_org,
             name="platform-gateway",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
         )
         self.gateway_link = LensGatewayLink.objects.create(
             organization=self.platform_org,
@@ -122,9 +123,7 @@ class CopilotChatTeardownTests(TestCase):
             ]
         )
         self.knowledge_source.sl_assistant_uuid = None
-        self.knowledge_source.save(
-            update_fields=["sl_assistant_uuid", "updated_at"]
-        )
+        self.knowledge_source.save(update_fields=["sl_assistant_uuid", "updated_at"])
 
         chat_lifecycle._bind_assistant_to_provision_claim(
             self.session,
@@ -232,9 +231,7 @@ class CopilotChatTeardownTests(TestCase):
             LensWorkspaceBinding.State.DELETED,
         )
         self.assertFalse(
-            LensGatewayChatSlot.objects.filter(
-                session_link=self.session
-            ).exists()
+            LensGatewayChatSlot.objects.filter(session_link=self.session).exists()
         )
         self.assertEqual(run_agent_task.call_args.kwargs["kind"], "lens.ks.cleanup")
 
@@ -252,9 +249,7 @@ class CopilotChatTeardownTests(TestCase):
         self.session.save(update_fields=["lifecycle_status", "updated_at"])
 
         with self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError):
-            chat_lifecycle.run_copilot_chat_teardown(
-                session_link_id=self.session.id
-            )
+            chat_lifecycle.run_copilot_chat_teardown(session_link_id=self.session.id)
 
         self.session.refresh_from_db()
         self.workspace_binding.refresh_from_db()
@@ -332,9 +327,7 @@ class CopilotChatTeardownTests(TestCase):
         self.assertIsNone(self.session.knowledge_source_id)
         self.assertIn("LensNode was unavailable", self.session.lifecycle_error)
         self.assertFalse(
-            LensGatewayChatSlot.objects.filter(
-                session_link=self.session
-            ).exists()
+            LensGatewayChatSlot.objects.filter(session_link=self.session).exists()
         )
 
     @mock.patch("apps.lens_bridge.services.assistant_access.soft_delete_assistant_link")
@@ -367,9 +360,7 @@ class CopilotChatTeardownTests(TestCase):
         )
 
         def block_knowledge_source_cleanup(**_kwargs):
-            LensKnowledgeSource.all_objects.filter(
-                pk=self.knowledge_source.id
-            ).update(
+            LensKnowledgeSource.all_objects.filter(pk=self.knowledge_source.id).update(
                 teardown_state_json={
                     "cancel_conversion": {"status": "waiting"},
                     "blocking": {
@@ -385,14 +376,15 @@ class CopilotChatTeardownTests(TestCase):
                 "Waiting for LensNode to stop document conversion."
             )
 
-        with mock.patch(
-            "apps.lens_bridge.services.knowledge_source_teardown."
-            "run_knowledge_source_teardown",
-            side_effect=block_knowledge_source_cleanup,
-        ), self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError):
-            chat_lifecycle.run_copilot_chat_teardown(
-                session_link_id=self.session.id
-            )
+        with (
+            mock.patch(
+                "apps.lens_bridge.services.knowledge_source_teardown."
+                "run_knowledge_source_teardown",
+                side_effect=block_knowledge_source_cleanup,
+            ),
+            self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError),
+        ):
+            chat_lifecycle.run_copilot_chat_teardown(session_link_id=self.session.id)
 
         self.session.refresh_from_db()
         self.workspace_binding.refresh_from_db()
@@ -461,21 +453,22 @@ class CopilotChatTeardownTests(TestCase):
         }
 
         def require_intervention(**_kwargs):
-            LensKnowledgeSource.all_objects.filter(
-                pk=self.knowledge_source.id
-            ).update(teardown_state_json={"blocking": blocking})
+            LensKnowledgeSource.all_objects.filter(pk=self.knowledge_source.id).update(
+                teardown_state_json={"blocking": blocking}
+            )
             raise knowledge_source_teardown.KnowledgeSourceTeardownIncompleteError(
                 "Workspace cleanup requires operator intervention."
             )
 
-        with mock.patch(
-            "apps.lens_bridge.services.knowledge_source_teardown."
-            "run_knowledge_source_teardown",
-            side_effect=require_intervention,
-        ), self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError):
-            chat_lifecycle.run_copilot_chat_teardown(
-                session_link_id=self.session.id
-            )
+        with (
+            mock.patch(
+                "apps.lens_bridge.services.knowledge_source_teardown."
+                "run_knowledge_source_teardown",
+                side_effect=require_intervention,
+            ),
+            self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError),
+        ):
+            chat_lifecycle.run_copilot_chat_teardown(session_link_id=self.session.id)
 
         self.session.refresh_from_db()
         self.assertEqual(
@@ -488,18 +481,94 @@ class CopilotChatTeardownTests(TestCase):
             blocking,
         )
         self.assertTrue(
-            LensGatewayChatSlot.objects.filter(
-                session_link=self.session
-            ).exists()
+            LensGatewayChatSlot.objects.filter(session_link=self.session).exists()
+        )
+
+    @mock.patch("apps.lens_bridge.services.assistant_access.soft_delete_assistant_link")
+    @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
+    @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
+    def test_quarantined_workspace_releases_slot_while_purge_retries(
+        self,
+        request_json,
+        _delete_assistant,
+        _soft_delete_assistant,
+    ):
+        request_json.side_effect = self._not_found()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.cleanup_intent = LensSessionLink.CleanupIntent.DELETE_SESSION
+        self.session.cleanup_status = LensSessionLink.CleanupStatus.PENDING
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "cleanup_intent",
+                "cleanup_status",
+                "updated_at",
+            ]
+        )
+        LensGatewayChatSlot.objects.create(
+            gateway_link=self.gateway_link,
+            slot_number=1,
+            session_link=self.session,
+            session_generation=self.session.provision_generation,
+            acquired_at=timezone.now(),
+            heartbeat_at=timezone.now(),
+        )
+
+        def fail_after_quarantine(**_kwargs):
+            LensKnowledgeSource.all_objects.filter(pk=self.knowledge_source.id).update(
+                teardown_state_json={
+                    "cancel_chat_restore": {"status": "success"},
+                    "cancel_conversion": {"status": "success"},
+                    "workspace_cleanup_safety": {
+                        "workspace_uid": str(self.workspace_binding.workspace_uid),
+                        "workspace_quarantined": True,
+                        "purge_complete": False,
+                        "tombstone_state": "retiring",
+                    },
+                }
+            )
+            raise knowledge_source_teardown.KnowledgeSourceTeardownIncompleteError(
+                "Workspace trash purge will be retried."
+            )
+
+        with (
+            mock.patch(
+                "apps.lens_bridge.services.knowledge_source_teardown."
+                "run_knowledge_source_teardown",
+                side_effect=fail_after_quarantine,
+            ),
+            self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError),
+        ):
+            chat_lifecycle.run_copilot_chat_teardown(session_link_id=self.session.id)
+
+        self.session.refresh_from_db()
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.DELETING,
+        )
+        self.assertEqual(
+            self.session.capacity_reservation_status,
+            LensSessionLink.CapacityReservationStatus.RESERVED,
+        )
+        self.assertEqual(
+            self.session.teardown_state_json["prepare_slot_release_barrier"]["status"],
+            "satisfied",
+        )
+        self.assertEqual(
+            self.session.teardown_state_json["prepare_slot_release_barrier"][
+                "session_generation"
+            ],
+            self.session.provision_generation,
+        )
+        self.assertFalse(
+            LensGatewayChatSlot.objects.filter(session_link=self.session).exists()
         )
 
     @mock.patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "_queue_teardown_or_record_error"
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
     )
     @mock.patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "gateway_chat_queue.wake_gateway_queue"
+        "apps.lens_bridge.services.chat_lifecycle.gateway_chat_queue.wake_gateway_queue"
     )
     def test_failed_provision_records_reset_for_retry_intent(
         self,
@@ -565,9 +634,7 @@ class CopilotChatTeardownTests(TestCase):
         "apps.lens_bridge.services.chat_lifecycle._resolve_chat_scopes",
         return_value=None,
     )
-    @mock.patch(
-        "apps.lens_bridge.services.gateway_execution.context_for_gateway_link"
-    )
+    @mock.patch("apps.lens_bridge.services.gateway_execution.context_for_gateway_link")
     def test_chat_knowledge_source_always_pins_selected_snapshot(
         self,
         _context,
@@ -617,9 +684,7 @@ class CopilotChatTeardownTests(TestCase):
         )
         self.assertEqual(knowledge_source.pinned_snapshot_id, 11)
 
-    @mock.patch(
-        "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown"
-    )
+    @mock.patch("apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown")
     def test_orphan_ks_cleanup_returns_without_enqueue_when_deleted(
         self,
         queue_ks_teardown,
@@ -648,9 +713,7 @@ class CopilotChatTeardownTests(TestCase):
             LensKnowledgeSource.LifecycleStatus.DELETING,
         )
 
-    @mock.patch(
-        "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown"
-    )
+    @mock.patch("apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown")
     def test_orphan_ks_cleanup_does_not_enqueue_when_busy_or_scheduled(
         self,
         queue_ks_teardown,
@@ -672,9 +735,7 @@ class CopilotChatTeardownTests(TestCase):
 
             queue_ks_teardown.assert_not_called()
 
-    @mock.patch(
-        "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown"
-    )
+    @mock.patch("apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown")
     def test_orphan_ks_cleanup_enqueues_when_inline_teardown_fails(
         self,
         queue_ks_teardown,
@@ -693,9 +754,7 @@ class CopilotChatTeardownTests(TestCase):
             knowledge_source_id=self.knowledge_source.id
         )
 
-    @mock.patch(
-        "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown"
-    )
+    @mock.patch("apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown")
     def test_orphan_ks_cleanup_skips_enqueue_when_retry_already_scheduled(
         self,
         queue_ks_teardown,
@@ -721,9 +780,7 @@ class CopilotChatTeardownTests(TestCase):
 
         queue_ks_teardown.assert_not_called()
 
-    @mock.patch(
-        "apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown"
-    )
+    @mock.patch("apps.lens_bridge.services.sync_queue.queue_knowledge_source_teardown")
     def test_orphan_ks_cleanup_skips_enqueue_when_teardown_lease_is_live(
         self,
         queue_ks_teardown,
@@ -828,8 +885,7 @@ class CopilotChatTeardownTests(TestCase):
         )
 
     @mock.patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "_queue_teardown_or_record_error"
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
     )
     @mock.patch(
         "apps.lens_bridge.services.chat_lifecycle._cleanup_failed_provision",
@@ -858,17 +914,19 @@ class CopilotChatTeardownTests(TestCase):
             ]
         )
 
-        with mock.patch(
-            "apps.lens_bridge.services.chat_lifecycle."
-            "_claim_copilot_chat_provision",
-            return_value=(str(claim_token), "claimed"),
-        ), self.captureOnCommitCallbacks(execute=True), self.assertRaisesRegex(
-            RuntimeError,
-            "provision failed",
+        with (
+            mock.patch(
+                "apps.lens_bridge.services.chat_lifecycle."
+                "_claim_copilot_chat_provision",
+                return_value=(str(claim_token), "claimed"),
+            ),
+            self.captureOnCommitCallbacks(execute=True),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "provision failed",
+            ),
         ):
-            chat_lifecycle.run_copilot_chat_provision(
-                session_link_id=self.session.id
-            )
+            chat_lifecycle.run_copilot_chat_provision(session_link_id=self.session.id)
 
         self.session.refresh_from_db()
         self.assertEqual(
@@ -1007,22 +1065,30 @@ class CopilotChatTeardownTests(TestCase):
         self.assertLessEqual(len(first_slug), 160)
         self.assertLessEqual(len(second_slug), 160)
         self.assertTrue(first_slug.endswith(f"-ks-{self.knowledge_source.id}"))
-        self.assertTrue(
-            second_slug.endswith(f"-ks-{second_knowledge_source.id}")
-        )
+        self.assertTrue(second_slug.endswith(f"-ks-{second_knowledge_source.id}"))
         self.assertNotEqual(first_slug, second_slug)
 
-    @mock.patch("apps.lens_bridge.services.chat_lifecycle._grant_assistant_to_chat_user")
-    @mock.patch("apps.lens_bridge.services.chat_lifecycle.assistant_access.ensure_assistant_link")
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle._grant_assistant_to_chat_user"
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle.assistant_access.ensure_assistant_link"
+    )
     @mock.patch(
         "apps.lens_bridge.services.gateway_readiness.agent_ws_routable",
         return_value=True,
     )
     @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
     @mock.patch("apps.lens_bridge.services.chat_lifecycle._find_remote_uuid")
-    @mock.patch("apps.lens_bridge.services.chat_lifecycle.chat_user_provisioning.ensure_sl_chat_user")
-    @mock.patch("apps.lens_bridge.services.chat_lifecycle.knowledge_source_sync.run_knowledge_source_sync")
-    @mock.patch("apps.lens_bridge.services.chat_lifecycle.provisioning.create_sl_assistant_for_ks")
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle.chat_user_provisioning.ensure_sl_chat_user"
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle.knowledge_source_sync.run_knowledge_source_sync"
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle.provisioning.create_sl_assistant_for_ks"
+    )
     def test_journal_recovers_remote_creates_without_reposting(
         self,
         create_assistant,
@@ -1044,9 +1110,7 @@ class CopilotChatTeardownTests(TestCase):
             ks=self.knowledge_source,
         )
         self.knowledge_source.sl_assistant_uuid = None
-        self.knowledge_source.save(
-            update_fields=["sl_assistant_uuid", "updated_at"]
-        )
+        self.knowledge_source.save(update_fields=["sl_assistant_uuid", "updated_at"])
         self.gateway_link.sl_lensnode_uuid = uuid.uuid4()
         self.gateway_link.sidecar_status = LensGatewayLink.SidecarStatus.ONLINE
         self.gateway_link.save(
@@ -1121,7 +1185,10 @@ class CopilotChatTeardownTests(TestCase):
         self.assertEqual(result["status"], "ready")
         create_assistant.assert_not_called()
         self.assertFalse(
-            any(call.args[:2] == ("POST", "/api/lens/sessions/") for call in request_json.call_args_list)
+            any(
+                call.args[:2] == ("POST", "/api/lens/sessions/")
+                for call in request_json.call_args_list
+            )
         )
         request_json.assert_called_once_with(
             "PATCH",
@@ -1138,8 +1205,7 @@ class CopilotChatTeardownTests(TestCase):
         )
 
     @mock.patch(
-        "apps.lens_bridge.tasks.chat_lifecycle."
-        "execute_copilot_chat_teardown_task.delay"
+        "apps.lens_bridge.tasks.chat_lifecycle.execute_copilot_chat_teardown_task.delay"
     )
     def test_reconciler_requeues_due_teardown(self, delay):
         self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
@@ -1158,8 +1224,7 @@ class CopilotChatTeardownTests(TestCase):
         delay.assert_called_once_with(session_link_id=self.session.id)
 
     @mock.patch(
-        "apps.lens_bridge.tasks.chat_lifecycle."
-        "execute_copilot_chat_teardown_task.delay"
+        "apps.lens_bridge.tasks.chat_lifecycle.execute_copilot_chat_teardown_task.delay"
     )
     def test_reconciler_does_not_requeue_live_long_running_claim(self, delay):
         self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
@@ -1180,8 +1245,7 @@ class CopilotChatTeardownTests(TestCase):
         delay.assert_not_called()
 
     @mock.patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "_queue_teardown_or_record_error"
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
     )
     def test_teardown_request_atomically_fences_provisioning(self, queue_teardown):
         provision_token = uuid.uuid4()
@@ -1214,8 +1278,7 @@ class CopilotChatTeardownTests(TestCase):
         queue_teardown.assert_called_once_with(self.session.id)
 
     @mock.patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "_queue_teardown_or_record_error"
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
     )
     def test_repeated_teardown_request_preserves_live_claim(self, queue_teardown):
         teardown_token = uuid.uuid4()
@@ -1238,7 +1301,6 @@ class CopilotChatTeardownTests(TestCase):
                 "updated_at",
             ]
         )
-
         with self.captureOnCommitCallbacks(execute=True):
             result = chat_lifecycle.request_copilot_chat_teardown(self.session)
 
@@ -1250,8 +1312,76 @@ class CopilotChatTeardownTests(TestCase):
         queue_teardown.assert_called_once_with(self.session.id)
 
     @mock.patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "_queue_teardown_or_record_error"
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
+    )
+    def test_retry_delete_rechecks_blocked_cleanup_without_bypassing_fences(
+        self,
+        queue_teardown,
+    ):
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.cleanup_intent = LensSessionLink.CleanupIntent.DELETE_SESSION
+        self.session.cleanup_status = LensSessionLink.CleanupStatus.BLOCKED
+        self.session.teardown_attempts = 12
+        self.session.teardown_state_json = {
+            "intent": "delete_session",
+            "blocking": {
+                "reason": "restore_executor_still_stopping",
+                "task_id": "restore-task-1",
+                "intervention_required": True,
+            },
+            "cancel_chat_restore": {"status": "waiting"},
+        }
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "cleanup_intent",
+                "cleanup_status",
+                "teardown_attempts",
+                "teardown_state_json",
+                "updated_at",
+            ]
+        )
+        self.knowledge_source.teardown_attempts = 12
+        self.knowledge_source.teardown_state_json = {
+            "blocking": {
+                "reason": "restore_executor_still_stopping",
+                "task_id": "restore-task-1",
+                "intervention_required": True,
+            },
+            "cancel_chat_restore": {"status": "waiting"},
+        }
+        self.knowledge_source.save(
+            update_fields=[
+                "teardown_attempts",
+                "teardown_state_json",
+                "updated_at",
+            ]
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            result = chat_lifecycle.request_copilot_chat_teardown(self.session)
+
+        result.refresh_from_db()
+        self.knowledge_source.refresh_from_db()
+        self.assertEqual(
+            result.cleanup_status,
+            LensSessionLink.CleanupStatus.PENDING,
+        )
+        self.assertEqual(result.teardown_attempts, 0)
+        self.assertNotIn("blocking", result.teardown_state_json)
+        self.assertEqual(
+            result.teardown_state_json["cancel_chat_restore"]["status"],
+            "waiting",
+        )
+        self.assertEqual(self.knowledge_source.teardown_attempts, 0)
+        self.assertNotIn(
+            "blocking",
+            self.knowledge_source.teardown_state_json,
+        )
+        queue_teardown.assert_called_once_with(self.session.id)
+
+    @mock.patch(
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
     )
     def test_delete_overrides_retry_cleanup_and_fences_live_claim(
         self,
@@ -1300,8 +1430,7 @@ class CopilotChatTeardownTests(TestCase):
         queue_teardown.assert_called_once_with(self.session.id)
 
     @mock.patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "_queue_teardown_or_record_error"
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
     )
     @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
     def test_late_session_is_compensated_and_cannot_resurrect_chat(
@@ -1353,8 +1482,7 @@ class CopilotChatTeardownTests(TestCase):
         self.assertIsNone(self.session.sl_session_uuid)
 
     @mock.patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "_queue_teardown_or_record_error"
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
     )
     @mock.patch("apps.lens_bridge.services.chat_lifecycle.sl_client.request_json")
     def test_failed_late_compensation_reopens_durable_teardown(
@@ -1393,8 +1521,7 @@ class CopilotChatTeardownTests(TestCase):
         queue_teardown.assert_called_once_with(self.session.id)
 
     @mock.patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "_queue_provision_or_mark_failed"
+        "apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed"
     )
     def test_manual_retry_recovers_stale_provision_claim(self, queue_provision):
         self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
@@ -1477,8 +1604,7 @@ class CopilotChatTeardownTests(TestCase):
         delay.assert_not_called()
 
     @mock.patch(
-        "apps.lens_bridge.tasks.chat_lifecycle."
-        "execute_copilot_chat_teardown_task.delay"
+        "apps.lens_bridge.tasks.chat_lifecycle.execute_copilot_chat_teardown_task.delay"
     )
     def test_teardown_reconciler_isolates_dispatch_failures(self, delay):
         second_session = LensSessionLink.objects.create(
@@ -1522,8 +1648,7 @@ class CopilotChatTeardownTests(TestCase):
         "execute_knowledge_source_teardown_task.delay"
     )
     @mock.patch(
-        "apps.lens_bridge.tasks.chat_lifecycle."
-        "execute_copilot_chat_teardown_task.delay"
+        "apps.lens_bridge.tasks.chat_lifecycle.execute_copilot_chat_teardown_task.delay"
     )
     def test_teardown_reconciler_skips_operator_intervention(
         self,
@@ -1594,9 +1719,7 @@ class CopilotChatTeardownTests(TestCase):
         delete_assistant.side_effect = delete_with_failure
 
         with self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError):
-            chat_lifecycle.run_copilot_chat_teardown(
-                session_link_id=self.session.id
-            )
+            chat_lifecycle.run_copilot_chat_teardown(session_link_id=self.session.id)
 
         self.session.refresh_from_db()
         self.knowledge_source.refresh_from_db()
@@ -1636,9 +1759,7 @@ class CopilotChatTeardownTests(TestCase):
             )
         )
         self.session.teardown_next_retry_at = timezone.now() - timedelta(seconds=1)
-        self.session.save(
-            update_fields=["teardown_next_retry_at", "updated_at"]
-        )
+        self.session.save(update_fields=["teardown_next_retry_at", "updated_at"])
 
         result = chat_lifecycle.run_copilot_chat_teardown(
             session_link_id=self.session.id
@@ -1683,9 +1804,7 @@ class CopilotChatTeardownTests(TestCase):
         )
 
         with self.assertRaises(chat_lifecycle.ChatTeardownIncompleteError):
-            chat_lifecycle.run_copilot_chat_teardown(
-                session_link_id=self.session.id
-            )
+            chat_lifecycle.run_copilot_chat_teardown(session_link_id=self.session.id)
 
         self.session.refresh_from_db()
         self.assertEqual(
@@ -1704,8 +1823,7 @@ class CopilotChatTeardownTests(TestCase):
         run_agent_task.assert_not_called()
 
     @mock.patch(
-        "apps.lens_bridge.services.chat_lifecycle."
-        "_queue_teardown_or_record_error"
+        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
     )
     def test_conflicting_late_uuid_is_preserved_in_journal(self, queue_teardown):
         original_uuid = self.session.sl_assistant_uuid
@@ -1747,12 +1865,17 @@ class CopilotChatTeardownTests(TestCase):
         )
         queue_teardown.assert_called_once_with(self.session.id)
 
+    @mock.patch(
+        "apps.node.services.internal.node_workload.get_node_workload_blockers",
+        return_value=[object()],
+    )
     @mock.patch("apps.lens_bridge.services.assistants._delete_sl_assistant")
     @mock.patch("apps.node.services.internal.agent_task.run_agent_task_sync")
     def test_knowledge_source_teardown_deletes_assistant_before_workspace(
         self,
         run_agent_task,
         delete_assistant,
+        gateway_workload_blockers,
     ):
         assistant_link = LensAssistantLink.objects.create(
             organization=self.tenant,
@@ -1790,6 +1913,7 @@ class CopilotChatTeardownTests(TestCase):
             self.workspace_binding.state,
             LensWorkspaceBinding.State.DELETED,
         )
+        gateway_workload_blockers.assert_not_called()
 
     @mock.patch(
         "apps.lens_bridge.services.knowledge_source_teardown."
@@ -1810,9 +1934,7 @@ class CopilotChatTeardownTests(TestCase):
     ):
         datasource_uuid = uuid.uuid4()
         self.knowledge_source.sl_datasource_uuid = datasource_uuid
-        self.knowledge_source.save(
-            update_fields=["sl_datasource_uuid", "updated_at"]
-        )
+        self.knowledge_source.save(update_fields=["sl_datasource_uuid", "updated_at"])
         LensAssistantLink.objects.create(
             organization=self.tenant,
             sl_assistant_uuid=self.knowledge_source.sl_assistant_uuid,
@@ -1825,9 +1947,7 @@ class CopilotChatTeardownTests(TestCase):
         cancel_conversion.side_effect = lambda *_args: events.append(
             "cancel_conversion"
         )
-        delete_assistant.side_effect = lambda *_args: events.append(
-            "delete_assistant"
-        )
+        delete_assistant.side_effect = lambda *_args: events.append("delete_assistant")
         delete_datasource.side_effect = lambda *_args: events.append(
             "delete_datasource"
         )
@@ -1881,9 +2001,7 @@ class CopilotChatTeardownTests(TestCase):
         _conversion_stopped,
     ):
         self.knowledge_source.sl_datasource_uuid = uuid.uuid4()
-        self.knowledge_source.sync_state_json = {
-            "conversion": {"task_id": "convert-1"}
-        }
+        self.knowledge_source.sync_state_json = {"conversion": {"task_id": "convert-1"}}
         self.knowledge_source.save(
             update_fields=[
                 "sl_datasource_uuid",
@@ -1904,9 +2022,7 @@ class CopilotChatTeardownTests(TestCase):
         delete_datasource.assert_not_called()
         self.knowledge_source.refresh_from_db()
         self.assertEqual(
-            self.knowledge_source.teardown_state_json["cancel_conversion"][
-                "status"
-            ],
+            self.knowledge_source.teardown_state_json["cancel_conversion"]["status"],
             "waiting",
         )
 
@@ -1919,7 +2035,8 @@ class CopilotChatTeardownTests(TestCase):
             organization=self.tenant,
             name="private-gateway",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
         )
         private_link = LensGatewayLink.objects.create(
             organization=self.tenant,

--- a/src/backend/apps/lens_bridge/tests/test_gateway_chat_queue.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_chat_queue.py
@@ -122,9 +122,7 @@ class GatewayChatQueueTests(TestCase):
 
     def test_higher_concurrency_allows_fifo_window_to_fill_slots(self):
         self.gateway_link.chat_prepare_concurrency = 2
-        self.gateway_link.save(
-            update_fields=["chat_prepare_concurrency", "updated_at"]
-        )
+        self.gateway_link.save(update_fields=["chat_prepare_concurrency", "updated_at"])
         first = self._session()
         second = self._session()
         third = self._session()
@@ -157,9 +155,7 @@ class GatewayChatQueueTests(TestCase):
         unready.capacity_reservation_status = (
             LensSessionLink.CapacityReservationStatus.PENDING
         )
-        unready.save(
-            update_fields=["capacity_reservation_status", "updated_at"]
-        )
+        unready.save(update_fields=["capacity_reservation_status", "updated_at"])
         ready = self._session()
 
         acquired = gateway_chat_queue.try_acquire_chat_prepare_slot(
@@ -181,30 +177,22 @@ class GatewayChatQueueTests(TestCase):
         unready.capacity_reservation_status = (
             LensSessionLink.CapacityReservationStatus.PENDING
         )
-        unready.save(
-            update_fields=["capacity_reservation_status", "updated_at"]
-        )
+        unready.save(update_fields=["capacity_reservation_status", "updated_at"])
         self.gateway_link.chat_queue_capacity = 0
-        self.gateway_link.save(
-            update_fields=["chat_queue_capacity", "updated_at"]
-        )
+        self.gateway_link.save(update_fields=["chat_queue_capacity", "updated_at"])
 
         with self.assertRaises(AppError):
             gateway_chat_queue.assert_chat_queue_admission(
                 gateway_link=self.gateway_link,
             )
 
-    @patch(
-        "apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed"
-    )
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
     def test_wake_skips_unready_chat_and_dispatches_ready_chat(self, queue_provision):
         unready = self._session()
         unready.capacity_reservation_status = (
             LensSessionLink.CapacityReservationStatus.PENDING
         )
-        unready.save(
-            update_fields=["capacity_reservation_status", "updated_at"]
-        )
+        unready.save(update_fields=["capacity_reservation_status", "updated_at"])
         ready = self._session()
 
         gateway_chat_queue.wake_gateway_queue(self.gateway_link.id)
@@ -245,6 +233,62 @@ class GatewayChatQueueTests(TestCase):
                 gateway_link=self.gateway_link,
             )
 
+        self.assertTrue(
+            LensGatewayChatSlot.objects.filter(session_link_id=blocked.id).exists()
+        )
+
+    def test_quarantined_workspace_barrier_recovers_slot_after_process_restart(self):
+        blocked = self._session()
+        gateway_chat_queue.try_acquire_chat_prepare_slot(
+            session_link_id=blocked.id,
+            expected_generation=blocked.provision_generation,
+        )
+        LensSessionLink.objects.filter(pk=blocked.id).update(
+            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+            cleanup_status=LensSessionLink.CleanupStatus.BLOCKED,
+            teardown_state_json={
+                "prepare_slot_release_barrier": {
+                    "status": "satisfied",
+                    "session_generation": blocked.provision_generation,
+                }
+            },
+        )
+        waiting = self._session()
+
+        acquired = gateway_chat_queue.try_acquire_chat_prepare_slot(
+            session_link_id=waiting.id,
+            expected_generation=waiting.provision_generation,
+        )
+
+        self.assertTrue(acquired.acquired)
+        self.assertFalse(
+            LensGatewayChatSlot.objects.filter(session_link_id=blocked.id).exists()
+        )
+
+    def test_quarantine_barrier_cannot_release_another_generation(self):
+        blocked = self._session()
+        gateway_chat_queue.try_acquire_chat_prepare_slot(
+            session_link_id=blocked.id,
+            expected_generation=blocked.provision_generation,
+        )
+        LensSessionLink.objects.filter(pk=blocked.id).update(
+            lifecycle_status=LensSessionLink.LifecycleStatus.DELETING,
+            cleanup_status=LensSessionLink.CleanupStatus.BLOCKED,
+            teardown_state_json={
+                "prepare_slot_release_barrier": {
+                    "status": "satisfied",
+                    "session_generation": blocked.provision_generation + 1,
+                }
+            },
+        )
+        waiting = self._session()
+
+        acquired = gateway_chat_queue.try_acquire_chat_prepare_slot(
+            session_link_id=waiting.id,
+            expected_generation=waiting.provision_generation,
+        )
+
+        self.assertFalse(acquired.acquired)
         self.assertTrue(
             LensGatewayChatSlot.objects.filter(session_link_id=blocked.id).exists()
         )

--- a/src/backend/apps/lens_bridge/tests/test_knowledge_source_sync.py
+++ b/src/backend/apps/lens_bridge/tests/test_knowledge_source_sync.py
@@ -1,12 +1,17 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from django.db import transaction
 from django.test import SimpleTestCase, TestCase, TransactionTestCase
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from apps.iam.models import Organization
-from apps.lens_bridge.models import LensGatewayLink, LensKnowledgeSource
+from apps.lens_bridge.models import (
+    LensGatewayLink,
+    LensKnowledgeSource,
+    LensWorkspaceBinding,
+)
 from apps.lens_bridge.services import knowledge_source_sync
 from apps.lens_bridge.services.managed_datasource import ManagedDatasourcePending
 from apps.lens_bridge.services.knowledge_source_sync import (
@@ -27,7 +32,8 @@ class KnowledgeSourceSyncLeaseTests(TransactionTestCase):
             organization=self.organization,
             name="sync-gateway",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
         )
         gateway_link = LensGatewayLink.objects.create(
             organization=self.organization,
@@ -46,9 +52,7 @@ class KnowledgeSourceSyncLeaseTests(TransactionTestCase):
             sync_next_poll_at=timezone.now(),
         )
 
-    @patch(
-        "apps.lens_bridge.services.knowledge_source_sync._run_sync_pipeline"
-    )
+    @patch("apps.lens_bridge.services.knowledge_source_sync._run_sync_pipeline")
     def test_duplicate_delivery_does_not_enter_pipeline(self, run_pipeline):
         claim_token, status = knowledge_source_sync._claim_sync(
             organization_id=self.organization.id,
@@ -105,9 +109,7 @@ class KnowledgeSourceSyncLeaseTests(TransactionTestCase):
         self.assertIsNone(self.knowledge_source.sync_claimed_at)
         self.assertGreater(self.knowledge_source.sync_next_poll_at, before)
 
-    @patch(
-        "apps.lens_bridge.services.knowledge_source_sync._run_sync_pipeline"
-    )
+    @patch("apps.lens_bridge.services.knowledge_source_sync._run_sync_pipeline")
     def test_success_releases_claim_and_poll_marker(self, run_pipeline):
         run_pipeline.return_value = {
             "knowledge_source_id": self.knowledge_source.id,
@@ -132,9 +134,7 @@ class KnowledgeSourceSyncLeaseTests(TransactionTestCase):
 
         now = timezone.now()
         self.knowledge_source.sync_next_poll_at = now - timedelta(seconds=1)
-        self.knowledge_source.save(
-            update_fields=["sync_next_poll_at", "updated_at"]
-        )
+        self.knowledge_source.save(update_fields=["sync_next_poll_at", "updated_at"])
         future = LensKnowledgeSource.objects.create(
             organization=self.organization,
             name="Future source",
@@ -164,11 +164,7 @@ class KnowledgeSourceSyncLeaseTests(TransactionTestCase):
             sync_claim_token="606610e7-9ec5-4405-bba6-06ee74b3864b",
             sync_claimed_at=(
                 now
-                - timedelta(
-                    seconds=(
-                        knowledge_source_sync.SYNC_CLAIM_TTL_SECONDS + 1
-                    )
-                )
+                - timedelta(seconds=(knowledge_source_sync.SYNC_CLAIM_TTL_SECONDS + 1))
             ),
         )
 
@@ -189,12 +185,8 @@ class KnowledgeSourceSyncLeaseTests(TransactionTestCase):
             reconcile_knowledge_source_syncs_task,
         )
 
-        self.knowledge_source.sync_next_poll_at = timezone.now() - timedelta(
-            seconds=1
-        )
-        self.knowledge_source.save(
-            update_fields=["sync_next_poll_at", "updated_at"]
-        )
+        self.knowledge_source.sync_next_poll_at = timezone.now() - timedelta(seconds=1)
+        self.knowledge_source.save(update_fields=["sync_next_poll_at", "updated_at"])
 
         result = reconcile_knowledge_source_syncs_task(limit=10)
 
@@ -379,8 +371,7 @@ class PushAssistantPhaseTests(SimpleTestCase):
         "provisioning.wait_for_lensnode_ready"
     )
     @patch(
-        "apps.lens_bridge.services.knowledge_source_sync."
-        "context_for_knowledge_source"
+        "apps.lens_bridge.services.knowledge_source_sync.context_for_knowledge_source"
     )
     @patch("apps.lens_bridge.services.knowledge_source_sync._update_sync_phase")
     def test_waits_for_authoritative_gateway_workspace_root(
@@ -433,7 +424,8 @@ class ManagedRestorePipelineOrderTests(TestCase):
             organization=gateway_org,
             name="gateway",
             role=Node.Role.GATEWAY,
-            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
         )
         gateway_link = LensGatewayLink.objects.create(
             organization=gateway_org,
@@ -455,6 +447,82 @@ class ManagedRestorePipelineOrderTests(TestCase):
             ingest_policy_json={"document": True},
             scan_enabled=True,
         )
+        self.workspace_binding = LensWorkspaceBinding.objects.create(
+            organization=self.organization,
+            knowledge_source=self.knowledge_source,
+            gateway_link=self.gateway_link,
+            execution_organization_id=gateway_org.id,
+            execution_node_id=self.gateway.id,
+            workspace_kind=LensWorkspaceBinding.WorkspaceKind.MANAGED_RESTORE,
+            workspace_root="/workspace/platform/data",
+            relative_path="tenants/1/knowledge-sources/1",
+            state=LensWorkspaceBinding.State.READY,
+            identity_status=LensWorkspaceBinding.IdentityStatus.READY,
+        )
+
+    def test_restore_identity_is_durable_before_agent_delivery_callback(self):
+        record = MagicMock(id=91)
+        observed_record_ids = []
+
+        def create_restore(**_kwargs):
+            transaction.on_commit(
+                lambda: observed_record_ids.append(
+                    LensKnowledgeSource.all_objects.values_list(
+                        "last_restore_record_id",
+                        flat=True,
+                    ).get(pk=self.knowledge_source.id)
+                )
+            )
+            return record
+
+        with (
+            patch.object(
+                knowledge_source_sync.restore_services,
+                "create_lens_workspace_restore_record",
+                side_effect=create_restore,
+            ),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            published = knowledge_source_sync._create_and_publish_workspace_restore(
+                org=self.organization,
+                ks=self.knowledge_source,
+                restore_data={"items": []},
+                sync_state={},
+                snapshot_id=17,
+                restore_scope_status={"0": "pending"},
+            )
+
+        self.assertEqual(published.id, record.id)
+        self.assertEqual(observed_record_ids, [record.id])
+        self.knowledge_source.refresh_from_db()
+        self.assertEqual(self.knowledge_source.last_restore_record_id, record.id)
+
+    def test_deleting_knowledge_source_cannot_publish_restore(self):
+        self.knowledge_source.lifecycle_status = (
+            LensKnowledgeSource.LifecycleStatus.DELETING
+        )
+        self.knowledge_source.save(update_fields=["lifecycle_status", "updated_at"])
+
+        with (
+            patch.object(
+                knowledge_source_sync.restore_services,
+                "create_lens_workspace_restore_record",
+            ) as create_restore,
+            self.assertRaisesRegex(
+                knowledge_source_sync.KnowledgeSourceSyncError,
+                "deletion was requested",
+            ),
+        ):
+            knowledge_source_sync._create_and_publish_workspace_restore(
+                org=self.organization,
+                ks=self.knowledge_source,
+                restore_data={"items": []},
+                sync_state={},
+                snapshot_id=17,
+                restore_scope_status={"0": "pending"},
+            )
+
+        create_restore.assert_not_called()
 
     def test_conversion_finishes_before_assistant_push(self):
         phase_calls = []
@@ -515,9 +583,7 @@ class ManagedRestorePipelineOrderTests(TestCase):
             "image": False,
             "embedded_image": False,
         }
-        self.knowledge_source.save(
-            update_fields=["ingest_policy_json", "updated_at"]
-        )
+        self.knowledge_source.save(update_fields=["ingest_policy_json", "updated_at"])
         phase_calls = []
 
         def record(name):
@@ -583,9 +649,7 @@ class ManagedRestorePipelineOrderTests(TestCase):
                 "status": "SUCCESS",
             },
         }
-        self.knowledge_source.save(
-            update_fields=["sync_state_json", "updated_at"]
-        )
+        self.knowledge_source.save(update_fields=["sync_state_json", "updated_at"])
         phase_calls = []
 
         def record(name):
@@ -661,9 +725,7 @@ class ManagedRestorePipelineOrderTests(TestCase):
                 "policy_fingerprint": "current-policy",
             },
         }
-        self.knowledge_source.save(
-            update_fields=["sync_state_json", "updated_at"]
-        )
+        self.knowledge_source.save(update_fields=["sync_state_json", "updated_at"])
 
         with (
             patch.object(
@@ -704,9 +766,7 @@ class ManagedRestorePipelineOrderTests(TestCase):
                 "policy_fingerprint": "stale-policy",
             },
         }
-        self.knowledge_source.save(
-            update_fields=["sync_state_json", "updated_at"]
-        )
+        self.knowledge_source.save(update_fields=["sync_state_json", "updated_at"])
         phase_calls = []
 
         def record(name):
@@ -760,26 +820,22 @@ class ManagedRestorePipelineOrderTests(TestCase):
         )
 
     @patch(
-        "apps.lens_bridge.services.knowledge_source_sync."
-        "enqueue_knowledge_source_sync"
+        "apps.lens_bridge.services.knowledge_source_sync.enqueue_knowledge_source_sync"
     )
     @patch(
         "apps.lens_bridge.services.knowledge_source_sync."
         "gateway_readiness.require_hfl_usable_gateway"
     )
     @patch(
-        "apps.node.services.internal.node_lifecycle."
-        "_active_lifecycle_task",
+        "apps.node.services.internal.node_lifecycle._active_lifecycle_task",
         return_value=None,
     )
     @patch(
-        "apps.lens_bridge.services.knowledge_source_sync."
-        "get_node_workload_blockers",
+        "apps.lens_bridge.services.knowledge_source_sync.get_node_workload_blockers",
         return_value=[],
     )
     @patch(
-        "apps.lens_bridge.services.knowledge_source_sync."
-        "context_for_knowledge_source"
+        "apps.lens_bridge.services.knowledge_source_sync.context_for_knowledge_source"
     )
     def test_manual_sync_after_completion_starts_new_generation(
         self,
@@ -825,12 +881,10 @@ class ManagedRestorePipelineOrderTests(TestCase):
         )
 
     @patch(
-        "apps.lens_bridge.services.knowledge_source_sync."
-        "enqueue_knowledge_source_sync"
+        "apps.lens_bridge.services.knowledge_source_sync.enqueue_knowledge_source_sync"
     )
     @patch(
-        "apps.lens_bridge.services.knowledge_source_sync."
-        "_restore_record_failed",
+        "apps.lens_bridge.services.knowledge_source_sync._restore_record_failed",
         return_value=True,
     )
     @patch(
@@ -838,18 +892,15 @@ class ManagedRestorePipelineOrderTests(TestCase):
         "gateway_readiness.require_hfl_usable_gateway"
     )
     @patch(
-        "apps.node.services.internal.node_lifecycle."
-        "_active_lifecycle_task",
+        "apps.node.services.internal.node_lifecycle._active_lifecycle_task",
         return_value=None,
     )
     @patch(
-        "apps.lens_bridge.services.knowledge_source_sync."
-        "get_node_workload_blockers",
+        "apps.lens_bridge.services.knowledge_source_sync.get_node_workload_blockers",
         return_value=[],
     )
     @patch(
-        "apps.lens_bridge.services.knowledge_source_sync."
-        "context_for_knowledge_source"
+        "apps.lens_bridge.services.knowledge_source_sync.context_for_knowledge_source"
     )
     def test_manual_retry_starts_one_new_restore_generation(
         self,
@@ -905,18 +956,15 @@ class ManagedRestorePipelineOrderTests(TestCase):
         "gateway_readiness.require_hfl_usable_gateway"
     )
     @patch(
-        "apps.node.services.internal.node_lifecycle."
-        "_active_lifecycle_task",
+        "apps.node.services.internal.node_lifecycle._active_lifecycle_task",
         return_value=None,
     )
     @patch(
-        "apps.lens_bridge.services.knowledge_source_sync."
-        "get_node_workload_blockers",
+        "apps.lens_bridge.services.knowledge_source_sync.get_node_workload_blockers",
         return_value=[],
     )
     @patch(
-        "apps.lens_bridge.services.knowledge_source_sync."
-        "context_for_knowledge_source"
+        "apps.lens_bridge.services.knowledge_source_sync.context_for_knowledge_source"
     )
     def test_manual_retry_waits_for_final_conversion_stop_acknowledgement(
         self,

--- a/src/backend/apps/lens_bridge/tests/test_resume_blocked_chat_cleanup_command.py
+++ b/src/backend/apps/lens_bridge/tests/test_resume_blocked_chat_cleanup_command.py
@@ -138,9 +138,7 @@ class ResumeBlockedChatCleanupDatabaseTests(TestCase):
             teardown_attempts=99,
         )
 
-    @patch(
-        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
-    )
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error")
     @patch(
         "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
         "sl_client.get_task_by_id",
@@ -207,9 +205,7 @@ class ResumeBlockedChatCleanupDatabaseTests(TestCase):
                 "intervention_required": True,
             },
         }
-        self.session.save(
-            update_fields=["teardown_state_json", "updated_at"]
-        )
+        self.session.save(update_fields=["teardown_state_json", "updated_at"])
 
         with self.assertRaisesRegex(CommandError, "recorded blocking condition"):
             Command().handle(
@@ -233,15 +229,11 @@ class ResumeBlockedChatCleanupDatabaseTests(TestCase):
             "intent": "delete_session",
             "blocking": nonconversion_blocking,
         }
-        self.session.save(
-            update_fields=["teardown_state_json", "updated_at"]
-        )
+        self.session.save(update_fields=["teardown_state_json", "updated_at"])
         self.knowledge_source.teardown_state_json = {
             "blocking": nonconversion_blocking,
         }
-        self.knowledge_source.save(
-            update_fields=["teardown_state_json", "updated_at"]
-        )
+        self.knowledge_source.save(update_fields=["teardown_state_json", "updated_at"])
 
         with self.assertRaisesRegex(CommandError, "not blocked"):
             Command().handle(
@@ -251,9 +243,7 @@ class ResumeBlockedChatCleanupDatabaseTests(TestCase):
                 confirm_executor_stopped=True,
             )
 
-    @patch(
-        "apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error"
-    )
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error")
     @patch(
         "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
         "sl_client.get_task_by_id"
@@ -321,9 +311,7 @@ class ResumeBlockedChatCleanupDatabaseTests(TestCase):
                 "intervention_required": True,
             },
         }
-        self.session.save(
-            update_fields=["teardown_state_json", "updated_at"]
-        )
+        self.session.save(update_fields=["teardown_state_json", "updated_at"])
 
         with self.assertRaisesRegex(CommandError, "Conversion cleanup requires"):
             Command().handle(
@@ -337,9 +325,58 @@ class ResumeBlockedChatCleanupDatabaseTests(TestCase):
         self.knowledge_source.refresh_from_db()
         self.assertIn("blocking", self.knowledge_source.teardown_state_json)
 
-    @patch(
-        "apps.lens_bridge.services.knowledge_source_teardown._queue_teardown"
-    )
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_teardown_or_record_error")
+    def test_resume_chat_restore_stop_requires_matching_explicit_confirmation(
+        self,
+        queue_teardown,
+    ):
+        restore_task_id = "3a52d390-c8a1-47e7-bab0-fac104ad3f36"
+        blocking = {
+            "reason": "restore_executor_still_stopping",
+            "task_id": restore_task_id,
+            "intervention_required": True,
+        }
+        self.session.teardown_state_json = {
+            "intent": "delete_session",
+            "blocking": blocking,
+        }
+        self.session.save(update_fields=["teardown_state_json", "updated_at"])
+        self.knowledge_source.teardown_state_json = {"blocking": blocking}
+        self.knowledge_source.save(update_fields=["teardown_state_json", "updated_at"])
+
+        with self.captureOnCommitCallbacks(execute=True):
+            Command().handle(
+                session_id=self.session.id,
+                source_lens_task_id="",
+                restore_task_id=restore_task_id,
+                reason="The Data Gateway restore process was verified as stopped.",
+                confirm_executor_stopped=True,
+                confirm_retry=False,
+            )
+
+        self.session.refresh_from_db()
+        self.knowledge_source.refresh_from_db()
+        self.assertEqual(
+            self.session.teardown_state_json["manual_restore_stop_confirmation"][
+                "task_id"
+            ],
+            restore_task_id,
+        )
+        self.assertEqual(
+            self.knowledge_source.teardown_state_json[
+                "manual_restore_stop_confirmation"
+            ]["task_id"],
+            restore_task_id,
+        )
+        self.assertEqual(
+            self.knowledge_source.teardown_state_json[
+                "manual_restore_stop_confirmations"
+            ][restore_task_id]["task_id"],
+            restore_task_id,
+        )
+        queue_teardown.assert_called_once_with(self.session.id)
+
+    @patch("apps.lens_bridge.services.knowledge_source_teardown._queue_teardown")
     def test_resume_orphan_knowledge_source_cleanup(self, queue_teardown):
         orphan = LensKnowledgeSource.objects.create(
             organization=self.tenant,
@@ -383,9 +420,7 @@ class ResumeBlockedChatCleanupDatabaseTests(TestCase):
                 "intervention_required": True,
             }
         }
-        self.knowledge_source.save(
-            update_fields=["teardown_state_json", "updated_at"]
-        )
+        self.knowledge_source.save(update_fields=["teardown_state_json", "updated_at"])
 
         with self.assertRaisesRegex(CommandError, "still belongs to a Chat"):
             Command().handle(
@@ -405,9 +440,7 @@ class ResumeBlockedChatCleanupDatabaseTests(TestCase):
             source_path="/data/orphaned-conversion",
             created_by=self.user,
             lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETING,
-            sync_state_json={
-                "conversion": {"task_id": "orphan-convert-1"}
-            },
+            sync_state_json={"conversion": {"task_id": "orphan-convert-1"}},
             teardown_state_json={
                 "blocking": {
                     "reason": "conversion_stop_unconfirmed",
@@ -426,9 +459,7 @@ class ResumeBlockedChatCleanupDatabaseTests(TestCase):
                 confirm_retry=True,
             )
 
-    @patch(
-        "apps.lens_bridge.services.knowledge_source_teardown._queue_teardown"
-    )
+    @patch("apps.lens_bridge.services.knowledge_source_teardown._queue_teardown")
     @patch(
         "apps.lens_bridge.management.commands.resume_blocked_chat_cleanup."
         "sl_client.get_task_by_id",
@@ -447,9 +478,7 @@ class ResumeBlockedChatCleanupDatabaseTests(TestCase):
             source_path="/data/orphaned-conversion-recovery",
             created_by=self.user,
             lifecycle_status=LensKnowledgeSource.LifecycleStatus.DELETING,
-            sync_state_json={
-                "conversion": {"task_id": "orphan-convert-1"}
-            },
+            sync_state_json={"conversion": {"task_id": "orphan-convert-1"}},
             teardown_state_json={
                 "blocking": {
                     "reason": "conversion_stop_unconfirmed",
@@ -473,8 +502,8 @@ class ResumeBlockedChatCleanupDatabaseTests(TestCase):
         self.assertEqual(orphan.teardown_attempts, 0)
         self.assertNotIn("blocking", orphan.teardown_state_json)
         self.assertTrue(
-            orphan.sync_state_json["conversion"][
-                "manual_stop_confirmation"
-            ]["confirmed"]
+            orphan.sync_state_json["conversion"]["manual_stop_confirmation"][
+                "confirmed"
+            ]
         )
         queue_teardown.assert_called_once_with(orphan.id)

--- a/src/backend/apps/node/services/internal/task.py
+++ b/src/backend/apps/node/services/internal/task.py
@@ -304,10 +304,14 @@ def _initial_watchdog_deadline(
         return base + timezone.timedelta(
             seconds=max(1, node_conf.AUTOMATIC_PROBE_WATCHDOG_SECONDS)
         )
-    if correlation_type in {
-        "protection.snapshot_delete",
-        "protection.backup_config_reset",
-    } and kind == "snapshot.delete":
+    if (
+        correlation_type
+        in {
+            "protection.snapshot_delete",
+            "protection.backup_config_reset",
+        }
+        and kind == "snapshot.delete"
+    ):
         base = from_time or timezone.now()
         return base + timezone.timedelta(
             seconds=max(1, node_conf.SNAPSHOT_DELETE_WATCHDOG_SECONDS)
@@ -863,7 +867,52 @@ def create_agent_task(
     return task
 
 
+def _is_managed_workspace_restore_task(task: NodeTask) -> bool:
+    """Return whether task may write one identity-bound Chat workspace."""
+
+    payload = task.payload if isinstance(task.payload, dict) else {}
+    return bool(
+        task.kind in {"restore.run", "kopia.restore"}
+        and task.correlation_type == "restore.record"
+        and str(task.correlation_id or "").strip()
+        and payload.get("workspace_kind") == "managed_restore"
+        and str(payload.get("workspace_uid") or "").strip()
+        and str(payload.get("managed_workspace_path") or "").strip()
+    )
+
+
 def deliver_agent_task(
+    *,
+    task: NodeTask,
+    delivery_payload: dict | None = None,
+    allow_ack_redelivery: bool = False,
+) -> NodeTask:
+    """Serialize managed restore delivery against workspace cancellation."""
+
+    if _is_managed_workspace_restore_task(task):
+        # A pending managed restore is the only command that can race Chat
+        # teardown and later write the same workspace. Hold its row lock across
+        # downlink publication so cancellation either wins before publication
+        # or follows the command and waits for executor-stop evidence.
+        with transaction.atomic():
+            locked = (
+                NodeTask.objects.select_for_update(of=("self",))
+                .select_related("node")
+                .get(pk=task.pk)
+            )
+            return _deliver_agent_task(
+                task=locked,
+                delivery_payload=delivery_payload,
+                allow_ack_redelivery=allow_ack_redelivery,
+            )
+    return _deliver_agent_task(
+        task=task,
+        delivery_payload=delivery_payload,
+        allow_ack_redelivery=allow_ack_redelivery,
+    )
+
+
+def _deliver_agent_task(
     *,
     task: NodeTask,
     delivery_payload: dict | None = None,
@@ -1452,6 +1501,28 @@ def complete_task(
 
     incoming_result = dict(result or {})
     incoming_terminal_status = _incoming_terminal_status(incoming)
+    executor_stop_evidence = (
+        task.status == NodeTask.Status.CANCELED
+        and _is_managed_workspace_restore_task(task)
+        and incoming_result.get("executor_finished") is True
+        and incoming_result.get("completion_source") == "agent_executor"
+    )
+    failed_wire_cancel = incoming_terminal_status == NodeTask.Status.FAILED and str(
+        error or ""
+    ).strip().lower() in {"canceled", "cancelled"}
+    if executor_stop_evidence and (
+        incoming_terminal_status == NodeTask.Status.CANCELED or failed_wire_cancel
+    ):
+        # Cancellation grace may seal the control-plane row before the Agent's
+        # restore process group has actually exited. Older Agents report their
+        # local cancelled terminal state as wire ``failed`` with error
+        # ``canceled``. Normalize only this identity-bound executor proof and
+        # preserve the cancellation audit fields.
+        merged_cancel_result = dict(task.result or {})
+        merged_cancel_result.update(incoming_result)
+        incoming_result = merged_cancel_result
+        incoming = "canceled"
+        incoming_terminal_status = NodeTask.Status.CANCELED
     if (
         _is_lifecycle_correlated_task(task)
         and task.status == NodeTask.Status.SUCCESS
@@ -1537,7 +1608,7 @@ def complete_task(
         correlation_id=task.correlation_id,
     )
 
-    terminal = status.lower()
+    terminal = incoming
     if terminal == "running":
         now = timezone.now()
         task.status = NodeTask.Status.RUNNING
@@ -1582,14 +1653,14 @@ def complete_task(
         task.status = NodeTask.Status.FAILED
         task.last_error = (error or terminal)[:2000]
 
-    if result:
-        task.result = result
+    if incoming_result:
+        task.result = incoming_result
     else:
         task.result = _without_delivery_runtime_state(task.result)
-    if (
-        _is_lifecycle_correlated_task(task)
-        and task.kind in {"agent.upgrade", "agent.uninstall"}
-    ):
+    if _is_lifecycle_correlated_task(task) and task.kind in {
+        "agent.upgrade",
+        "agent.uninstall",
+    }:
         lifecycle_result = dict(task.result or {})
         lifecycle_result["lifecycle_terminal_sealed"] = True
         task.result = lifecycle_result
@@ -1877,15 +1948,12 @@ def sweep_watchdog_timeouts(
                 if "result" in message_type.lower()
                 else node_conf.TASK_UPLINK_PROJECTION_GRACE_SECONDS
             )
-            bounded_remote_execution = (
-                _is_source_nas_probe(
-                    correlation_type=task.correlation_type,
-                    kind=task.kind,
-                )
-                or _is_repository_initialize_task(
-                    correlation_type=task.correlation_type,
-                    kind=task.kind,
-                )
+            bounded_remote_execution = _is_source_nas_probe(
+                correlation_type=task.correlation_type,
+                kind=task.kind,
+            ) or _is_repository_initialize_task(
+                correlation_type=task.correlation_type,
+                kind=task.kind,
             )
             result_projection_pending = "result" in message_type.lower()
             # Download-capable Agents already use the durable progress lease
@@ -1926,11 +1994,15 @@ def sweep_watchdog_timeouts(
                 task.result = merged
                 task.last_error = "result acknowledgement timeout"
                 update_fields = ["status", "result", "last_error", "updated_at"]
-            elif _uses_upgrade_download_progress(task) and _download_snapshot(
-                (task.result or {}).get("last_progress")
-                if isinstance(task.result, dict)
-                else None
-            ) is not None:
+            elif (
+                _uses_upgrade_download_progress(task)
+                and _download_snapshot(
+                    (task.result or {}).get("last_progress")
+                    if isinstance(task.result, dict)
+                    else None
+                )
+                is not None
+            ):
                 merged = dict(task.result or {})
                 merged["diagnostic_error_code"] = (
                     "AGENT_PACKAGE_DOWNLOAD_PROGRESS_TIMEOUT"

--- a/src/backend/apps/node/tests/test_task_cancel_grace.py
+++ b/src/backend/apps/node/tests/test_task_cancel_grace.py
@@ -8,7 +8,14 @@ from django.utils import timezone
 from apps.iam.models import Organization
 from apps.node.models import Node, NodeTask
 from apps.node.models.base import NodeRole
-from apps.node.services.internal.task import cancel_task, sweep_cancel_grace_expired
+from apps.node.services.internal.task import (
+    _is_managed_workspace_restore_task,
+    cancel_task,
+    complete_task,
+    sweep_cancel_grace_expired,
+)
+from apps.node.ws.uplink import _handle_task_result
+from apps.node.ws.wire import ParsedUplink, WireType
 
 
 class NodeTaskCancelGraceTests(TestCase):
@@ -18,7 +25,8 @@ class NodeTaskCancelGraceTests(TestCase):
             organization=self.org,
             name="cancel-grace-agent",
             role=NodeRole.AGENT,
-            status=Node.Status.ACTIVE, availability=Node.Availability.ONLINE,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
         )
 
     def create_task(self, *, status=NodeTask.Status.RUNNING) -> NodeTask:
@@ -42,7 +50,9 @@ class NodeTaskCancelGraceTests(TestCase):
 
         self.assertEqual(second.status, NodeTask.Status.RUNNING)
         self.assertEqual(second.cancel_requested_at, first_requested_at)
-        self.assertEqual(second.result["cancel_requested_at"], first_requested_at.isoformat())
+        self.assertEqual(
+            second.result["cancel_requested_at"], first_requested_at.isoformat()
+        )
 
     @patch("apps.node.services.internal.task._send_cancel_command")
     def test_pending_cancel_is_immediately_terminal(self, _send_cancel):
@@ -91,3 +101,111 @@ class NodeTaskCancelGraceTests(TestCase):
         task.refresh_from_db()
         self.assertEqual(task.status, NodeTask.Status.RUNNING)
         projection.assert_not_called()
+
+    def test_cancelled_managed_restore_accepts_late_executor_stop_evidence(self):
+        task = self.create_task(status=NodeTask.Status.CANCELED)
+        task.kind = "restore.run"
+        task.correlation_type = "restore.record"
+        task.payload = {
+            "workspace_kind": "managed_restore",
+            "workspace_uid": "8f65d43a-09fd-4ae7-b5f1-159352838a23",
+            "managed_workspace_path": "/var/lib/hyperfilelens/insight/workspace",
+        }
+        task.result = {
+            "cancel_requested": True,
+            "cancel_finalized_by": "grace_timeout",
+        }
+        task.save(
+            update_fields=[
+                "kind",
+                "correlation_type",
+                "payload",
+                "result",
+                "updated_at",
+            ]
+        )
+        self.assertTrue(_is_managed_workspace_restore_task(task), task.payload)
+
+        completed = complete_task(
+            task_id=task.id,
+            node_id=self.node.id,
+            status="failed",
+            result={
+                "executor_finished": True,
+                "completion_source": "agent_executor",
+            },
+            error="canceled",
+        )
+
+        self.assertEqual(completed.status, NodeTask.Status.CANCELED)
+        self.assertTrue(completed.result["cancel_requested"])
+        self.assertEqual(completed.result["cancel_finalized_by"], "grace_timeout")
+        self.assertTrue(completed.result["executor_finished"])
+        self.assertEqual(completed.result["completion_source"], "agent_executor")
+
+    def test_cancelled_managed_restore_rejects_unrelated_failed_result(self):
+        task = self.create_task(status=NodeTask.Status.CANCELED)
+        task.kind = "restore.run"
+        task.correlation_type = "restore.record"
+        task.payload = {
+            "workspace_kind": "managed_restore",
+            "workspace_uid": "8f65d43a-09fd-4ae7-b5f1-159352838a23",
+            "managed_workspace_path": "/var/lib/hyperfilelens/insight/workspace",
+        }
+        task.save(update_fields=["kind", "correlation_type", "payload", "updated_at"])
+
+        completed = complete_task(
+            task_id=task.id,
+            node_id=self.node.id,
+            status="failed",
+            result={
+                "executor_finished": True,
+                "completion_source": "agent_executor",
+            },
+            error="restore failed",
+        )
+
+        self.assertEqual(completed.status, NodeTask.Status.CANCELED)
+        self.assertNotIn("executor_finished", completed.result)
+
+    def test_websocket_failed_cancel_preserves_executor_stop_evidence(self):
+        task = self.create_task(status=NodeTask.Status.CANCELED)
+        task.kind = "restore.run"
+        task.correlation_type = "restore.record"
+        task.correlation_id = "managed-restore-record"
+        task.payload = {
+            "workspace_kind": "managed_restore",
+            "workspace_uid": "8f65d43a-09fd-4ae7-b5f1-159352838a23",
+            "managed_workspace_path": "/var/lib/hyperfilelens/insight/workspace",
+        }
+        task.result = {"cancel_finalized_by": "grace_timeout"}
+        task.save(
+            update_fields=[
+                "kind",
+                "correlation_type",
+                "correlation_id",
+                "payload",
+                "result",
+                "updated_at",
+            ]
+        )
+
+        completed = _handle_task_result(
+            node_id=self.node.id,
+            message=ParsedUplink(
+                msg_type=WireType.TASK_RESULT,
+                task_id=str(task.id),
+                status="failed",
+                result={
+                    "executor_finished": True,
+                    "completion_source": "agent_executor",
+                    "executor_finished_at": "2026-08-31T14:00:00Z",
+                },
+                error="canceled",
+            ),
+        )
+
+        self.assertEqual(completed.status, NodeTask.Status.CANCELED)
+        self.assertEqual(completed.result["cancel_finalized_by"], "grace_timeout")
+        self.assertTrue(completed.result["executor_finished"])
+        self.assertEqual(completed.result["completion_source"], "agent_executor")

--- a/src/backend/apps/node/tests/test_task_command_ack.py
+++ b/src/backend/apps/node/tests/test_task_command_ack.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import threading
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.db import close_old_connections
+from django.test import TestCase, TransactionTestCase, skipUnlessDBFeature
 from django.utils import timezone
 from redis.exceptions import ConnectionError as RedisConnectionError
 
@@ -313,9 +315,7 @@ class TaskCommandAckTests(TestCase):
 
     @patch("apps.node.services.internal.task.redis_store.set_task_info")
     @patch("apps.node.services.internal.task.redis_store.push_task_stream")
-    def test_repository_initialize_uses_dispatch_start(
-        self, _push, _set_info
-    ):
+    def test_repository_initialize_uses_dispatch_start(self, _push, _set_info):
         dispatched_at = timezone.now() - timezone.timedelta(seconds=20)
         task = self.task(
             kind="repo.initialize",
@@ -344,9 +344,7 @@ class TaskCommandAckTests(TestCase):
 
     @patch("apps.node.services.internal.task.redis_store.set_task_info")
     @patch("apps.node.services.internal.task.redis_store.push_task_stream")
-    def test_legacy_repository_initialize_uses_dispatch_start(
-        self, _push, _set_info
-    ):
+    def test_legacy_repository_initialize_uses_dispatch_start(self, _push, _set_info):
         dispatched_at = timezone.now() - timezone.timedelta(seconds=20)
         task = self.task(
             kind="repo.initialize",
@@ -544,9 +542,7 @@ class TaskCommandAckTests(TestCase):
         send_cancel,
     ):
         self.node.metadata = {
-            "inventory": {
-                "capabilities": ["agent_upgrade_download_progress_v1"]
-            }
+            "inventory": {"capabilities": ["agent_upgrade_download_progress_v1"]}
         }
         self.node.save(update_fields=["metadata", "updated_at"])
         task = self.task(
@@ -590,9 +586,7 @@ class TaskCommandAckTests(TestCase):
     @patch("apps.node.services.internal.task._sync_task_info")
     def test_upgrade_download_bytes_renew_progress_deadline(self, _sync, _push):
         self.node.metadata = {
-            "inventory": {
-                "capabilities": ["agent_upgrade_download_progress_v1"]
-            }
+            "inventory": {"capabilities": ["agent_upgrade_download_progress_v1"]}
         }
         self.node.save(update_fields=["metadata", "updated_at"])
         original_deadline = timezone.now() + timezone.timedelta(seconds=5)
@@ -730,9 +724,7 @@ class TaskCommandAckTests(TestCase):
         "apps.node.services.internal.task.redis_store.ws_recovery_hold_active",
         return_value=False,
     )
-    def test_unknown_delivery_protocol_is_reclassified_instead_of_stranded(
-        self, _hold
-    ):
+    def test_unknown_delivery_protocol_is_reclassified_instead_of_stranded(self, _hold):
         task = self.task(result={"_delivery_protocol": "future-protocol"})
 
         summary = reconcile_unaccepted_agent_tasks(limit=10)
@@ -833,9 +825,7 @@ class TaskCommandAckTests(TestCase):
         send_cancel,
     ):
         self.node.metadata = {
-            "inventory": {
-                "capabilities": ["agent_upgrade_download_progress_v1"]
-            }
+            "inventory": {"capabilities": ["agent_upgrade_download_progress_v1"]}
         }
         self.node.save(update_fields=["metadata", "updated_at"])
         task = self.task(
@@ -1157,3 +1147,87 @@ class TaskCommandAckTests(TestCase):
 
         self.assertEqual(delivered.status, NodeTask.Status.SUCCESS)
         self.assertEqual(delivered.result, {"completed": True})
+
+
+@skipUnlessDBFeature("has_select_for_update")
+class ManagedWorkspaceRestoreDeliveryRaceTests(TransactionTestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(
+            key="managed-restore-delivery",
+            name="Managed Restore Delivery",
+        )
+        self.node = Node.objects.create(
+            organization=self.org,
+            name="managed-restore-gateway",
+            role=Node.Role.GATEWAY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            last_seen_at=timezone.now(),
+        )
+
+    @patch("apps.node.services.internal.task.redis_store.push_task_stream")
+    @patch("apps.node.services.internal.task.redis_store.set_task_info")
+    @patch("apps.node.services.internal.task._send_cancel_command")
+    @patch(
+        "apps.node.services.internal.task._node_route_state",
+        return_value=_RouteState.ONLINE,
+    )
+    def test_cancel_cannot_overtake_managed_restore_command(
+        self,
+        _route,
+        send_cancel,
+        _set_info,
+        _push_stream,
+    ):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="restore.run",
+            correlation_type="restore.record",
+            correlation_id="managed-restore-record",
+            status=NodeTask.Status.PENDING,
+            payload={
+                "workspace_kind": "managed_restore",
+                "workspace_uid": "8f65d43a-09fd-4ae7-b5f1-159352838a23",
+                "managed_workspace_path": "/var/lib/hyperfilelens/insight/workspace",
+            },
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=2),
+        )
+        cancel_started = threading.Event()
+        cancel_finished = threading.Event()
+        thread_errors: list[BaseException] = []
+        cancel_thread: threading.Thread | None = None
+
+        def cancel_in_thread() -> None:
+            close_old_connections()
+            cancel_started.set()
+            try:
+                cancel_task(task_id=task.id, reason="Chat deletion requested")
+            except BaseException as exc:  # pragma: no cover - surfaced below
+                thread_errors.append(exc)
+            finally:
+                close_old_connections()
+                cancel_finished.set()
+
+        def send_command(*, task: NodeTask) -> None:
+            nonlocal cancel_thread
+            cancel_thread = threading.Thread(target=cancel_in_thread)
+            cancel_thread.start()
+            self.assertTrue(cancel_started.wait(timeout=2))
+            self.assertFalse(cancel_finished.wait(timeout=0.2))
+
+        with patch(
+            "apps.node.services.internal.task._send_task_command",
+            side_effect=send_command,
+        ):
+            delivered = deliver_agent_task(task=task)
+
+        self.assertTrue(cancel_finished.wait(timeout=2))
+        if cancel_thread is not None:
+            cancel_thread.join(timeout=2)
+        self.assertEqual(thread_errors, [])
+        delivered.refresh_from_db()
+        self.assertEqual(delivered.status, NodeTask.Status.RUNNING)
+        self.assertIsNotNone(delivered.dispatched_at)
+        self.assertTrue(delivered.result["cancel_requested"])
+        send_cancel.assert_called_once()

--- a/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.test.ts
+++ b/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.test.ts
@@ -128,7 +128,7 @@ describe('CopilotLifecycleState', () => {
       cleanup_status: 'running',
     }))
 
-    expect(wrapper.text()).toContain('Recovering Chat Resources')
+    expect(wrapper.text()).toContain('Preparing Chat for Retry')
     expect(wrapper.text()).not.toContain('Deleting Chat')
     expect(wrapper.text()).not.toContain('Try Again')
   })
@@ -140,8 +140,20 @@ describe('CopilotLifecycleState', () => {
       cleanup_status: 'blocked',
     }))
 
-    expect(wrapper.text()).toContain('Chat Recovery Needs Attention')
-    expect(wrapper.text()).toContain('Temporary data is being retained')
+    expect(wrapper.text()).toContain('Chat Cleanup Needs Attention')
+    expect(wrapper.text()).toContain('Temporary data remains protected')
+    expect(wrapper.text()).not.toContain('Deleting Chat')
+  })
+
+  it('offers a bounded delete retry when deletion cleanup is blocked', () => {
+    const wrapper = mountState(session({
+      lifecycle_status: 'deleting',
+      cleanup_intent: 'delete_session',
+      cleanup_status: 'blocked',
+    }))
+
+    expect(wrapper.text()).toContain('Chat Cleanup Needs Attention')
+    expect(wrapper.text()).toContain('Retry Delete')
     expect(wrapper.text()).not.toContain('Deleting Chat')
   })
 

--- a/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.vue
+++ b/src/frontend/src/pages/insight/copilot/CopilotLifecycleState.vue
@@ -105,9 +105,14 @@ const isRecoveryCleanup = computed(() => (
   && ['pending', 'running'].includes(props.session.cleanup_status || '')
 ))
 const isCleanupBlocked = computed(() => (
-  props.session.lifecycle_status === 'failed'
-  && props.session.cleanup_intent === 'reset_for_retry'
+  (
+    (props.session.lifecycle_status === 'failed' && props.session.cleanup_intent === 'reset_for_retry')
+    || (props.session.lifecycle_status === 'deleting' && props.session.cleanup_intent === 'delete_session')
+  )
   && props.session.cleanup_status === 'blocked'
+))
+const isDeleteCleanupBlocked = computed(() => (
+  isCleanupBlocked.value && props.session.lifecycle_status === 'deleting'
 ))
 const isGatewayQueued = computed(() => (
   props.session.lifecycle_status === 'provisioning'
@@ -132,8 +137,8 @@ function stepState(index: number) {
         :size="30"
         class="copilot-lifecycle-spin"
       /></span>
-      <h2>Recovering Chat Resources</h2>
-      <p>Preparation stopped, and temporary resources are being cleaned up safely. You can retry when recovery finishes.</p>
+      <h2>Preparing Chat for Retry</h2>
+      <p>The previous preparation attempt stopped. Temporary resources are being removed safely before you can try again.</p>
       <div class="copilot-lifecycle-actions">
         <ElButton @click="emit('delete')">
           Delete Chat
@@ -146,11 +151,11 @@ function stepState(index: number) {
       class="copilot-lifecycle-card is-failed"
     >
       <span class="copilot-lifecycle-icon is-failed"><TriangleAlert :size="30" /></span>
-      <h2>Chat Recovery Needs Attention</h2>
-      <p>Cleanup is waiting for SourceLens to confirm that document conversion has stopped. Temporary data is being retained to prevent unsafe deletion.</p>
+      <h2>Chat Cleanup Needs Attention</h2>
+      <p>Active processing could not be confirmed as stopped. Temporary data remains protected so cleanup can be retried safely.</p>
       <div class="copilot-lifecycle-actions">
         <ElButton @click="emit('delete')">
-          Delete Chat
+          {{ isDeleteCleanupBlocked ? 'Retry Delete' : 'Delete Chat' }}
         </ElButton>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- scope Chat teardown checks to the owning restore, Knowledge Source, and workspace identity without blocking unrelated Data Gateway work
- serialize managed restore delivery and cancellation, and preserve explicit Agent executor-stop evidence
- quarantine managed workspaces with UID locks and durable tombstones before releasing Chat preparation capacity
- add bounded cleanup retries, audited operator recovery, and clearer retry/delete lifecycle feedback
- preserve existing standalone Knowledge Source and ordinary restore behavior

## Validation

- Agent wire and database race tests
- Agent managed workspace prepare/cleanup tests
- Go vet for affected Agent packages
- Django teardown, restore-stop, queue, sync, recovery command, and task cancellation tests
- frontend Copilot lifecycle tests, ESLint, and Vue type checking
- Ruff, Python compilation, and diff checks