### PR TITLE
Preserve snapshots during active restores and Chat preparation

### DIFF
--- a/src/backend/apps/lens_bridge/services/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/services/chat_lifecycle.py
@@ -54,8 +54,13 @@ from apps.protection.models import (
 from apps.storage.services.internal.repository_workload import (
     RepositoryWorkload,
     lock_repositories_for_workload,
+    validate_repositories_for_workload,
 )
 from apps.protection.services.source_identity import resolve_source_display_name
+from apps.protection.services.snapshot_usage import (
+    acquire_snapshot_usage,
+    release_chat_usage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +89,21 @@ class ChatCreateIdempotencyConflict(APIException):
     status_code = http_status.HTTP_409_CONFLICT
     default_detail = "The chat request key was already used with different data."
     default_code = "chat_create_idempotency_conflict"
+
+
+def _acquire_chat_snapshot_usage(
+    *, organization_id: int, snapshot_id: int, session_link_id: int
+) -> None:
+    try:
+        acquire_snapshot_usage(
+            organization_id=organization_id,
+            snapshot_id=snapshot_id,
+            consumer_type="chat",
+            consumer_id=session_link_id,
+        )
+    except DjangoValidationError as exc:
+        detail = exc.message_dict if hasattr(exc, "message_dict") else exc.messages
+        raise ValidationError(detail=detail) from exc
 
 
 def _chat_create_request_identity(
@@ -366,6 +386,16 @@ def create_copilot_chat(
     if existing is not None:
         if existing.create_request_hash != request_hash:
             raise ChatCreateIdempotencyConflict()
+        if (
+            existing.lifecycle_status
+            == LensSessionLink.LifecycleStatus.PROVISIONING
+            and existing.backup_source_snapshot_id is not None
+        ):
+            _acquire_chat_snapshot_usage(
+                organization_id=org.id,
+                snapshot_id=existing.backup_source_snapshot_id,
+                session_link_id=existing.id,
+            )
         return existing
 
     config = BackupConfig.objects.filter(
@@ -374,7 +404,7 @@ def create_copilot_chat(
     if config is None:
         raise ValidationError({"backup_config_id": "Backup source not found."})
     try:
-        lock_repositories_for_workload(
+        validate_repositories_for_workload(
             organization_id=org.id,
             repository_ids=[config.repository_id],
             workload=RepositoryWorkload.RESTORE_READ,
@@ -546,6 +576,49 @@ def create_copilot_chat(
 
     try:
         with transaction.atomic():
+            from apps.source.services.internal.source_operation_fence import (
+                assert_source_product_operation_allowed,
+                lock_source_identity,
+            )
+
+            assert_source_product_operation_allowed(
+                organization_id=org.id,
+                source_type=(
+                    "agent" if config.source_type == "host" else config.source_type
+                ),
+                source_ref_id=config.source_ref_id,
+            )
+            lock_source_identity(
+                organization_id=org.id,
+                source_type=(
+                    "agent" if config.source_type == "host" else config.source_type
+                ),
+                source_ref_id=config.source_ref_id,
+            )
+            snapshot = (
+                BackupSourceSnapshot.objects.select_for_update()
+                .filter(
+                    id=snapshot.id,
+                    organization_id=org.id,
+                    backup_config_id=config.id,
+                )
+                .first()
+            )
+            if snapshot is None or snapshot.status not in {
+                BackupSourceSnapshot.Status.AVAILABLE,
+                BackupSourceSnapshot.Status.PARTIAL,
+            }:
+                raise ValidationError(
+                    {"backup_source_snapshot_id": "Snapshot is no longer available."}
+                )
+            try:
+                lock_repositories_for_workload(
+                    organization_id=org.id,
+                    repository_ids=[config.repository_id],
+                    workload=RepositoryWorkload.RESTORE_READ,
+                )
+            except DjangoValidationError as exc:
+                raise ValidationError(exc.message_dict) from exc
             gateway_link = (
                 LensGatewayLink.objects.select_for_update()
                 .select_related("gateway", "organization")
@@ -565,6 +638,11 @@ def create_copilot_chat(
                 gateway_link=gateway_link,
             )
             link = _create_session_link()
+            _acquire_chat_snapshot_usage(
+                organization_id=org.id,
+                snapshot_id=snapshot.id,
+                session_link_id=link.id,
+            )
             link.gateway_queue_entered_at = timezone.now()
             link.save(update_fields=["gateway_queue_entered_at", "updated_at"])
     except IntegrityError:
@@ -578,6 +656,12 @@ def create_copilot_chat(
             raise
         if link.create_request_hash != request_hash:
             raise ChatCreateIdempotencyConflict()
+        if link.lifecycle_status == LensSessionLink.LifecycleStatus.PROVISIONING:
+            _acquire_chat_snapshot_usage(
+                organization_id=org.id,
+                snapshot_id=link.backup_source_snapshot_id,
+                session_link_id=link.id,
+            )
         return link
 
     transaction.on_commit(lambda: _queue_provision_or_mark_failed(link.id))
@@ -1978,6 +2062,11 @@ def _complete_copilot_chat_provision(
             "updated_at",
         ]
     )
+    if link.backup_source_snapshot_id is not None:
+        release_chat_usage(
+            session_link_id=link.id,
+            snapshot_id=link.backup_source_snapshot_id,
+        )
     transaction.on_commit(
         lambda: gateway_chat_queue.release_chat_prepare_slot(
             session_link_id=link.id,
@@ -2815,6 +2904,11 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     )
     if updated != 1:
         raise ChatTeardownIncompleteError("Chat teardown lease was lost.")
+    if not critical_errors and link.backup_source_snapshot_id is not None:
+        release_chat_usage(
+            session_link_id=link.id,
+            snapshot_id=link.backup_source_snapshot_id,
+        )
     if slot_generation is not None and prepare_slot_release_safe:
         gateway_chat_queue.release_chat_prepare_slot(
             session_link_id=link.id,
@@ -2848,6 +2942,7 @@ def run_copilot_chat_teardown(*, session_link_id: int) -> dict[str, Any]:
     }
 
 
+@transaction.atomic
 def _mark_provision_failed_by_id(
     session_link_id: int,
     claim_token: str,
@@ -2875,6 +2970,16 @@ def _mark_provision_failed_by_id(
         updated_at=timezone.now(),
     )
     if updated:
+        snapshot_id = (
+            LensSessionLink.objects.filter(pk=session_link_id)
+            .values_list("backup_source_snapshot_id", flat=True)
+            .first()
+        )
+        if snapshot_id is not None:
+            release_chat_usage(
+                session_link_id=session_link_id,
+                snapshot_id=snapshot_id,
+            )
         released_gateway_id = gateway_chat_queue.release_chat_prepare_slot(
             session_link_id=session_link_id,
             expected_generation=expected_generation,
@@ -3073,6 +3178,13 @@ def retry_copilot_chat_provision(link: LensSessionLink) -> LensSessionLink:
     gateway_link = locked.gateway_link or (
         locked.chat_binding.gateway_link if locked.chat_binding_id else None
     )
+    if locked.backup_source_snapshot_id is not None:
+        _acquire_chat_snapshot_usage(
+            organization_id=locked.organization_id,
+            snapshot_id=locked.backup_source_snapshot_id,
+            session_link_id=locked.id,
+        )
+
     if gateway_link is not None:
         # Backfill the canonical binding for sessions created by an older
         # release. Invalid historical rows without any Gateway keep the prior

--- a/src/backend/apps/lens_bridge/tests/test_chat_lifecycle_queue.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_lifecycle_queue.py
@@ -30,6 +30,7 @@ from apps.protection.models import (
     BackupConfig,
     BackupSourceSnapshot,
     BackupSourceSnapshotDirectory,
+    SnapshotUsageLease,
 )
 from apps.storage.repositories.models import Repository
 from apps.storage.services.internal.repository_location import (
@@ -365,6 +366,40 @@ class CopilotRetryTests(TestCase):
             updated.lifecycle_status, LensSessionLink.LifecycleStatus.PROVISIONING
         )
         self.assertEqual(updated.provision_phase, LensSessionLink.ProvisionPhase.QUEUED)
+        queue_provision.assert_called_once_with(session.id)
+
+    @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
+    def test_failed_session_retry_reacquires_snapshot_usage(self, queue_provision):
+        source_agent = Node.objects.create(
+            organization=self.organization,
+            name="retry-chat-source",
+            role=Node.Role.AGENT,
+        )
+        snapshot = BackupSourceSnapshot.objects.create(
+            organization_id=self.organization.id,
+            snapshot_uid="retry-snapshot",
+            idempotency_key="retry-snapshot",
+            source_type="agent",
+            source_ref_id=source_agent.id,
+            backup_config_id=1,
+            repository_id=1,
+            task_id=1,
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        session = self.create_session(LensSessionLink.LifecycleStatus.FAILED)
+        session.backup_source_snapshot_id = snapshot.id
+        session.save(update_fields=["backup_source_snapshot_id", "updated_at"])
+
+        with self.captureOnCommitCallbacks(execute=True):
+            chat_lifecycle.retry_copilot_chat_provision(session)
+
+        self.assertTrue(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+                consumer_id=str(session.id),
+            ).exists()
+        )
         queue_provision.assert_called_once_with(session.id)
 
     @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")
@@ -936,6 +971,11 @@ class CopilotChatModelBindingTests(TestCase):
             name="private-gateway",
             role=Node.Role.GATEWAY,
         )
+        self.source_agent = Node.objects.create(
+            organization=self.organization,
+            name="chat-model-binding-source",
+            role=Node.Role.AGENT,
+        )
         self.gateway_link = LensGatewayLink.objects.create(
             organization=self.organization,
             gateway=self.gateway,
@@ -960,7 +1000,7 @@ class CopilotChatModelBindingTests(TestCase):
             organization_id=self.organization.id,
             name="Documents",
             source_type="host",
-            source_ref_id=1,
+            source_ref_id=self.source_agent.id,
             repository_id=self.repository.id,
         )
         self.snapshot = BackupSourceSnapshot.objects.create(
@@ -968,7 +1008,7 @@ class CopilotChatModelBindingTests(TestCase):
             snapshot_uid="snapshot-model-binding",
             idempotency_key="snapshot-model-binding",
             source_type="host",
-            source_ref_id=1,
+            source_ref_id=self.source_agent.id,
             backup_config_id=self.config.id,
             repository_id=self.repository.id,
             task_id=1,
@@ -1072,6 +1112,13 @@ class CopilotChatModelBindingTests(TestCase):
         self.assertEqual(str(session.agent_model_ref), str(agent_uuid))
         self.assertIsNone(session.multimodal_model_ref)
         self.assertIsNotNone(session.gateway_queue_entered_at)
+        self.assertTrue(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=self.snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+                consumer_id=str(session.id),
+            ).exists()
+        )
         queue_provision.assert_called_once_with(session.id)
 
     @patch("apps.lens_bridge.services.chat_lifecycle._queue_provision_or_mark_failed")

--- a/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
+++ b/src/backend/apps/lens_bridge/tests/test_chat_teardown.py
@@ -30,6 +30,11 @@ from apps.lens_bridge.tasks.chat_lifecycle import (
     reconcile_lens_resource_teardowns_task,
 )
 from apps.node.models import Node
+from apps.protection.models import BackupSourceSnapshot, SnapshotUsageLease
+from apps.protection.services.snapshot_usage import (
+    acquire_snapshot_usage,
+    reconcile_snapshot_usage_leases,
+)
 
 
 class CopilotChatTeardownTests(TestCase):
@@ -47,6 +52,13 @@ class CopilotChatTeardownTests(TestCase):
             organization=self.platform_org,
             name="platform-gateway",
             role=Node.Role.GATEWAY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        self.source_agent = Node.objects.create(
+            organization=self.tenant,
+            name="chat-teardown-source",
+            role=Node.Role.AGENT,
             status=Node.Status.ACTIVE,
             availability=Node.Availability.ONLINE,
         )
@@ -91,6 +103,183 @@ class CopilotChatTeardownTests(TestCase):
             sl_assistant_uuid=self.knowledge_source.sl_assistant_uuid,
             lifecycle_status=LensSessionLink.LifecycleStatus.READY,
         )
+
+    def test_ready_chat_releases_snapshot_usage_lease(self):
+        snapshot = BackupSourceSnapshot.objects.create(
+            organization_id=self.tenant.id,
+            snapshot_uid="chat-ready-snapshot",
+            idempotency_key="chat-ready-snapshot",
+            source_type="agent",
+            source_ref_id=self.source_agent.id,
+            backup_config_id=1,
+            repository_id=1,
+            task_id=1,
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        claim_token = uuid.uuid4()
+        assistant_uuid = self.knowledge_source.sl_assistant_uuid
+        session_uuid = uuid.uuid4()
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
+        self.session.backup_source_snapshot_id = snapshot.id
+        self.session.provision_claim_token = claim_token
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "backup_source_snapshot_id",
+                "provision_claim_token",
+                "updated_at",
+            ]
+        )
+        acquire_snapshot_usage(
+            organization_id=self.tenant.id,
+            snapshot_id=snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id=self.session.id,
+        )
+
+        chat_lifecycle._complete_copilot_chat_provision(
+            link_id=self.session.id,
+            claim_token=str(claim_token),
+            knowledge_source_id=self.knowledge_source.id,
+            assistant_uuid=assistant_uuid,
+            session_uuid=session_uuid,
+        )
+
+        self.session.refresh_from_db()
+        self.assertEqual(
+            self.session.lifecycle_status,
+            LensSessionLink.LifecycleStatus.READY,
+        )
+        self.assertFalse(
+            SnapshotUsageLease.objects.filter(snapshot_id=snapshot.id).exists()
+        )
+
+    def test_failed_chat_keeps_snapshot_while_cleanup_is_incomplete(self):
+        snapshot = BackupSourceSnapshot.objects.create(
+            organization_id=self.tenant.id,
+            snapshot_uid="chat-cleanup-snapshot",
+            idempotency_key="chat-cleanup-snapshot",
+            source_type="agent",
+            source_ref_id=self.source_agent.id,
+            backup_config_id=1,
+            repository_id=1,
+            task_id=1,
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.FAILED
+        self.session.cleanup_status = LensSessionLink.CleanupStatus.BLOCKED
+        self.session.backup_source_snapshot_id = snapshot.id
+        self.session.provision_next_retry_at = None
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "cleanup_status",
+                "backup_source_snapshot_id",
+                "provision_next_retry_at",
+                "updated_at",
+            ]
+        )
+        acquire_snapshot_usage(
+            organization_id=self.tenant.id,
+            snapshot_id=snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id=self.session.id,
+        )
+
+        reconcile_snapshot_usage_leases()
+
+        self.assertTrue(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+                consumer_id=str(self.session.id),
+            ).exists()
+        )
+
+    def test_legacy_deleting_chat_with_complete_cleanup_releases_lease(self):
+        snapshot = BackupSourceSnapshot.objects.create(
+            organization_id=self.tenant.id,
+            snapshot_uid="legacy-deleting-chat-snapshot",
+            idempotency_key="legacy-deleting-chat-snapshot",
+            source_type="agent",
+            source_ref_id=self.source_agent.id,
+            backup_config_id=1,
+            repository_id=1,
+            task_id=1,
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        self.session.lifecycle_status = LensSessionLink.LifecycleStatus.DELETING
+        self.session.cleanup_status = LensSessionLink.CleanupStatus.COMPLETE
+        self.session.backup_source_snapshot_id = snapshot.id
+        self.session.save(
+            update_fields=[
+                "lifecycle_status",
+                "cleanup_status",
+                "backup_source_snapshot_id",
+                "updated_at",
+            ]
+        )
+        acquire_snapshot_usage(
+            organization_id=self.tenant.id,
+            snapshot_id=snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id=self.session.id,
+        )
+
+        reconcile_snapshot_usage_leases()
+
+        self.assertFalse(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+                consumer_id=str(self.session.id),
+            ).exists()
+        )
+
+    def test_snapshot_usage_reconciler_rotates_past_retained_lease(self):
+        retained_snapshot = BackupSourceSnapshot.objects.create(
+            organization_id=self.tenant.id,
+            snapshot_uid="retained-reconcile-snapshot",
+            idempotency_key="retained-reconcile-snapshot",
+            source_type="agent",
+            source_ref_id=self.source_agent.id,
+            backup_config_id=1,
+            repository_id=1,
+            task_id=1,
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        releasable_snapshot = BackupSourceSnapshot.objects.create(
+            organization_id=self.tenant.id,
+            snapshot_uid="releasable-reconcile-snapshot",
+            idempotency_key="releasable-reconcile-snapshot",
+            source_type="agent",
+            source_ref_id=self.source_agent.id,
+            backup_config_id=1,
+            repository_id=1,
+            task_id=1,
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        retained = SnapshotUsageLease.objects.create(
+            organization_id=self.tenant.id,
+            snapshot_id=retained_snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id="unclassified-safe-retention",
+        )
+        releasable = SnapshotUsageLease.objects.create(
+            organization_id=self.tenant.id,
+            snapshot_id=releasable_snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id=str(self.session.id),
+        )
+
+        first = reconcile_snapshot_usage_leases(limit=1)
+        retained.refresh_from_db()
+        second = reconcile_snapshot_usage_leases(limit=1)
+
+        self.assertEqual(first, {"checked": 1, "released": 0, "retained": 1})
+        self.assertIsNotNone(retained.last_reconciled_at)
+        self.assertEqual(second, {"checked": 1, "released": 1, "retained": 0})
+        self.assertFalse(SnapshotUsageLease.objects.filter(pk=releasable.id).exists())
 
     @staticmethod
     def _not_found() -> sl_client.LensBridgeError:
@@ -575,15 +764,34 @@ class CopilotChatTeardownTests(TestCase):
         wake_gateway_queue,
         queue_teardown,
     ):
+        snapshot = BackupSourceSnapshot.objects.create(
+            organization_id=self.tenant.id,
+            snapshot_uid="failed-provision-snapshot",
+            idempotency_key="failed-provision-snapshot",
+            source_type="agent",
+            source_ref_id=self.source_agent.id,
+            backup_config_id=1,
+            repository_id=1,
+            task_id=1,
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
         claim_token = uuid.uuid4()
         self.session.lifecycle_status = LensSessionLink.LifecycleStatus.PROVISIONING
         self.session.provision_claim_token = claim_token
+        self.session.backup_source_snapshot_id = snapshot.id
         self.session.save(
             update_fields=[
                 "lifecycle_status",
                 "provision_claim_token",
+                "backup_source_snapshot_id",
                 "updated_at",
             ]
+        )
+        acquire_snapshot_usage(
+            organization_id=self.tenant.id,
+            snapshot_id=snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id=self.session.id,
         )
 
         with self.captureOnCommitCallbacks(execute=True):
@@ -610,6 +818,13 @@ class CopilotChatTeardownTests(TestCase):
         self.assertEqual(
             self.session.cleanup_status,
             LensSessionLink.CleanupStatus.PENDING,
+        )
+        self.assertTrue(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+                consumer_id=str(self.session.id),
+            ).exists()
         )
         self.assertEqual(self.session.status, LensSessionLink.Status.ACTIVE)
         queue_teardown.assert_called_once_with(self.session.id)

--- a/src/backend/apps/node/services/internal/node_lifecycle.py
+++ b/src/backend/apps/node/services/internal/node_lifecycle.py
@@ -1446,6 +1446,20 @@ def _start_node_remove_locked(
                 code="source_operation_in_progress",
             ) from exc
 
+        from apps.protection.models import SnapshotUsageLease
+
+        snapshot_usage_active = SnapshotUsageLease.objects.filter(
+            organization_id=org.id,
+            snapshot__organization_id=org.id,
+            snapshot__source_type__in={"agent", "host"},
+            snapshot__source_ref_id=node.id,
+        ).exists()
+        if snapshot_usage_active:
+            raise NodeLifecycleError(
+                "A backup snapshot is currently in use by a Restore or Chat preparation.",
+                code="snapshot_in_use",
+            )
+
     active = _active_lifecycle_task(org=org, node=node)
     if active is not None:
         raise NodeLifecycleError(

--- a/src/backend/apps/protection/api/views/backup_source_snapshot.py
+++ b/src/backend/apps/protection/api/views/backup_source_snapshot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils.dateparse import parse_datetime
 from rest_framework import mixins, status, viewsets
 from rest_framework.exceptions import NotFound, ValidationError
@@ -217,7 +218,11 @@ class BackupSourceSnapshotViewSet(
 
     def destroy(self, request, *args, **kwargs):
         snapshot = self.get_object()
-        task = create_and_queue_snapshot_delete_task(source_snapshot=snapshot)
+        try:
+            task = create_and_queue_snapshot_delete_task(source_snapshot=snapshot)
+        except DjangoValidationError as exc:
+            detail = exc.message_dict if hasattr(exc, "message_dict") else exc.messages
+            raise ValidationError(detail=detail) from exc
         return Response(
             {
                 "deleted": False,

--- a/src/backend/apps/protection/management/commands/repair_snapshot_delete_state.py
+++ b/src/backend/apps/protection/management/commands/repair_snapshot_delete_state.py
@@ -15,6 +15,7 @@ from apps.protection.services.snapshot_delete import (
     create_and_queue_snapshot_delete_task,
     fail_snapshot_delete_task,
 )
+from apps.protection.services.snapshot_usage import snapshot_is_protected
 from apps.task.models import Task
 from apps.task.services.interface import complete_task
 
@@ -51,6 +52,13 @@ class Command(BaseCommand):
         delete_failed = 0
         unchanged = 0
         for snapshot in snapshots.order_by("id").iterator():
+            if snapshot_is_protected(snapshot_id=snapshot.id):
+                unchanged += 1
+                self.stdout.write(
+                    f"snapshot={snapshot.id} task=unknown current={snapshot.status} "
+                    "action=unchanged reason=snapshot_in_use"
+                )
+                continue
             task = _latest_delete_task(
                 organization_id=snapshot.organization_id,
                 source_snapshot_id=snapshot.id,
@@ -121,8 +129,14 @@ class Command(BaseCommand):
                 continue
 
             if can_finalize:
-                self._finalize_snapshot(snapshot=snapshot, task=task, result=result)
-                reconciled += 1
+                if self._finalize_snapshot(
+                    snapshot=snapshot,
+                    task=task,
+                    result=result,
+                ):
+                    reconciled += 1
+                else:
+                    unchanged += 1
                 continue
 
             self._mark_failed(snapshot=snapshot, task=task, result=result)
@@ -142,17 +156,26 @@ class Command(BaseCommand):
         )
 
     @staticmethod
-    def _finalize_snapshot(*, snapshot: BackupSourceSnapshot, task: Task, result: dict) -> None:
+    def _finalize_snapshot(
+        *, snapshot: BackupSourceSnapshot, task: Task, result: dict
+    ) -> bool:
         now = timezone.now()
         with transaction.atomic():
-            BackupSourceSnapshotDirectory.objects.filter(source_snapshot=snapshot).exclude(
+            locked_snapshot = BackupSourceSnapshot.objects.select_for_update().get(
+                pk=snapshot.pk
+            )
+            if snapshot_is_protected(snapshot_id=locked_snapshot.id):
+                return False
+            BackupSourceSnapshotDirectory.objects.filter(
+                source_snapshot=locked_snapshot
+            ).exclude(
                 status=BackupSourceSnapshotDirectory.Status.DELETED
             ).update(status=BackupSourceSnapshotDirectory.Status.DELETED, updated_at=now)
-            snapshot.status = BackupSourceSnapshot.Status.DELETED
-            snapshot.deleted_at = now
-            snapshot.error_code = ""
-            snapshot.error_message = ""
-            snapshot.save(
+            locked_snapshot.status = BackupSourceSnapshot.Status.DELETED
+            locked_snapshot.deleted_at = now
+            locked_snapshot.error_code = ""
+            locked_snapshot.error_message = ""
+            locked_snapshot.save(
                 update_fields=["status", "deleted_at", "error_code", "error_message", "updated_at"]
             )
             if task.status not in {
@@ -168,6 +191,7 @@ class Command(BaseCommand):
                     progress=100,
                     result_payload=result,
                 )
+        return True
 
     @staticmethod
     def _mark_failed(*, snapshot: BackupSourceSnapshot, task: Task, result: dict) -> None:

--- a/src/backend/apps/protection/migrations/0024_snapshot_usage_lease.py
+++ b/src/backend/apps/protection/migrations/0024_snapshot_usage_lease.py
@@ -1,0 +1,61 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("protection", "0023_backup_config_create_request"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SnapshotUsageLease",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("organization_id", models.BigIntegerField(db_index=True)),
+                (
+                    "snapshot",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="usage_leases",
+                        to="protection.backupsourcesnapshot",
+                    ),
+                ),
+                (
+                    "consumer_type",
+                    models.CharField(
+                        choices=[
+                            ("restore", "Restore"),
+                            ("chat", "Chat preparation"),
+                        ],
+                        max_length=16,
+                    ),
+                ),
+                ("consumer_id", models.CharField(max_length=128)),
+                ("created_at", models.DateTimeField(auto_now_add=True, db_index=True)),
+            ],
+            options={
+                "db_table": "protection_snapshot_usage_lease",
+                "indexes": [
+                    models.Index(
+                        fields=["organization_id", "snapshot_id"],
+                        name="prot_snap_usage_org_snap_idx",
+                    ),
+                ],
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=["snapshot_id", "consumer_type", "consumer_id"],
+                        name="uniq_prot_snap_usage_consumer",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/src/backend/apps/protection/migrations/0025_backfill_snapshot_usage_leases.py
+++ b/src/backend/apps/protection/migrations/0025_backfill_snapshot_usage_leases.py
@@ -1,0 +1,99 @@
+from django.db import migrations
+from django.db.models import Q
+
+
+def backfill_snapshot_usage_leases(apps, schema_editor):
+    lease_model = apps.get_model("protection", "SnapshotUsageLease")
+    snapshot_model = apps.get_model("protection", "BackupSourceSnapshot")
+    restore_model = apps.get_model("restore", "RestoreRecord")
+    task_model = apps.get_model("task", "Task")
+    session_model = apps.get_model("lens_bridge", "LensSessionLink")
+
+    active_task_statuses = {"pending", "waiting", "blocked", "running"}
+    active_restore_task_ids = set(
+        task_model.objects.filter(
+            task_type__in={"restore", "insight_workspace_restore"},
+            status__in=active_task_statuses,
+        ).values_list("id", flat=True)
+    )
+    restore_rows = list(
+        restore_model.objects.filter(
+            task_id__in=active_restore_task_ids,
+            source_snapshot_id__isnull=False,
+        ).values("id", "organization_id", "source_snapshot_id")
+    )
+    active_session_rows = list(
+        session_model.objects.filter(
+            backup_source_snapshot_id__isnull=False,
+        )
+        .filter(
+            Q(lifecycle_status__in={"provisioning", "deleting"})
+            | Q(
+                lifecycle_status="failed",
+                cleanup_status__in={"pending", "running", "blocked"},
+            )
+        )
+        .values("id", "organization_id", "backup_source_snapshot_id")
+    )
+    referenced_snapshot_ids = {
+        row["source_snapshot_id"] for row in restore_rows
+    } | {row["backup_source_snapshot_id"] for row in active_session_rows}
+    # Backfill every snapshot that has not reached the completed deleted state.
+    # A legacy active Chat/Restore may already have driven the snapshot into an
+    # intermediate deleting/failed state; omitting that lease would let an old
+    # delete task race the still-running consumer during migration.
+    valid_snapshot_keys = set(
+        snapshot_model.objects.filter(
+            id__in=referenced_snapshot_ids,
+            deleted_at__isnull=True,
+        )
+        .exclude(status="deleted")
+        .values_list("organization_id", "id")
+    )
+    lease_rows = [
+        lease_model(
+            organization_id=row["organization_id"],
+            snapshot_id=row["source_snapshot_id"],
+            consumer_type="restore",
+            consumer_id=str(row["id"]),
+        )
+        for row in restore_rows
+        if (
+            row["organization_id"],
+            row["source_snapshot_id"],
+        )
+        in valid_snapshot_keys
+    ]
+    if lease_rows:
+        lease_model.objects.bulk_create(
+            lease_rows,
+            ignore_conflicts=True,
+        )
+
+    session_leases = [
+        lease_model(
+            organization_id=row["organization_id"],
+            snapshot_id=row["backup_source_snapshot_id"],
+            consumer_type="chat",
+            consumer_id=str(row["id"]),
+        )
+        for row in active_session_rows
+        if (
+            row["organization_id"],
+            row["backup_source_snapshot_id"],
+        )
+        in valid_snapshot_keys
+    ]
+    if session_leases:
+        lease_model.objects.bulk_create(session_leases, ignore_conflicts=True)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("protection", "0024_snapshot_usage_lease"),
+        ("restore", "0008_user_restore_idempotency"),
+        ("task", "0015_backup_config_provision_task_type"),
+        ("lens_bridge", "0040_session_analysis_type"),
+    ]
+
+    operations = [migrations.RunPython(backfill_snapshot_usage_leases, migrations.RunPython.noop)]

--- a/src/backend/apps/protection/migrations/0026_snapshot_usage_reconcile_cursor.py
+++ b/src/backend/apps/protection/migrations/0026_snapshot_usage_reconcile_cursor.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("protection", "0025_backfill_snapshot_usage_leases"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="snapshotusagelease",
+            name="last_reconciled_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+    ]

--- a/src/backend/apps/protection/models/__init__.py
+++ b/src/backend/apps/protection/models/__init__.py
@@ -10,6 +10,7 @@ from apps.protection.models.backup_source_snapshot import (
 from apps.protection.models.backup_policy import BackupPolicy
 from apps.protection.models.file_filter_rule import FileFilterRule
 from apps.protection.models.snapshot_download import SnapshotDownloadArtifact
+from apps.protection.models.snapshot_usage import SnapshotUsageLease
 
 __all__ = [
     "BackupConfig",
@@ -20,4 +21,5 @@ __all__ = [
     "BackupPolicy",
     "FileFilterRule",
     "SnapshotDownloadArtifact",
+    "SnapshotUsageLease",
 ]

--- a/src/backend/apps/protection/models/snapshot_usage.py
+++ b/src/backend/apps/protection/models/snapshot_usage.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from django.db import models
+
+
+class SnapshotUsageLease(models.Model):
+    """Durable, lightweight protection for a snapshot currently in use."""
+
+    class ConsumerType(models.TextChoices):
+        RESTORE = "restore", "Restore"
+        CHAT = "chat", "Chat preparation"
+
+    organization_id = models.BigIntegerField(db_index=True)
+    snapshot = models.ForeignKey(
+        "protection.BackupSourceSnapshot",
+        on_delete=models.PROTECT,
+        related_name="usage_leases",
+    )
+    consumer_type = models.CharField(max_length=16, choices=ConsumerType.choices)
+    consumer_id = models.CharField(max_length=128)
+    created_at = models.DateTimeField(auto_now_add=True, db_index=True)
+    last_reconciled_at = models.DateTimeField(null=True, blank=True, db_index=True)
+
+    class Meta:
+        db_table = "protection_snapshot_usage_lease"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["snapshot_id", "consumer_type", "consumer_id"],
+                name="uniq_prot_snap_usage_consumer",
+            ),
+        ]
+        indexes = [
+            models.Index(
+                fields=["organization_id", "snapshot_id"],
+                name="prot_snap_usage_org_snap_idx",
+            ),
+        ]

--- a/src/backend/apps/protection/services/backup_config.py
+++ b/src/backend/apps/protection/services/backup_config.py
@@ -26,10 +26,12 @@ from apps.protection.models import (
     BackupPolicy,
     BackupSourceSnapshot,
     FileFilterRule,
+    SnapshotUsageLease,
 )
 from apps.protection.services.repository_compatibility import (
     validate_backup_repository_compatible,
 )
+from apps.protection.services.snapshot_usage import SnapshotUsageConflict
 from apps.restore.services.interface import create_restore_plan
 from apps.source.constants import ResourceType
 from apps.source.models import SourceResource
@@ -1655,6 +1657,9 @@ def purge_backup_config_data_for_source(
 ) -> dict[str, int]:
     """Internal source cleanup path for removing backup artifacts tied to a source."""
     from apps.restore.models import RestorePlan
+    from apps.source.services.internal.source_operation_fence import (
+        lock_source_identity,
+    )
 
     configs = list(
         BackupConfig.objects.filter(
@@ -1672,10 +1677,44 @@ def purge_backup_config_data_for_source(
         }
     repository_ids = sorted({int(row[1]) for row in configs})
 
-    snapshots_removed = BackupSourceSnapshot.objects.filter(
-        organization_id=organization_id,
-        backup_config_id__in=config_ids,
-    ).delete()[0]
+    # This helper is also used by Agent uninstall and pipeline rollback, which
+    # historically deleted snapshot rows without going through the normal
+    # snapshot-delete service. Lock the source and snapshots together so an
+    # active Restore/Chat lease is observed before deletion and a concurrent
+    # lease acquisition cannot slip between the check and the delete.
+    with transaction.atomic():
+        lock_source_identity(
+            organization_id=organization_id,
+            source_type=source_type,
+            source_ref_id=source_ref_id,
+        )
+        snapshots = list(
+            BackupSourceSnapshot.objects.select_for_update().filter(
+                organization_id=organization_id,
+                backup_config_id__in=config_ids,
+            )
+        )
+        protected_snapshot_ids = set(
+            SnapshotUsageLease.objects.filter(
+                organization_id=organization_id,
+                snapshot_id__in=[snapshot.id for snapshot in snapshots],
+            ).values_list("snapshot_id", flat=True)
+        )
+        if protected_snapshot_ids:
+            raise SnapshotUsageConflict(
+                {
+                    "source_ref_id": (
+                        "Backup source snapshots are currently in use by a "
+                        "Restore or Chat preparation."
+                    ),
+                    "snapshot_ids": sorted(protected_snapshot_ids),
+                }
+            )
+        snapshots_removed = 0
+        if snapshots:
+            snapshots_removed = BackupSourceSnapshot.objects.filter(
+                id__in=[snapshot.id for snapshot in snapshots],
+            ).delete()[0]
     restore_plans_removed = RestorePlan.objects.filter(
         organization_id=organization_id,
         backup_config_id__in=config_ids,

--- a/src/backend/apps/protection/services/backup_config_reset.py
+++ b/src/backend/apps/protection/services/backup_config_reset.py
@@ -27,6 +27,10 @@ from apps.protection.services.snapshot_delete_execution import (
     run_snapshot_delete,
     snapshot_delete_agent_work_active,
 )
+from apps.protection.services.snapshot_usage import (
+    SnapshotUsageConflict,
+    protected_snapshot_ids,
+)
 from apps.storage.repositories.models import Repository
 from apps.source.constants import PipelineStep
 from apps.source.services.internal.selectable_ids import parse_selectable_id
@@ -208,7 +212,22 @@ def ensure_backup_config_reset_task(
     if not configs:
         return None, False
     config_ids = [config.id for config in configs]
-    snapshots = _snapshots_for_configs(organization_id=organization_id, config_ids=config_ids)
+    snapshots = list(
+        BackupSourceSnapshot.objects.select_for_update()
+        .filter(
+            organization_id=organization_id,
+            backup_config_id__in=config_ids,
+        )
+        .order_by("id")
+    )
+    if protected_snapshot_ids(snapshot.id for snapshot in snapshots):
+        raise SnapshotUsageConflict(
+            {
+                "source_snapshot_id": (
+                    "A snapshot is currently in use by a restore or Chat preparation."
+                )
+            }
+        )
     repository_ids = sorted({int(config.repository_id) for config in configs if int(config.repository_id or 0) > 0})
     payload = {
         "source_type": source_type,
@@ -445,6 +464,30 @@ def _run_backup_config_reset_task_locked(
     config_ids = [int(value) for value in payload.get("backup_config_ids") or [] if int(value or 0) > 0]
 
     try:
+        with transaction.atomic():
+            snapshots = list(
+                BackupSourceSnapshot.objects.select_for_update()
+                .filter(
+                    organization_id=organization_id,
+                    backup_config_id__in=config_ids,
+                )
+                .order_by("id")
+            )
+            if protected_snapshot_ids(snapshot.id for snapshot in snapshots):
+                raise SnapshotUsageConflict(
+                    {
+                        "source_snapshot_id": (
+                            "A snapshot is currently in use by a restore or Chat preparation."
+                        )
+                    }
+                )
+            BackupConfig.objects.filter(
+                organization_id=organization_id,
+                id__in=config_ids,
+            ).update(
+                status=BackupConfig.Status.RESETTING,
+                reset_task_uuid=task.task_uuid,
+            )
         _set_step_status(
             task=task,
             step_name="prepare_reset",
@@ -556,6 +599,17 @@ def _run_backup_config_reset_task_locked(
             result_payload=result,
         )
         return result
+    except SnapshotUsageConflict as exc:
+        _defer_backup_config_reset_for_remote_work(
+            task=task,
+            message=str(exc),
+        )
+        return {
+            "source_type": source_type,
+            "source_ref_id": source_ref_id,
+            "status": "waiting",
+            "reason": "snapshot_in_use",
+        }
     except (AgentSnapshotDeletePending, ControllerSnapshotDeleteBusy) as exc:
         _defer_backup_config_reset_for_remote_work(
             task=task,

--- a/src/backend/apps/protection/services/policy_execution.py
+++ b/src/backend/apps/protection/services/policy_execution.py
@@ -11,6 +11,11 @@ from django.utils import timezone
 from apps.protection.models import BackupConfig, BackupPolicy, BackupSourceSnapshot
 from apps.protection.services.backup_task import start_backup_tasks
 from apps.protection.services.snapshot_delete import create_and_queue_snapshot_delete_task
+from apps.protection.services.snapshot_usage import (
+    SnapshotUsageConflict,
+    protected_snapshot_ids,
+    reconcile_snapshot_usage_leases,
+)
 from apps.task.models import Task
 
 
@@ -284,6 +289,7 @@ def _bucket_key(snapshot: BackupSourceSnapshot, unit: str):
 def _apply_bucket_retention(
     *,
     keep_ids: set[int],
+    protected_ids: set[int],
     snapshots: list[BackupSourceSnapshot],
     now,
     enabled: bool,
@@ -296,6 +302,8 @@ def _apply_bucket_retention(
     cutoff = now - delta
     seen: set[str] = set()
     for snapshot in snapshots:
+        if int(snapshot.id) in protected_ids:
+            continue
         if _snapshot_time(snapshot) < cutoff:
             continue
         key = _bucket_key(snapshot, unit)
@@ -330,9 +338,20 @@ def retention_delete_candidates_for_config(
     if len(snapshots) <= 1:
         return []
     current = timezone.localtime(now or timezone.now())
-    keep_ids = {int(snapshot.id) for snapshot in snapshots[: max(1, int(retention.get("recent_points") or 1))]}
+    protected_ids = protected_snapshot_ids(snapshot.id for snapshot in snapshots)
+    recent_points = max(1, int(retention.get("recent_points") or 1))
+    # A temporary usage lease is a safety fence, not a retention point. Keep
+    # the configured number of ordinary recovery points in addition to every
+    # snapshot currently required by Restore or Chat preparation.
+    unprotected_recent_ids = [
+        int(snapshot.id)
+        for snapshot in snapshots
+        if int(snapshot.id) not in protected_ids
+    ][:recent_points]
+    keep_ids = protected_ids | set(unprotected_recent_ids)
     _apply_bucket_retention(
         keep_ids=keep_ids,
+        protected_ids=protected_ids,
         snapshots=snapshots,
         now=current,
         enabled=bool(retention.get("hourly_enabled", False)),
@@ -342,6 +361,7 @@ def retention_delete_candidates_for_config(
     )
     _apply_bucket_retention(
         keep_ids=keep_ids,
+        protected_ids=protected_ids,
         snapshots=snapshots,
         now=current,
         enabled=bool(retention.get("daily_enabled", False)),
@@ -351,6 +371,7 @@ def retention_delete_candidates_for_config(
     )
     _apply_bucket_retention(
         keep_ids=keep_ids,
+        protected_ids=protected_ids,
         snapshots=snapshots,
         now=current,
         enabled=bool(retention.get("weekly_enabled", False)),
@@ -360,6 +381,7 @@ def retention_delete_candidates_for_config(
     )
     _apply_bucket_retention(
         keep_ids=keep_ids,
+        protected_ids=protected_ids,
         snapshots=snapshots,
         now=current,
         enabled=bool(retention.get("monthly_enabled", False)),
@@ -369,6 +391,7 @@ def retention_delete_candidates_for_config(
     )
     _apply_bucket_retention(
         keep_ids=keep_ids,
+        protected_ids=protected_ids,
         snapshots=snapshots,
         now=current,
         enabled=bool(retention.get("annual_enabled", False)),
@@ -395,6 +418,7 @@ def failed_snapshot_delete_candidates_for_config(
             backup_config_id=config.id,
             deleted_at__isnull=True,
             status=BackupSourceSnapshot.Status.FAILED,
+            usage_leases__isnull=True,
         ).order_by("finished_at", "created_at", "id")
     )
 
@@ -407,11 +431,15 @@ def apply_retention_policies(*, now=None, limit: int = 100) -> dict[str, int]:
             config=config,
             policy=policy,
         )[: max(1, int(limit))]:
-            with transaction.atomic():
-                task = create_and_queue_snapshot_delete_task(
-                    source_snapshot=snapshot,
-                    trigger_type=Task.TriggerType.SYSTEM,
-                )
+            try:
+                with transaction.atomic():
+                    task = create_and_queue_snapshot_delete_task(
+                        source_snapshot=snapshot,
+                        trigger_type=Task.TriggerType.SYSTEM,
+                    )
+            except SnapshotUsageConflict:
+                skipped += 1
+                continue
             if task.status in {Task.Status.PENDING, Task.Status.RUNNING}:
                 created += 1
             else:
@@ -421,11 +449,15 @@ def apply_retention_policies(*, now=None, limit: int = 100) -> dict[str, int]:
             policy=policy,
             now=now,
         )[: max(1, int(limit))]:
-            with transaction.atomic():
-                task = create_and_queue_snapshot_delete_task(
-                    source_snapshot=snapshot,
-                    trigger_type=Task.TriggerType.SYSTEM,
-                )
+            try:
+                with transaction.atomic():
+                    task = create_and_queue_snapshot_delete_task(
+                        source_snapshot=snapshot,
+                        trigger_type=Task.TriggerType.SYSTEM,
+                    )
+            except SnapshotUsageConflict:
+                skipped += 1
+                continue
             if task.status in {Task.Status.PENDING, Task.Status.RUNNING}:
                 created += 1
             else:
@@ -434,6 +466,7 @@ def apply_retention_policies(*, now=None, limit: int = 100) -> dict[str, int]:
 
 
 def run_backup_policy_maintenance(*, now=None, retention_limit: int = 100) -> dict[str, int]:
+    reconcile_snapshot_usage_leases(limit=max(100, int(retention_limit) * 5))
     scheduled = schedule_due_backup_tasks(now=now)
     retention = apply_retention_policies(now=now, limit=retention_limit)
     return {

--- a/src/backend/apps/protection/services/snapshot_delete.py
+++ b/src/backend/apps/protection/services/snapshot_delete.py
@@ -28,6 +28,10 @@ from apps.protection.services.snapshot_delete_execution import (
     run_snapshot_delete,
     snapshot_delete_agent_work_active,
 )
+from apps.protection.services.snapshot_usage import (
+    SnapshotUsageConflict,
+    snapshot_is_protected,
+)
 from apps.storage.services.internal.repository_workload import (
     RepositoryWorkload,
     lock_repositories_for_workload,
@@ -141,12 +145,25 @@ def _kopia_snapshot_directories_by_id(rows: list[BackupSourceSnapshotDirectory])
     return directories_by_id
 
 
+@transaction.atomic
 def create_snapshot_delete_task(
     *,
     source_snapshot: BackupSourceSnapshot,
     trigger_type: str = Task.TriggerType.SYSTEM,
     source_unregister_task: Task | None = None,
 ) -> Task:
+    source_snapshot = BackupSourceSnapshot.objects.select_for_update().get(
+        organization_id=source_snapshot.organization_id,
+        id=source_snapshot.id,
+    )
+    if snapshot_is_protected(snapshot_id=source_snapshot.id):
+        raise SnapshotUsageConflict(
+            {
+                "source_snapshot_id": (
+                    "Snapshot is currently in use by a restore or Chat preparation."
+                )
+            }
+        )
     if source_snapshot.status == BackupSourceSnapshot.Status.DELETED:
         raise ValidationError({"source_snapshot_id": "Snapshot is already deleted."})
     active = _active_delete_task(
@@ -234,6 +251,14 @@ def create_and_queue_snapshot_delete_task(
             organization_id=source_snapshot.organization_id,
             id=source_snapshot.id,
         )
+        if snapshot_is_protected(snapshot_id=locked_snapshot.id):
+            raise SnapshotUsageConflict(
+                {
+                    "source_snapshot_id": (
+                        "Snapshot is currently in use by a restore or Chat preparation."
+                    )
+                }
+            )
         active = _active_delete_task(
             organization_id=locked_snapshot.organization_id,
             source_snapshot_id=locked_snapshot.id,
@@ -486,8 +511,20 @@ def run_snapshot_delete_task(
             task_uuid=task_uuid,
             source_snapshot_id=source_snapshot_id,
         )
+    except SnapshotUsageConflict as exc:
+        _defer_snapshot_delete(
+            organization_id=organization_id,
+            task_uuid=task_uuid,
+            message=str(exc),
+        )
+        return {
+            "task_uuid": str(task_uuid),
+            "source_snapshot_id": source_snapshot_id,
+            "status": "waiting",
+            "reason": "snapshot_in_use",
+        }
     except (AgentSnapshotDeletePending, ControllerSnapshotDeleteBusy) as exc:
-        _defer_snapshot_delete_for_remote_work(
+        _defer_snapshot_delete(
             organization_id=organization_id,
             task_uuid=task_uuid,
             message=str(exc),
@@ -533,16 +570,17 @@ def run_snapshot_delete_task(
         cache.delete(lock_key)
 
 
-def _defer_snapshot_delete_for_remote_work(
+def _defer_snapshot_delete(
     *, organization_id: int, task_uuid: str, message: str
 ) -> None:
+    """Return a blocked delete task to pending without recording a failure."""
     with transaction.atomic():
         task = (
             Task.objects.select_for_update()
             .filter(
                 organization_id=organization_id,
                 task_uuid=task_uuid,
-                status=Task.Status.RUNNING,
+                status__in={Task.Status.PENDING, Task.Status.RUNNING},
             )
             .first()
         )
@@ -568,12 +606,22 @@ def _run_snapshot_delete_task_locked(
     task = Task.objects.filter(organization_id=organization_id, task_uuid=task_uuid).first()
     if task is None:
         raise Task.DoesNotExist
-    source_snapshot = BackupSourceSnapshot.objects.filter(
-        organization_id=organization_id,
-        id=source_snapshot_id,
-    ).first()
-    if source_snapshot is None:
-        raise BackupSourceSnapshot.DoesNotExist
+    with transaction.atomic():
+        source_snapshot = (
+            BackupSourceSnapshot.objects.select_for_update()
+            .filter(organization_id=organization_id, id=source_snapshot_id)
+            .first()
+        )
+        if source_snapshot is None:
+            raise BackupSourceSnapshot.DoesNotExist
+        if snapshot_is_protected(snapshot_id=source_snapshot.id):
+            raise SnapshotUsageConflict(
+                {
+                    "source_snapshot_id": (
+                        "Snapshot is currently in use by a restore or Chat preparation."
+                    )
+                }
+            )
     if task.status in _DELETE_TERMINAL:
         return task.result_payload if isinstance(task.result_payload, dict) else {}
     if task.status == Task.Status.PENDING:
@@ -798,10 +846,21 @@ def reconcile_snapshot_delete_tasks(*, now=None, limit: int = 100) -> dict[str, 
             organization_id=task.organization_id,
             source_snapshot_id=snapshot_id,
         ) if snapshot_id else None
-        if snapshot is not None and latest is not None and latest.id == task.id:
-            Task.objects.filter(id=task.id, status=Task.Status.PENDING).update(updated_at=current)
-            queue_snapshot_delete_task(task=task, source_snapshot_id=snapshot_id)
-            requeued_pending += 1
+        if snapshot is None or latest is None or latest.id != task.id:
+            continue
+        if snapshot_is_protected(snapshot_id=snapshot.id):
+            # Rotate safely blocked rows out of this bounded batch so they do
+            # not starve unrelated pending deletes. Once the lease is gone,
+            # the same five-minute recovery window will make the task due.
+            Task.objects.filter(id=task.id, status=Task.Status.PENDING).update(
+                updated_at=current
+            )
+            continue
+        Task.objects.filter(id=task.id, status=Task.Status.PENDING).update(
+            updated_at=current
+        )
+        queue_snapshot_delete_task(task=task, source_snapshot_id=snapshot_id)
+        requeued_pending += 1
 
     stale_running = list(
         Task.objects.filter(
@@ -833,13 +892,18 @@ def reconcile_snapshot_delete_tasks(*, now=None, limit: int = 100) -> dict[str, 
         recovered_running += 1
 
     failed_snapshots = list(
-        BackupSourceSnapshot.objects.filter(status=BackupSourceSnapshot.Status.DELETE_FAILED)
+        BackupSourceSnapshot.objects.filter(
+            status=BackupSourceSnapshot.Status.DELETE_FAILED,
+            usage_leases__isnull=True,
+        )
         .order_by("updated_at", "id")[:limit]
     )
     for snapshot in failed_snapshots:
         with transaction.atomic():
             locked = BackupSourceSnapshot.objects.select_for_update().get(id=snapshot.id)
             if locked.status != BackupSourceSnapshot.Status.DELETE_FAILED:
+                continue
+            if snapshot_is_protected(snapshot_id=locked.id):
                 continue
             task = _latest_delete_task(
                 organization_id=locked.organization_id,

--- a/src/backend/apps/protection/services/snapshot_usage.py
+++ b/src/backend/apps/protection/services/snapshot_usage.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.models import F, Q
+from django.utils import timezone
+
+from apps.protection.models import (
+    BackupConfig,
+    BackupSourceSnapshot,
+    SnapshotUsageLease,
+)
+
+
+class SnapshotUsageConflict(ValidationError):
+    """Raised when a snapshot is already protected or cannot be deleted."""
+
+
+def _consumer_id(value: int | str) -> str:
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError("Snapshot usage consumer ID is required.")
+    return normalized
+
+
+def acquire_snapshot_usage(
+    *,
+    organization_id: int,
+    snapshot_id: int,
+    consumer_type: str,
+    consumer_id: int | str,
+) -> SnapshotUsageLease:
+    """Protect an available snapshot; safe to call repeatedly."""
+    normalized_consumer_type = str(consumer_type).strip()
+    if normalized_consumer_type not in SnapshotUsageLease.ConsumerType.values:
+        raise ValueError(
+            f"Unsupported snapshot usage consumer type: {normalized_consumer_type}"
+        )
+    snapshot_identity = (
+        BackupSourceSnapshot.objects.filter(
+            organization_id=organization_id,
+            pk=int(snapshot_id),
+        )
+        .values("source_type", "source_ref_id")
+        .first()
+    )
+    if snapshot_identity is None:
+        raise ValidationError({"source_snapshot_id": "Snapshot not found."})
+    source_type = str(snapshot_identity["source_type"])
+    if source_type == "host":
+        source_type = "agent"
+    with transaction.atomic():
+        from apps.source.services.internal.source_operation_fence import (
+            active_source_control_task,
+            lock_source_identity,
+        )
+
+        # Match Source Reset/Unregister's source -> snapshot lock order. This
+        # makes the control-task check and lease creation one admission fence:
+        # cleanup cannot start after the check but before the lease commits.
+        lock_source_identity(
+            organization_id=organization_id,
+            source_type=source_type,
+            source_ref_id=int(snapshot_identity["source_ref_id"]),
+        )
+        control_task = active_source_control_task(
+            organization_id=organization_id,
+            source_type=source_type,
+            source_ref_id=int(snapshot_identity["source_ref_id"]),
+        )
+        if control_task is not None:
+            raise SnapshotUsageConflict(
+                {
+                    "source_snapshot_id": (
+                        "The backup source is being reset or deregistered."
+                    ),
+                    "task_uuid": str(control_task.task_uuid),
+                }
+            )
+        if source_type == "agent":
+            from apps.node.models import Node, NodeTask
+
+            node_removal_active = Node.objects.filter(
+                organization_id=organization_id,
+                id=int(snapshot_identity["source_ref_id"]),
+                status__in={Node.Status.REMOVING, Node.Status.CLEANING_UP},
+            ).exists() or NodeTask.objects.filter(
+                organization_id=organization_id,
+                node_id=int(snapshot_identity["source_ref_id"]),
+                kind="agent.uninstall",
+                status__in={NodeTask.Status.PENDING, NodeTask.Status.RUNNING},
+            ).exists()
+            if node_removal_active:
+                raise SnapshotUsageConflict(
+                    {
+                        "source_snapshot_id": (
+                            "The backup source Agent is being removed."
+                        )
+                    }
+                )
+        snapshot = (
+            BackupSourceSnapshot.objects.select_for_update()
+            .filter(organization_id=organization_id, pk=int(snapshot_id))
+            .first()
+        )
+        if snapshot is None:
+            raise ValidationError({"source_snapshot_id": "Snapshot not found."})
+        if snapshot.status not in {
+            BackupSourceSnapshot.Status.AVAILABLE,
+            BackupSourceSnapshot.Status.PARTIAL,
+        }:
+            raise SnapshotUsageConflict(
+                {"source_snapshot_id": "Snapshot is no longer available."}
+            )
+        if BackupConfig.objects.filter(
+            organization_id=organization_id,
+            id=snapshot.backup_config_id,
+            status=BackupConfig.Status.RESETTING,
+        ).exists():
+            raise SnapshotUsageConflict(
+                {"source_snapshot_id": "Snapshot configuration is being reset."}
+            )
+        lease, _ = SnapshotUsageLease.objects.get_or_create(
+            organization_id=organization_id,
+            snapshot_id=int(snapshot_id),
+            consumer_type=normalized_consumer_type,
+            consumer_id=_consumer_id(consumer_id),
+        )
+        return lease
+
+
+def release_snapshot_usage(
+    *,
+    snapshot_id: int,
+    consumer_type: str,
+    consumer_id: int | str,
+) -> int:
+    """Release one usage lease; repeated release is idempotent."""
+    return SnapshotUsageLease.objects.filter(
+        snapshot_id=int(snapshot_id),
+        consumer_type=str(consumer_type),
+        consumer_id=_consumer_id(consumer_id),
+    ).delete()[0]
+
+
+def snapshot_is_protected(*, snapshot_id: int) -> bool:
+    return SnapshotUsageLease.objects.filter(snapshot_id=int(snapshot_id)).exists()
+
+
+def protected_snapshot_ids(snapshot_ids: Iterable[int] | None = None) -> set[int]:
+    queryset = SnapshotUsageLease.objects.all()
+    if snapshot_ids is not None:
+        ids = {int(value) for value in snapshot_ids}
+        if not ids:
+            return set()
+        queryset = queryset.filter(snapshot_id__in=ids)
+    return {int(value) for value in queryset.values_list("snapshot_id", flat=True)}
+
+
+def release_restore_usage(*, restore_record_id: int, snapshot_id: int) -> int:
+    return release_snapshot_usage(
+        snapshot_id=snapshot_id,
+        consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+        consumer_id=restore_record_id,
+    )
+
+
+def release_chat_usage(*, session_link_id: int, snapshot_id: int) -> int:
+    return release_snapshot_usage(
+        snapshot_id=snapshot_id,
+        consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+        consumer_id=session_link_id,
+    )
+
+
+def reconcile_snapshot_usage_leases(*, limit: int = 500) -> dict[str, int]:
+    """Release orphaned or terminal leases after interrupted callbacks."""
+    from apps.lens_bridge.models import LensSessionLink
+    from apps.node.models import NodeTask
+    from apps.restore.models import RestoreRecord
+    from apps.task.models import Task
+
+    released = 0
+    retained = 0
+    retained_lease_ids: list[int] = []
+    leases = list(
+        SnapshotUsageLease.objects.order_by(
+            F("last_reconciled_at").asc(nulls_first=True),
+            "id",
+        )[: max(1, int(limit))]
+    )
+    for lease in leases:
+        try:
+            consumer_pk = int(lease.consumer_id)
+        except (TypeError, ValueError):
+            retained += 1
+            retained_lease_ids.append(lease.id)
+            continue
+        if lease.consumer_type == SnapshotUsageLease.ConsumerType.RESTORE:
+            record = RestoreRecord.objects.filter(pk=consumer_pk).first()
+            if record is None:
+                orphan_remote_work_active = NodeTask.objects.filter(
+                    status__in={NodeTask.Status.PENDING, NodeTask.Status.RUNNING},
+                ).filter(
+                    Q(payload__restore_record_id=consumer_pk)
+                    | Q(payload__restore_record_id=str(consumer_pk))
+                ).exists()
+                if orphan_remote_work_active:
+                    retained += 1
+                    retained_lease_ids.append(lease.id)
+                    continue
+                lease.delete()
+                released += 1
+                continue
+            remote_work_active = NodeTask.objects.filter(
+                Q(organization_id=record.organization_id)
+                | Q(organization_id=record.target_execution_organization_id),
+                correlation_id=str(record.task_uuid),
+                status__in={NodeTask.Status.PENDING, NodeTask.Status.RUNNING},
+            ).exists()
+            if remote_work_active:
+                retained += 1
+                retained_lease_ids.append(lease.id)
+                continue
+            task_status = (
+                Task.objects.filter(pk=record.task_id)
+                .values_list("status", flat=True)
+                .first()
+            )
+            if task_status is None:
+                lease.delete()
+                released += 1
+                continue
+            if task_status not in {
+                Task.Status.SUCCESS,
+                Task.Status.FAILED,
+                Task.Status.CANCELLED,
+                Task.Status.TIMEOUT,
+            }:
+                retained += 1
+                retained_lease_ids.append(lease.id)
+                continue
+            lease.delete()
+            released += 1
+            continue
+
+        if lease.consumer_type == SnapshotUsageLease.ConsumerType.CHAT:
+            with transaction.atomic():
+                session = (
+                    LensSessionLink.all_objects.select_for_update()
+                    .filter(pk=consumer_pk)
+                    .first()
+                )
+                if session is None:
+                    lease.delete()
+                    released += 1
+                    continue
+                if session.lifecycle_status in {
+                    LensSessionLink.LifecycleStatus.READY,
+                    LensSessionLink.LifecycleStatus.DELETED,
+                } or (
+                    session.lifecycle_status == LensSessionLink.LifecycleStatus.DELETING
+                    and session.cleanup_status == LensSessionLink.CleanupStatus.COMPLETE
+                ) or (
+                    session.lifecycle_status == LensSessionLink.LifecycleStatus.FAILED
+                    and session.provision_next_retry_at is None
+                    and session.cleanup_status
+                    in {
+                        LensSessionLink.CleanupStatus.NONE,
+                        LensSessionLink.CleanupStatus.COMPLETE,
+                    }
+                ):
+                    lease.delete()
+                    released += 1
+                    continue
+                retained += 1
+                retained_lease_ids.append(lease.id)
+            continue
+
+        # Unknown legacy consumers remain protected until an operator or a
+        # compatible release can classify them safely.
+        retained += 1
+        retained_lease_ids.append(lease.id)
+    if retained_lease_ids:
+        SnapshotUsageLease.objects.filter(id__in=retained_lease_ids).update(
+            last_reconciled_at=timezone.now()
+        )
+    return {"checked": len(leases), "released": released, "retained": retained}

--- a/src/backend/apps/protection/tests/test_backup_config_api.py
+++ b/src/backend/apps/protection/tests/test_backup_config_api.py
@@ -19,6 +19,7 @@ from apps.protection.models import (
     BackupSourceSnapshot,
     BackupSourceSnapshotDirectory,
     FileFilterRule,
+    SnapshotUsageLease,
 )
 from apps.protection.services import backup_config as backup_config_service
 from apps.protection.services.backup_config_reset import (
@@ -27,6 +28,10 @@ from apps.protection.services.backup_config_reset import (
     run_backup_config_reset_task,
 )
 from apps.protection.services.backup_source_snapshot import create_source_snapshot
+from apps.protection.services.snapshot_usage import (
+    SnapshotUsageConflict,
+    acquire_snapshot_usage,
+)
 from apps.protection.services.repository_policy import (
     sync_backup_config_repository_policy,
 )
@@ -2555,6 +2560,263 @@ class ProtectionBackupConfigApiTests(TestCase):
         self.assertEqual(config.status, BackupConfig.Status.RESETTING)
         self.assertEqual(str(config.reset_task_uuid), str(task.task_uuid))
         delay.assert_not_called()
+
+    def test_reset_backup_config_rejects_snapshot_in_active_use(self):
+        create = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(name="Reset protected config"),
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        config = BackupConfig.objects.get(id=create.data["id"])
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Protected snapshot backup",
+            status=Task.Status.SUCCESS,
+        )
+        snapshot = create_source_snapshot(
+            organization_id=self.org.id,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=config.id,
+            repository_id=self.repository.id,
+            task_id=backup_task.id,
+            task_uuid=backup_task.task_uuid,
+            idempotency_key="reset-protected-source",
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        acquire_snapshot_usage(
+            organization_id=self.org.id,
+            snapshot_id=snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id="active-chat",
+        )
+
+        with self.assertRaises(SnapshotUsageConflict):
+            ensure_backup_config_reset_task(
+                organization_id=self.org.id,
+                source_type="agent",
+                source_ref_id=self.agent.id,
+            )
+
+        config.refresh_from_db()
+        self.assertEqual(config.status, BackupConfig.Status.ACTIVE)
+        self.assertFalse(
+            Task.objects.filter(task_type=Task.Type.BACKUP_CONFIG_RESET).exists()
+        )
+
+    @mock.patch("apps.protection.services.backup_config_reset.run_agent_task_async")
+    def test_legacy_reset_task_waits_for_snapshot_usage(self, run_agent_task_async):
+        create = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(name="Legacy protected reset"),
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        config = BackupConfig.objects.get(id=create.data["id"])
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Legacy protected snapshot backup",
+            status=Task.Status.SUCCESS,
+        )
+        snapshot = create_source_snapshot(
+            organization_id=self.org.id,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=config.id,
+            repository_id=self.repository.id,
+            task_id=backup_task.id,
+            task_uuid=backup_task.task_uuid,
+            idempotency_key="legacy-reset-protected-source",
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        reset_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP_CONFIG_RESET,
+            display_name="Legacy reset task",
+            request_payload={
+                "source_type": "agent",
+                "source_ref_id": self.agent.id,
+                "backup_config_ids": [config.id],
+                "repository_ids": [self.repository.id],
+                "source_snapshot_ids": [snapshot.id],
+            },
+        )
+        for index, step_name in enumerate(
+            [
+                "prepare_reset",
+                "delete_kopia_snapshots",
+                "delete_snapshot_records",
+                "delete_restore_plans",
+                "delete_backup_configs",
+                "finalize_reset",
+            ],
+            start=1,
+        ):
+            reset_task.steps.create(step_index=index, step_name=step_name)
+        config.status = BackupConfig.Status.RESETTING
+        config.reset_task_uuid = reset_task.task_uuid
+        config.save(update_fields=["status", "reset_task_uuid", "updated_at"])
+        SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id="legacy-active-chat",
+        )
+
+        result = run_backup_config_reset_task(
+            organization_id=self.org.id,
+            task_uuid=str(reset_task.task_uuid),
+            source_type="agent",
+            source_ref_id=self.agent.id,
+        )
+
+        reset_task.refresh_from_db()
+        self.assertEqual(result["status"], "waiting")
+        self.assertEqual(result["reason"], "snapshot_in_use")
+        self.assertEqual(reset_task.status, Task.Status.PENDING)
+        self.assertTrue(BackupSourceSnapshot.objects.filter(pk=snapshot.id).exists())
+        run_agent_task_async.assert_not_called()
+
+    def test_snapshot_usage_rejects_resetting_configuration(self):
+        create = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(name="Reset acquisition fence"),
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        config = BackupConfig.objects.get(id=create.data["id"])
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Reset acquisition snapshot backup",
+            status=Task.Status.SUCCESS,
+        )
+        snapshot = create_source_snapshot(
+            organization_id=self.org.id,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=config.id,
+            repository_id=self.repository.id,
+            task_id=backup_task.id,
+            task_uuid=backup_task.task_uuid,
+            idempotency_key="reset-acquisition-fence-source",
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        config.status = BackupConfig.Status.RESETTING
+        config.save(update_fields=["status", "updated_at"])
+
+        with self.assertRaises(SnapshotUsageConflict):
+            acquire_snapshot_usage(
+                organization_id=self.org.id,
+                snapshot_id=snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+                consumer_id="new-restore",
+            )
+
+        self.assertFalse(
+            SnapshotUsageLease.objects.filter(snapshot_id=snapshot.id).exists()
+        )
+
+    def test_snapshot_usage_rejects_source_unregister_in_progress(self):
+        create = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(name="Unregister acquisition fence"),
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        config = BackupConfig.objects.get(id=create.data["id"])
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Unregister acquisition snapshot backup",
+            status=Task.Status.SUCCESS,
+        )
+        snapshot = create_source_snapshot(
+            organization_id=self.org.id,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=config.id,
+            repository_id=self.repository.id,
+            task_id=backup_task.id,
+            task_uuid=backup_task.task_uuid,
+            idempotency_key="unregister-acquisition-fence-source",
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        unregister_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.SOURCE_UNREGISTER,
+            display_name="Source unregister in progress",
+            status=Task.Status.RUNNING,
+        )
+        TaskResource.objects.create(
+            task=unregister_task,
+            resource_type=TaskResource.Type.BACKUP_SOURCE,
+            resource_subtype="agent",
+            resource_id=self.agent.id,
+            is_primary=True,
+        )
+
+        with self.assertRaises(SnapshotUsageConflict):
+            acquire_snapshot_usage(
+                organization_id=self.org.id,
+                snapshot_id=snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+                consumer_id="new-chat",
+            )
+
+        self.assertFalse(
+            SnapshotUsageLease.objects.filter(snapshot_id=snapshot.id).exists()
+        )
+
+    def test_source_purge_rejects_snapshot_in_active_use(self):
+        create = self.client.post(
+            "/api/v1/protection/backup-configs/",
+            self._payload(name="Purge protected config"),
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        config = BackupConfig.objects.get(id=create.data["id"])
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Purge protected snapshot backup",
+            status=Task.Status.SUCCESS,
+        )
+        snapshot = create_source_snapshot(
+            organization_id=self.org.id,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=config.id,
+            repository_id=self.repository.id,
+            task_id=backup_task.id,
+            task_uuid=backup_task.task_uuid,
+            idempotency_key="purge-protected-source",
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id="active-chat",
+        )
+
+        with self.assertRaises(SnapshotUsageConflict):
+            backup_config_service.purge_backup_config_data_for_source(
+                organization_id=self.org.id,
+                source_type="agent",
+                source_ref_id=self.agent.id,
+            )
+
+        self.assertTrue(BackupConfig.objects.filter(pk=config.id).exists())
+        self.assertTrue(BackupSourceSnapshot.objects.filter(pk=snapshot.id).exists())
 
     @mock.patch(
         "apps.protection.tasks.backup_config_reset."

--- a/src/backend/apps/protection/tests/test_policy_execution.py
+++ b/src/backend/apps/protection/tests/test_policy_execution.py
@@ -9,8 +9,14 @@ from django.utils import timezone
 
 from apps.iam.models import Membership, Organization
 from apps.node.models import Node
-from apps.protection.models import BackupConfig, BackupPolicy, BackupSourceSnapshot
+from apps.protection.models import (
+    BackupConfig,
+    BackupPolicy,
+    BackupSourceSnapshot,
+    SnapshotUsageLease,
+)
 from apps.protection.services.backup_source_snapshot import create_source_snapshot
+from apps.protection.services.snapshot_usage import acquire_snapshot_usage
 from apps.protection.services.policy_execution import (
     _schedule_fire_key,
     apply_retention_policies,
@@ -265,6 +271,77 @@ class PolicyExecutionTests(TestCase):
         self.assertEqual([snapshot.id for snapshot in candidates], [old.id])
         self.assertNotIn(latest.id, [snapshot.id for snapshot in candidates])
 
+    def test_retention_candidates_exclude_protected_snapshot(self):
+        now = timezone.now()
+        old = self._snapshot("protected-old", now - timedelta(days=3))
+        self._snapshot("protected-latest", now - timedelta(hours=1))
+        acquire_snapshot_usage(
+            organization_id=self.org.id,
+            snapshot_id=old.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+            consumer_id=101,
+        )
+
+        candidates = retention_delete_candidates_for_config(
+            config=self.config,
+            policy=self.policy,
+            now=now,
+        )
+
+        self.assertEqual(candidates, [])
+
+    def test_protected_snapshot_does_not_consume_recent_point_limit(self):
+        now = timezone.now()
+        newest = self._snapshot("protected-newest", now - timedelta(hours=1))
+        retained = self._snapshot("protected-retained", now - timedelta(days=2))
+        expired = self._snapshot("protected-expired", now - timedelta(days=3))
+        acquire_snapshot_usage(
+            organization_id=self.org.id,
+            snapshot_id=newest.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id=102,
+        )
+
+        candidates = retention_delete_candidates_for_config(
+            config=self.config,
+            policy=self.policy,
+            now=now,
+        )
+
+        self.assertEqual([snapshot.id for snapshot in candidates], [expired.id])
+        self.assertNotIn(retained.id, [snapshot.id for snapshot in candidates])
+
+    def test_protected_snapshot_does_not_consume_daily_bucket(self):
+        now = timezone.now()
+        self.policy.retention = {
+            "enabled": True,
+            "recent_points": 1,
+            "daily_enabled": True,
+            "daily_days": 7,
+        }
+        self.policy.save(update_fields=["retention", "updated_at"])
+        self._snapshot("daily-newest", now - timedelta(hours=1))
+        protected = self._snapshot("daily-protected", now - timedelta(days=2))
+        retained = self._snapshot(
+            "daily-ordinary",
+            now - timedelta(days=2, hours=1),
+        )
+        acquire_snapshot_usage(
+            organization_id=self.org.id,
+            snapshot_id=protected.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id=103,
+        )
+
+        candidates = retention_delete_candidates_for_config(
+            config=self.config,
+            policy=self.policy,
+            now=now,
+        )
+
+        self.assertNotIn(protected.id, [snapshot.id for snapshot in candidates])
+        self.assertNotIn(retained.id, [snapshot.id for snapshot in candidates])
+
     @patch("apps.protection.services.policy_execution._policy_configs")
     @patch(
         "apps.protection.services.policy_execution.create_and_queue_snapshot_delete_task"
@@ -307,3 +384,25 @@ class PolicyExecutionTests(TestCase):
         self.assertEqual([snapshot.id for snapshot in candidates], [failed.id])
         self.assertNotIn(creating.id, [snapshot.id for snapshot in candidates])
         self.assertNotIn(available.id, [snapshot.id for snapshot in candidates])
+
+    def test_failed_candidates_exclude_protected_snapshot(self):
+        now = timezone.now()
+        protected = self._snapshot("failed-protected", now - timedelta(days=3))
+        protected.status = BackupSourceSnapshot.Status.FAILED
+        protected.save(update_fields=["status", "updated_at"])
+        SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=protected.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id="legacy-active-chat",
+        )
+        deletable = self._snapshot("failed-deletable", now - timedelta(days=2))
+        deletable.status = BackupSourceSnapshot.Status.FAILED
+        deletable.save(update_fields=["status", "updated_at"])
+
+        candidates = failed_snapshot_delete_candidates_for_config(
+            config=self.config,
+            policy=self.policy,
+        )
+
+        self.assertEqual([snapshot.id for snapshot in candidates], [deletable.id])

--- a/src/backend/apps/protection/tests/test_snapshot_delete_task.py
+++ b/src/backend/apps/protection/tests/test_snapshot_delete_task.py
@@ -19,6 +19,7 @@ from apps.protection.models import (
     BackupConfigDirectory,
     BackupSourceSnapshot,
     BackupSourceSnapshotDirectory,
+    SnapshotUsageLease,
 )
 from apps.protection.services.backup_source_snapshot import (
     create_source_snapshot,
@@ -34,6 +35,7 @@ from apps.protection.services.snapshot_delete import (
 from apps.protection.services.snapshot_delete_execution import (
     queue_snapshot_delete_result_followup,
 )
+from apps.protection.services.snapshot_usage import acquire_snapshot_usage
 from apps.source.models import SourceResource
 from apps.storage.repositories.models import Repository
 from apps.storage.services.internal.repository_location import (
@@ -142,6 +144,69 @@ class SnapshotDeleteTaskTests(TestCase):
             kopia_snapshot_id="kopia-b",
             status=BackupSourceSnapshotDirectory.Status.AVAILABLE,
         )
+
+    def test_create_snapshot_delete_task_rejects_protected_snapshot(self):
+        acquire_snapshot_usage(
+            organization_id=self.org.id,
+            snapshot_id=self.snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+            consumer_id=42,
+        )
+
+        with self.assertRaisesMessage(ValidationError, "currently in use"):
+            create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        self.snapshot.refresh_from_db()
+        self.assertEqual(self.snapshot.status, BackupSourceSnapshot.Status.AVAILABLE)
+        self.assertFalse(
+            Task.objects.filter(task_type=Task.Type.SNAPSHOT_DELETE).exists()
+        )
+
+    @patch("apps.protection.services.snapshot_delete.run_agent_task_async")
+    def test_pending_delete_waits_when_upgrade_backfills_usage_lease(
+        self, run_agent_task_async
+    ):
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+        SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=self.snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id="legacy-active-chat",
+        )
+
+        result = run_snapshot_delete_task(
+            organization_id=self.org.id,
+            task_uuid=str(task.task_uuid),
+            source_snapshot_id=self.snapshot.id,
+        )
+
+        task.refresh_from_db()
+        self.snapshot.refresh_from_db()
+        self.assertEqual(result["status"], "waiting")
+        self.assertEqual(result["reason"], "snapshot_in_use")
+        self.assertEqual(task.status, Task.Status.PENDING)
+        self.assertEqual(self.snapshot.status, BackupSourceSnapshot.Status.DELETING)
+        run_agent_task_async.assert_not_called()
+
+    @patch("apps.protection.services.snapshot_delete.queue_snapshot_delete_task")
+    def test_reconcile_does_not_requeue_pending_snapshot_in_use(self, queue_task):
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+        old = timezone.now() - timedelta(minutes=10)
+        Task.objects.filter(id=task.id).update(updated_at=old)
+        SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=self.snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id="legacy-active-chat",
+        )
+
+        result = reconcile_snapshot_delete_tasks(now=timezone.now())
+
+        task.refresh_from_db()
+        self.assertEqual(result["requeued_pending"], 0)
+        self.assertEqual(task.status, Task.Status.PENDING)
+        self.assertGreater(task.updated_at, old)
+        queue_task.assert_not_called()
 
     @patch("apps.protection.services.snapshot_delete.run_agent_task_async")
     def test_run_snapshot_delete_task_marks_logical_snapshot_deleted(
@@ -1128,6 +1193,39 @@ class SnapshotDeleteTaskTests(TestCase):
         )
 
     @patch("apps.protection.services.snapshot_delete.queue_snapshot_delete_task")
+    def test_reconcile_does_not_retry_delete_failed_snapshot_in_use(
+        self, queue_task
+    ):
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+        old = timezone.now() - timedelta(days=1)
+        Task.objects.filter(id=task.id).update(
+            status=Task.Status.FAILED,
+            finished_at=old,
+            updated_at=old,
+        )
+        BackupSourceSnapshot.objects.filter(id=self.snapshot.id).update(
+            status=BackupSourceSnapshot.Status.DELETE_FAILED,
+            updated_at=old,
+        )
+        SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=self.snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+            consumer_id="active-restore",
+        )
+
+        result = reconcile_snapshot_delete_tasks(now=timezone.now())
+
+        task.refresh_from_db()
+        self.snapshot.refresh_from_db()
+        self.assertEqual(result["retried_failed"], 0)
+        self.assertEqual(task.status, Task.Status.FAILED)
+        self.assertEqual(
+            self.snapshot.status, BackupSourceSnapshot.Status.DELETE_FAILED
+        )
+        queue_task.assert_not_called()
+
+    @patch("apps.protection.services.snapshot_delete.queue_snapshot_delete_task")
     def test_reconcile_skips_parent_with_active_agent_delete(self, queue_task):
         task = create_snapshot_delete_task(source_snapshot=self.snapshot)
         old = timezone.now() - timedelta(minutes=10)
@@ -1221,6 +1319,52 @@ class SnapshotDeleteTaskTests(TestCase):
             .exclude(status=BackupSourceSnapshotDirectory.Status.DELETED)
             .exists()
         )
+
+    def test_repair_command_cannot_finalize_snapshot_in_use(self):
+        BackupSourceSnapshotDirectory.objects.filter(
+            source_snapshot=self.snapshot
+        ).update(
+            status=BackupSourceSnapshotDirectory.Status.CANCELLED,
+            kopia_snapshot_id="None",
+        )
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+        SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=self.snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id="legacy-active-chat",
+        )
+        stdout = StringIO()
+
+        call_command("repair_snapshot_delete_state", apply=True, stdout=stdout)
+
+        self.snapshot.refresh_from_db()
+        task.refresh_from_db()
+        self.assertEqual(self.snapshot.status, BackupSourceSnapshot.Status.DELETING)
+        self.assertEqual(task.status, Task.Status.PENDING)
+        self.assertIn("reason=snapshot_in_use", stdout.getvalue())
+
+    @patch(
+        "apps.protection.management.commands.repair_snapshot_delete_state."
+        "snapshot_is_protected",
+        side_effect=[False, True],
+    )
+    def test_repair_command_rechecks_usage_under_snapshot_lock(self, protected):
+        BackupSourceSnapshotDirectory.objects.filter(
+            source_snapshot=self.snapshot
+        ).update(
+            status=BackupSourceSnapshotDirectory.Status.CANCELLED,
+            kopia_snapshot_id="None",
+        )
+        task = create_snapshot_delete_task(source_snapshot=self.snapshot)
+
+        call_command("repair_snapshot_delete_state", apply=True, stdout=StringIO())
+
+        self.snapshot.refresh_from_db()
+        task.refresh_from_db()
+        self.assertEqual(protected.call_count, 2)
+        self.assertEqual(self.snapshot.status, BackupSourceSnapshot.Status.DELETING)
+        self.assertEqual(task.status, Task.Status.PENDING)
 
     @patch("apps.protection.services.snapshot_delete.run_agent_task_async")
     def test_delete_failed_manual_retry_reuses_original_task(

--- a/src/backend/apps/restore/services/interface.py
+++ b/src/backend/apps/restore/services/interface.py
@@ -38,6 +38,7 @@ from apps.protection.services.progress.orchestrated_progress import (
 from apps.protection.services.snapshot_repository_locator import (
     resolve_snapshot_repository_reader,
 )
+from apps.protection.services.snapshot_usage import acquire_snapshot_usage
 from apps.protection.models import (
     BackupConfig,
     BackupConfigDirectory,
@@ -783,6 +784,7 @@ def _idempotent_restore_record(
     return existing
 
 
+@transaction.atomic
 def _create_restore_record(
     *,
     organization_id: int,
@@ -829,6 +831,7 @@ def _create_restore_record(
         raise ValidationError({"target_ref_id": "Restore execution node not found."})
     from apps.source.services.internal.source_operation_fence import (
         assert_source_product_operation_allowed,
+        lock_source_identity,
     )
 
     assert_source_product_operation_allowed(
@@ -836,6 +839,25 @@ def _create_restore_record(
         source_type=source_type,
         source_ref_id=source_ref_id,
     )
+    lock_source_identity(
+        organization_id=organization_id,
+        source_type=source_type,
+        source_ref_id=source_ref_id,
+    )
+    source_snapshot = (
+        BackupSourceSnapshot.objects.select_for_update()
+        .filter(
+            organization_id=organization_id,
+            pk=source_snapshot.id,
+        )
+        .first()
+    )
+    if source_snapshot is None:
+        raise ValidationError({"source_snapshot_id": "Snapshot not found."})
+    if source_snapshot.status not in RESTORABLE_SNAPSHOT_STATUSES:
+        raise ValidationError(
+            {"source_snapshot_id": "Selected source snapshot is not restorable."}
+        )
     directories = _expanded_directories(
         organization_id=organization_id,
         source_snapshot=source_snapshot,
@@ -862,6 +884,16 @@ def _create_restore_record(
     }
     existing = _idempotent_restore_record(**idempotency_lookup)
     if existing is not None:
+        task_status = Task.objects.filter(pk=existing.task_id).values_list(
+            "status", flat=True
+        ).first()
+        if task_status in ACTIVE_RESTORE_TASK_STATUSES:
+            acquire_snapshot_usage(
+                organization_id=organization_id,
+                snapshot_id=source_snapshot.id,
+                consumer_type="restore",
+                consumer_id=existing.id,
+            )
         return existing
     _ensure_no_active_restore_for_source(
         organization_id=organization_id,
@@ -945,6 +977,12 @@ def _create_restore_record(
                 conflict_mode=conflict_mode,
                 request_payload=request_payload,
                 created_by_id=created_by_id,
+            )
+            acquire_snapshot_usage(
+                organization_id=organization_id,
+                snapshot_id=source_snapshot.id,
+                consumer_type="restore",
+                consumer_id=record.id,
             )
     except IntegrityError:
         if not normalized_idempotency_key:

--- a/src/backend/apps/restore/signals.py
+++ b/src/backend/apps/restore/signals.py
@@ -19,6 +19,7 @@ from apps.restore.services.task_classification import normalize_restore_task_typ
 from apps.protection.services.progress.orchestrated_progress import (
     RESTORE_FINALIZE_START,
 )
+from apps.protection.services.snapshot_usage import release_restore_usage
 from apps.storage.repositories.models import Repository
 from apps.task.models import Task, TaskEvent, TaskStep
 from apps.task.services.interface import (
@@ -458,6 +459,10 @@ def _finalize_record_if_done(*, record: RestoreRecord, product_task: Task) -> No
             error_code="RESTORE_FAILED",
             error_message=error_message,
         )
+        release_restore_usage(
+            restore_record_id=record.id,
+            snapshot_id=record.source_snapshot_id,
+        )
         return
     _set_step_status(
         task=product_task,
@@ -486,6 +491,10 @@ def _finalize_record_if_done(*, record: RestoreRecord, product_task: Task) -> No
         status=Task.Status.SUCCESS,
         progress=100,
         result_payload=result_payload,
+    )
+    release_restore_usage(
+        restore_record_id=record.id,
+        snapshot_id=record.source_snapshot_id,
     )
 
 

--- a/src/backend/apps/restore/tests/test_restore_api.py
+++ b/src/backend/apps/restore/tests/test_restore_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -21,7 +22,9 @@ from apps.protection.models import (
     BackupConfigDirectory,
     BackupSourceSnapshot,
     BackupSourceSnapshotDirectory,
+    SnapshotUsageLease,
 )
+from apps.protection.services.snapshot_usage import reconcile_snapshot_usage_leases
 from apps.restore.models import (
     DirectNASMountLease,
     RestorePlan,
@@ -1342,6 +1345,13 @@ class RestoreApiTests(TestCase):
         node_task = NodeTask.objects.get(
             correlation_type="restore.record", correlation_id=str(record.task_uuid)
         )
+        self.assertTrue(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=self.snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+                consumer_id=str(record.id),
+            ).exists()
+        )
         self.assertEqual(node_task.payload["repository"]["type"], Repository.Type.S3)
         self.assertEqual(node_task.payload["target_path"], "/restore/data/data")
         self.assertEqual(node_task.payload["target_path_semantics"], "final")
@@ -2516,6 +2526,13 @@ class RestoreApiTests(TestCase):
         task.refresh_from_db()
         self.assertEqual(item.status, item.Status.SUCCESS)
         self.assertEqual(task.status, Task.Status.SUCCESS)
+        self.assertFalse(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=self.snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+                consumer_id=str(record.id),
+            ).exists()
+        )
         self.assertEqual(task.steps.get(step_name="restore").status, "success")
         completed_event = TaskEvent.objects.get(
             task=task,
@@ -2622,6 +2639,15 @@ class RestoreApiTests(TestCase):
         )
         self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
         record = RestoreRecord.objects.get(id=create.data["restore_record_id"])
+        # This serializer compatibility fixture represents a historical restore
+        # whose active snapshot usage has already ended before retention removes
+        # the snapshot. Active restores are intentionally protected from this
+        # direct deletion by SnapshotUsageLease.
+        SnapshotUsageLease.objects.filter(
+            snapshot_id=record.source_snapshot_id,
+            consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+            consumer_id=str(record.id),
+        ).delete()
         BackupSourceSnapshot.objects.filter(id=record.source_snapshot_id).delete()
 
         detail = self.client.get(
@@ -3155,6 +3181,13 @@ class RestoreApiTests(TestCase):
         self.assertEqual(task.status, Task.Status.FAILED)
         self.assertEqual(task.task_type, Task.Type.RESTORE)
         self.assertEqual(float(task.progress), 37)
+        self.assertFalse(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=self.snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+                consumer_id=str(record.id),
+            ).exists()
+        )
         self.assertIn("repository is not connected", task.error_message)
         self.assertEqual(task.steps.get(step_name="restore").status, "failed")
         self.assertEqual(task.steps.get(step_name="finalize").status, "failed")
@@ -3562,6 +3595,172 @@ class RestoreApiTests(TestCase):
             TaskEvent.objects.filter(
                 task=task,
                 message="Restore finished successfully",
+            ).exists()
+        )
+
+    @patch("apps.restore.services.interface.cancel_agent_task")
+    def test_cancelled_restore_keeps_snapshot_until_agent_work_stops(
+        self, cancel_agent_task
+    ):
+        create = self.client.post(
+            "/api/v1/restore/records/",
+            self._manual_restore_payload(),
+            format="json",
+            **self._headers(),
+        )
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        record = RestoreRecord.objects.get(id=create.data["restore_record_id"])
+        node_task = NodeTask.objects.get(
+            correlation_type="restore.record",
+            correlation_id=str(record.task_uuid),
+        )
+
+        response = self.client.post(
+            f"/api/v1/restore/tasks/{record.task_uuid}/cancel/",
+            {},
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        cancel_agent_task.assert_called()
+        reconcile_snapshot_usage_leases()
+        self.assertTrue(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=self.snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+                consumer_id=str(record.id),
+            ).exists()
+        )
+
+        node_task.status = NodeTask.Status.CANCELED
+        node_task.save(update_fields=["status", "updated_at"])
+        reconcile_snapshot_usage_leases()
+        self.assertFalse(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=self.snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+                consumer_id=str(record.id),
+            ).exists()
+        )
+
+    def test_missing_product_task_lease_waits_for_agent_work_before_reclaim(self):
+        record = RestoreRecord.objects.create(
+            organization_id=self.org.id,
+            requesting_organization_id=self.org.id,
+            target_execution_organization_id=self.org.id,
+            target_execution_node_id=self.target.id,
+            restore_uid="rst-orphaned-task",
+            source_mode=RestoreRecord.SourceMode.MANUAL,
+            task_id=999999,
+            task_uuid=uuid.uuid4(),
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=self.config.id,
+            source_snapshot_id=self.snapshot.id,
+            target_type="agent",
+            target_ref_id=self.target.id,
+            target_path="/restore/orphaned",
+            scope=RestoreRecord.Scope.SNAPSHOT,
+            conflict_mode=RestoreRecord.ConflictMode.SKIP,
+        )
+        SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=self.snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+            consumer_id=str(record.id),
+        )
+        node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.target,
+            kind="restore.run",
+            correlation_type="restore.record",
+            correlation_id=str(record.task_uuid),
+            status=NodeTask.Status.RUNNING,
+            payload={"restore_record_id": record.id},
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+        )
+
+        reconcile_snapshot_usage_leases()
+
+        self.assertTrue(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=self.snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+                consumer_id=str(record.id),
+            ).exists()
+        )
+
+        node_task.status = NodeTask.Status.CANCELED
+        node_task.save(update_fields=["status", "updated_at"])
+        reconcile_snapshot_usage_leases()
+
+        self.assertFalse(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=self.snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+                consumer_id=str(record.id),
+            ).exists()
+        )
+
+    def test_missing_restore_record_lease_waits_for_agent_work_before_reclaim(self):
+        record = RestoreRecord.objects.create(
+            organization_id=self.org.id,
+            requesting_organization_id=self.org.id,
+            target_execution_organization_id=self.org.id,
+            target_execution_node_id=self.target.id,
+            restore_uid="rst-orphaned-record",
+            source_mode=RestoreRecord.SourceMode.MANUAL,
+            task_id=999998,
+            task_uuid=uuid.uuid4(),
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=self.config.id,
+            source_snapshot_id=self.snapshot.id,
+            target_type="agent",
+            target_ref_id=self.target.id,
+            target_path="/restore/orphaned-record",
+            scope=RestoreRecord.Scope.SNAPSHOT,
+            conflict_mode=RestoreRecord.ConflictMode.SKIP,
+        )
+        record_id = record.id
+        SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=self.snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+            consumer_id=str(record_id),
+        )
+        node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.target,
+            kind="restore.run",
+            correlation_type="restore.record",
+            correlation_id=str(record.task_uuid),
+            status=NodeTask.Status.RUNNING,
+            payload={"restore_record_id": record_id},
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(hours=1),
+        )
+        record.delete()
+
+        reconcile_snapshot_usage_leases()
+
+        self.assertTrue(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=self.snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+                consumer_id=str(record_id),
+            ).exists()
+        )
+
+        node_task.status = NodeTask.Status.CANCELED
+        node_task.save(update_fields=["status", "updated_at"])
+        reconcile_snapshot_usage_leases()
+
+        self.assertFalse(
+            SnapshotUsageLease.objects.filter(
+                snapshot_id=self.snapshot.id,
+                consumer_type=SnapshotUsageLease.ConsumerType.RESTORE,
+                consumer_id=str(record_id),
             ).exists()
         )
 

--- a/src/backend/apps/source/services/internal/backup_source_delete.py
+++ b/src/backend/apps/source/services/internal/backup_source_delete.py
@@ -29,12 +29,17 @@ from apps.protection.models import (
     BackupConfig,
     BackupSourceSnapshot,
     BackupSourceSnapshotDirectory,
+    SnapshotUsageLease,
     SnapshotDownloadArtifact,
 )
 from apps.protection.services.snapshot_delete import (
     create_and_queue_snapshot_delete_task,
     create_snapshot_delete_task,
     run_snapshot_delete_task,
+)
+from apps.protection.services.snapshot_usage import (
+    SnapshotUsageConflict,
+    snapshot_is_protected,
 )
 from apps.restore.models import RestorePlan, RestoreRecord
 from apps.source.constants import (
@@ -1497,6 +1502,39 @@ def _cleanup_direct_nas_for_unregister(
 
     for repository_id, config_ids in configs_by_repository.items():
         repository = repositories[repository_id]
+        # Direct NAS cleanup removes an entire physical target before the
+        # per-snapshot cleanup stage runs.  Defer that destructive operation
+        # while any snapshot owned by this source is leased by Restore/Chat;
+        # otherwise the later lease check would be too late.  The parent
+        # unregister task is already durable, so acquire_snapshot_usage also
+        # rejects new leases for this source during the gap between this
+        # check and the child cleanup dispatch.
+        with transaction.atomic():
+            from apps.source.services.internal.source_operation_fence import (
+                lock_source_identity,
+            )
+
+            lock_source_identity(
+                organization_id=org.id,
+                source_type=ctx.source_type,
+                source_ref_id=ctx.source_ref_id,
+            )
+            protected_snapshot_count = SnapshotUsageLease.objects.filter(
+                organization_id=org.id,
+                snapshot__backup_config_id__in=config_ids,
+            ).values("snapshot_id").distinct().count()
+        if protected_snapshot_count:
+            # This is a transient wait, not a cleanup failure.  Do not add it
+            # to the durable warning/failure lists: those lists intentionally
+            # survive retries and would otherwise turn a later successful
+            # cleanup into a permanent partial-success result.
+            return DirectNasCleanupOutcome(
+                cleaned_repository_ids=cleaned_repository_ids,
+                cleanup_tasks=cleanup_tasks,
+                warnings=tuple(warnings),
+                retained_resources=tuple(dict.fromkeys(retained_resources)),
+                waiting=True,
+            )
         target_ids = direct_nas_cleanup_target_ids(
             repository=repository,
             backup_config_ids=config_ids,
@@ -2386,6 +2424,7 @@ def _execute_source_unregister_work(
                     "task_id": unregister_task.id,
                     "task_uuid": str(unregister_task.task_uuid),
                     "status": Task.Status.RUNNING,
+                    "waiting_for": "snapshot_usage_lease_release",
                 }
                 return _save_source_unregister_checkpoint(
                     task=unregister_task,
@@ -3557,6 +3596,14 @@ def _snapshot_delete_for_unregister(
     unregister_task: Task,
 ) -> tuple[bool | None, str | None, dict[str, Any]]:
     """Return terminal cleanup state or asynchronously wait on one child task."""
+    if snapshot_is_protected(snapshot_id=source_snapshot.id):
+        raise SnapshotUsageConflict(
+            {
+                "source_snapshot_id": (
+                    "Snapshot is currently in use by a restore or Chat preparation."
+                )
+            }
+        )
     attempt = int(unregister_task.retry_count or 0)
     task = (
         Task.objects.filter(
@@ -3833,6 +3880,19 @@ def _delete_repository_snapshots(
                     continue
             else:
                 ok, err = _snapshot_delete_strict(source_snapshot=snapshot)
+        except SnapshotUsageConflict as exc:
+            detail = "; ".join(str(message) for message in exc.messages)
+            reasons.append(
+                DeleteReason(
+                    code="snapshot_in_use",
+                    detail=detail or "Snapshot is currently in use.",
+                    source_id=ctx.selectable_id,
+                    source_name=ctx.display_name,
+                    repository_id=int(snapshot.repository_id),
+                    repository_name=repo_name,
+                )
+            )
+            continue
         except Exception as exc:
             logger.exception(
                 "Backup source snapshot cleanup raised "
@@ -4791,7 +4851,34 @@ def reconcile_stuck_source_unregister_tasks(
         ).order_by("updated_at", "id")[: max(1, int(limit))]
     )
     redispatched = 0
+    snapshot_usage_waiting = 0
     for row in stuck:
+        checkpoint = (
+            row.result_payload if isinstance(row.result_payload, dict) else {}
+        )
+        request_payload = (
+            row.request_payload if isinstance(row.request_payload, dict) else {}
+        )
+        cleanup_plan = request_payload.get("cleanup_plan")
+        planned_snapshot_ids = (
+            _normalize_pending_snapshot_ids(cleanup_plan.get("snapshot_ids"))
+            if checkpoint.get("waiting_for") == "snapshot_usage_lease_release"
+            and isinstance(cleanup_plan, dict)
+            else []
+        )
+        if planned_snapshot_ids and SnapshotUsageLease.objects.filter(
+            organization_id=row.organization_id,
+            snapshot_id__in=planned_snapshot_ids,
+        ).exists():
+            # Rotate this durable wait out of the bounded stale batch without
+            # repeatedly executing the same physical-cleanup preflight. The
+            # next reconciliation after the final lease is released resumes
+            # the existing unregister task.
+            Task.objects.filter(pk=row.pk, status=Task.Status.RUNNING).update(
+                updated_at=timezone.now()
+            )
+            snapshot_usage_waiting += 1
+            continue
         execute_source_unregister_task.delay(task_id=int(row.id))
         redispatched += 1
         logger.warning(
@@ -4803,6 +4890,7 @@ def reconcile_stuck_source_unregister_tasks(
     return {
         "scanned": len(stuck),
         "redispatched": redispatched,
+        "snapshot_usage_waiting": snapshot_usage_waiting,
         "deferred_scanned": len(deferred_ids),
         "deferred_ended": deferred_ended,
     }

--- a/src/backend/apps/source/tests/test_backup_source_delete_snapshots.py
+++ b/src/backend/apps/source/tests/test_backup_source_delete_snapshots.py
@@ -21,6 +21,7 @@ from apps.protection.models import (
     BackupConfig,
     BackupConfigDirectory,
     BackupSourceSnapshotDirectory,
+    SnapshotUsageLease,
 )
 from apps.protection.services.backup_source_snapshot import create_source_snapshot
 from apps.protection.services.snapshot_delete import (
@@ -663,6 +664,34 @@ class BackupSourceDeleteSnapshotTaskTests(TestCase):
             resource_type="backup_source",
         ).latest("id")
         self.assertEqual(audit.result, AuditResult.PARTIAL)
+
+    def test_force_delete_cannot_bypass_active_snapshot_usage(self):
+        SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=self.snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id="active-chat",
+        )
+
+        with self.assertRaises(BackupSourceDeleteFailed) as raised:
+            delete_backup_sources(
+                org=self.org,
+                ids=[f"nas:{self.resource.id}"],
+                force=True,
+                user=self.user,
+            )
+
+        self.resource.refresh_from_db()
+        self.assertEqual(raised.exception.reasons[0].code, "snapshot_in_use")
+        self.assertFalse(self.resource.is_deleted)
+        self.assertTrue(BackupConfig.objects.filter(pk=self.config.id).exists())
+        self.assertFalse(
+            BackupSourceRepositoryPurgePending.objects.filter(
+                organization_id=self.org.id,
+                source_kind="nas",
+                source_ref_id=self.resource.id,
+            ).exists()
+        )
 
     @patch(
         "apps.source.services.internal.backup_source_delete._soft_delete_identity",

--- a/src/backend/apps/source/tests/test_direct_nas_cleanup_unregister.py
+++ b/src/backend/apps/source/tests/test_direct_nas_cleanup_unregister.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest import mock
 from uuid import uuid4
 
@@ -9,11 +10,17 @@ from rest_framework.test import APIClient
 from apps.iam.models import Membership, Organization
 from apps.node.models import Node, NodeTask
 from apps.node.services.internal.node_lifecycle import NodeLifecycleError
-from apps.protection.models import BackupConfig
+from apps.protection.models import (
+    BackupConfig,
+    BackupSourceSnapshot,
+    SnapshotUsageLease,
+)
+from apps.protection.services.backup_source_snapshot import create_source_snapshot
 from apps.source.services.internal.backup_source_delete import (
     BackupSourceDeleteFailed,
     delete_backup_sources,
     preflight_delete_backup_sources,
+    reconcile_stuck_source_unregister_tasks,
     run_source_unregister_task,
 )
 from apps.storage.repositories.models import (
@@ -229,6 +236,109 @@ class DirectNasCleanupUnregisterTests(TestCase):
         self.assertEqual(source_unregister.status, Task.Status.SUCCESS)
         self.assertTrue(self.agent.is_deleted)
         self.assertFalse(BackupConfig.objects.filter(pk=self.config.id).exists())
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_cleanup._execute_physical_cleanup"
+    )
+    def test_active_snapshot_lease_defers_direct_nas_physical_cleanup(
+        self,
+        execute_cleanup,
+    ):
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Direct NAS leased snapshot backup",
+            status=Task.Status.SUCCESS,
+        )
+        snapshot = create_source_snapshot(
+            organization_id=self.org.id,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=self.config.id,
+            repository_id=self.repository.id,
+            task_id=backup_task.id,
+            task_uuid=backup_task.task_uuid,
+            idempotency_key="direct-nas-leased-snapshot",
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id="active-chat",
+        )
+
+        result = delete_backup_sources(
+            org=self.org,
+            ids=[f"agent:{self.agent.id}"],
+            force=True,
+        )
+
+        self.assertEqual(result["result"], "waiting")
+        self.assertEqual(result["waiting_for"], "snapshot_usage_lease_release")
+        self.assertEqual(result["warnings"], [])
+        execute_cleanup.assert_not_called()
+        self.assertTrue(
+            Task.objects.filter(
+                organization_id=self.org.id,
+                task_type=Task.Type.SOURCE_UNREGISTER,
+                status=Task.Status.RUNNING,
+            ).exists()
+        )
+
+    @mock.patch(
+        "apps.source.tasks.source_unregister.execute_source_unregister_task.delay"
+    )
+    def test_reconciler_does_not_repeat_cleanup_while_snapshot_is_leased(
+        self,
+        execute_unregister,
+    ):
+        backup_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.BACKUP,
+            display_name="Direct NAS reconciler lease backup",
+            status=Task.Status.SUCCESS,
+        )
+        snapshot = create_source_snapshot(
+            organization_id=self.org.id,
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=self.config.id,
+            repository_id=self.repository.id,
+            task_id=backup_task.id,
+            task_uuid=backup_task.task_uuid,
+            idempotency_key="direct-nas-reconciler-lease",
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        lease = SnapshotUsageLease.objects.create(
+            organization_id=self.org.id,
+            snapshot_id=snapshot.id,
+            consumer_type=SnapshotUsageLease.ConsumerType.CHAT,
+            consumer_id="active-chat",
+        )
+        waiting = delete_backup_sources(
+            org=self.org,
+            ids=[f"agent:{self.agent.id}"],
+            force=True,
+        )
+        unregister_task = Task.objects.get(pk=waiting["task_id"])
+        stale_at = timezone.now() - timedelta(minutes=5)
+        Task.objects.filter(pk=unregister_task.pk).update(updated_at=stale_at)
+
+        retained = reconcile_stuck_source_unregister_tasks(stale_seconds=30)
+
+        self.assertEqual(retained["snapshot_usage_waiting"], 1)
+        self.assertEqual(retained["redispatched"], 0)
+        execute_unregister.assert_not_called()
+
+        lease.delete()
+        Task.objects.filter(pk=unregister_task.pk).update(updated_at=stale_at)
+
+        resumed = reconcile_stuck_source_unregister_tasks(stale_seconds=30)
+
+        self.assertEqual(resumed["snapshot_usage_waiting"], 0)
+        self.assertEqual(resumed["redispatched"], 1)
+        execute_unregister.assert_called_once_with(task_id=unregister_task.id)
 
     @mock.patch(
         "apps.source.services.internal.backup_source_delete.agent_connection_status",

--- a/src/backend/apps/storage/services/internal/repository_workload.py
+++ b/src/backend/apps/storage/services/internal/repository_workload.py
@@ -25,15 +25,47 @@ def lock_repositories_for_workload(
     workload: str = RepositoryWorkload.RESTORE_READ,
 ) -> list[Repository]:
     """Lock and revalidate repositories before accepting data work."""
+    return _repositories_for_workload(
+        organization_id=organization_id,
+        repository_ids=repository_ids,
+        workload=workload,
+        lock=True,
+    )
+
+
+def validate_repositories_for_workload(
+    *,
+    organization_id: int,
+    repository_ids: Iterable[int],
+    workload: str = RepositoryWorkload.RESTORE_READ,
+) -> list[Repository]:
+    """Validate data-work prerequisites without establishing a lock fence."""
+    return _repositories_for_workload(
+        organization_id=organization_id,
+        repository_ids=repository_ids,
+        workload=workload,
+        lock=False,
+    )
+
+
+def _repositories_for_workload(
+    *,
+    organization_id: int,
+    repository_ids: Iterable[int],
+    workload: str,
+    lock: bool,
+) -> list[Repository]:
     if workload not in RepositoryWorkload.VALUES:
         raise ValueError(f"Unsupported repository workload: {workload}")
     ordered_ids = sorted({int(repository_id) for repository_id in repository_ids})
     if not ordered_ids:
         raise ValueError("At least one repository is required for data work.")
 
+    queryset = Repository.objects.all()
+    if lock:
+        queryset = queryset.select_for_update()
     repositories = list(
-        Repository.objects.select_for_update()
-        .filter(
+        queryset.filter(
             organization_id=organization_id,
             id__in=ordered_ids,
         )
@@ -93,4 +125,8 @@ def _require_repository_capability(repository: Repository, *, workload: str) -> 
         )
 
 
-__all__ = ["RepositoryWorkload", "lock_repositories_for_workload"]
+__all__ = [
+    "RepositoryWorkload",
+    "lock_repositories_for_workload",
+    "validate_repositories_for_workload",
+]


### PR DESCRIPTION
## Summary

- add durable snapshot usage leases for active Restore and Chat preparation lifecycles
- exclude leased snapshots from retention without consuming configured recovery-point limits
- fence snapshot deletion, configuration reset, source deregistration, Direct NAS cleanup, and Agent removal while data is in use
- release leases on terminal lifecycle transitions and reconcile interrupted or legacy lifecycle state
- backfill leases for active Restore and Chat records during migration

## Safety and compatibility

- keep completed Chats independent from their source snapshots
- preserve Source-to-Snapshot lock ordering across Restore, Chat, reset, and deregistration paths
- retain existing retry semantics for ordinary snapshot deletion and non-Direct-NAS storage
- do not modify SourceLens behavior or the main worktree

## Validation

- Ruff checks
- Python compile checks
- Django system checks
- migration drift check
- Git diff whitespace checks
- PostgreSQL integration tests could not start locally because the configured PostgreSQL service was unavailable; CI remains the authoritative database validation

Related to #949