### PR TITLE
Bootstrap Docker Compose V2 for existing Docker CE hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ Community runs on an Ubuntu host that you manage. The installation host must mee
 
 - Ubuntu 20.04, 22.04, or 24.04 on amd64.
 - At least 2 CPU cores, 4 GiB of memory, and 20 GiB of free space on the disk containing `/opt`.
-- Docker Engine 24.0.0 or later and Docker Compose V2 2.20.0 or later, with the Docker daemon running. If Docker is entirely absent, the online installer can install Docker CE and Compose V2 from the selected regional package source.
-- `curl`, Python 3, `sudo` access, and network access to GitHub, the container registry, the selected Docker CE source, and the Ubuntu package repositories.
+- Docker Engine 24.0.0 or later and Docker Compose V2 2.20.0 or later, with the Docker daemon running. If Docker is entirely absent, the online installer can install Docker CE and Compose V2 from the selected regional package source. If a supported, healthy Docker CE runtime is present but Compose V2 is missing, the installer can add only the pinned Compose plugin when the package plan leaves the existing Docker runtime unchanged.
+- `curl`, Python 3, `sudo` access, and network access to GitHub, the container registry, the selected or existing Docker CE source, and the Ubuntu package repositories.
 
-An existing Docker installation is always reused when it meets these requirements. If its version is too old, Compose V2 is missing, or the daemon is unavailable, repair or upgrade Docker manually before continuing; the installer does not replace or repair an existing Docker runtime. Removing HyperFileLens does not remove Docker, Compose, or containerd.
+The online installer supports Docker CE only; Ubuntu `docker.io`, Moby, Snap, and other unrecognized runtimes must be repaired or replaced manually. An existing Docker CE installation is always reused when it meets these requirements. If its version is too old, the daemon is unavailable, or Compose V2 cannot be added without changing existing Docker packages, repair or upgrade Docker manually before continuing; the installer does not replace or repair an existing Docker Engine. Removing HyperFileLens does not remove Docker, Compose, containerd, or a Docker CE apt source created by the installer.
 
 Run the following command on the prepared host:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -87,10 +87,10 @@ HyperFileLens 官方 SaaS 由 OnePro Cloud 提供和运营，无需自行部署�
 
 - Ubuntu 20.04、22.04 或 24.04，amd64 架构。
 - 至少 2 核 CPU、4 GiB 内存，以及 `/opt` 所在磁盘 20 GiB 可用空间。
-- Docker Engine 24.0.0 及以上版本、Docker Compose V2 2.20.0 及以上版本，并且 Docker daemon 正常运行。如果主机完全没有安装 Docker，在线安装程序可以通过所选区域的软件源安装 Docker CE 和 Compose V2。
-- 已安装 `curl` 和 Python 3，具备 `sudo` 权限，并可访问 Gitee、镜像仓库、所选 Docker CE 软件源和 Ubuntu 软件源。
+- Docker Engine 24.0.0 及以上版本、Docker Compose V2 2.20.0 及以上版本，并且 Docker daemon 正常运行。如果主机完全没有安装 Docker，在线安装程序可以通过所选区域的软件源安装 Docker CE 和 Compose V2。如果主机已有受支持且运行正常的 Docker CE 运行时，但缺少 Compose V2，在线安装程序仅会在软件包计划不改变现有 Docker 运行时的情况下安装固定版本的 Compose 插件。
+- 已安装 `curl` 和 Python 3，具备 `sudo` 权限，并可访问 Gitee、镜像仓库、所选或已有的 Docker CE 软件源和 Ubuntu 软件源。
 
-已有 Docker 符合上述要求时始终优先复用。如果版本过低、缺少 Compose V2 或 daemon 不可用，需要先手动修复或升级；安装程序不会替换或修复已有 Docker。卸载 HyperFileLens 不会卸载 Docker、Compose 或 containerd。
+在线安装程序仅支持 Docker CE；Ubuntu `docker.io`、Moby、Snap 以及其他无法识别的运行时需要手动修复或替换。已有 Docker CE 符合上述要求时始终优先复用。如果版本过低、daemon 不可用，或者无法在不改变现有 Docker 软件包的情况下补装 Compose V2，需要先手动修复或升级；安装程序不会替换或修复已有 Docker Engine。卸载 HyperFileLens 不会卸载 Docker、Compose、containerd，也不会删除安装程序创建的 Docker CE apt 软件源。
 
 在准备好的主机上执行：
 

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -42,6 +42,8 @@ DOCKER_TARGET_ENGINE_VERSION=""
 DOCKER_TARGET_COMPOSE_VERSION=""
 DOCKER_PACKAGE_INSTALL_ATTEMPTED=0
 DOCKER_BOOTSTRAPPED=0
+COMPOSE_PACKAGE_INSTALL_ATTEMPTED=0
+COMPOSE_BOOTSTRAPPED=0
 CURL_RETRY_ARGS=()
 APT_RETRY_ARGS=(-o Acquire::Retries=3 -o DPkg::Lock::Timeout=120)
 
@@ -135,23 +137,42 @@ Target
 EOF
 
 	printf '\nHost runtime\n'
-	if [[ "${DOCKER_RUNTIME_ACTION}" == install ]]; then
+	case "${DOCKER_RUNTIME_ACTION}" in
+	install)
 		printf '  Docker Engine  not installed → install %s\n' "${DOCKER_TARGET_ENGINE_VERSION}"
 		printf '  Docker Compose not installed → install %s\n' "${DOCKER_TARGET_COMPOSE_VERSION}"
 		printf '  Package source %s\n' "${DOCKER_CE_SOURCE_NAME}"
 		printf '  Docker service enable and start\n'
 		printf '  Lifecycle      retained when HyperFileLens is removed\n'
-	else
+		;;
+	install-compose)
+		printf '  Docker Engine  %s · reuse\n' "${DOCKER_ENGINE_VERSION}"
+		printf '  Docker Compose not installed → install docker-compose-plugin %s\n' \
+			"${DOCKER_COMPOSE_PACKAGE_VERSION}"
+		printf '  Package source %s\n' "${DOCKER_CE_SOURCE_NAME}"
+		printf '  Install scope  Compose V2 plugin only\n'
+		printf '  Docker service active\n'
+		printf '  Lifecycle      retained when HyperFileLens is removed\n'
+		;;
+	reuse)
 		printf '  Docker Engine  %s · reuse\n' "${DOCKER_ENGINE_VERSION}"
 		printf '  Docker Compose %s · reuse\n' "${DOCKER_COMPOSE_VERSION}"
 		printf '  Docker service active\n'
-	fi
+		;;
+	*) fail "internal Docker runtime action is invalid" ;;
+	esac
 }
 
 cleanup() {
 	local rc=$?
 	trap - EXIT INT TERM
-	if ((rc != 0 && DOCKER_PACKAGE_INSTALL_ATTEMPTED == 1 && DOCKER_BOOTSTRAPPED == 0)); then
+	if ((rc != 0 && COMPOSE_PACKAGE_INSTALL_ATTEMPTED == 1 && COMPOSE_BOOTSTRAPPED == 0)); then
+		printf '\n[WARN] Docker Compose V2 plugin installation did not complete and may have left a partially installed package.\n' >&2
+		printf '[INFO] The existing Docker Engine was not replaced; review dpkg --audit and repair the package state manually before retrying.\n' >&2
+	elif ((rc != 0 && COMPOSE_BOOTSTRAPPED == 1)); then
+		printf '\n[WARN] Docker Compose V2 was installed, but HyperFileLens installation did not complete.\n' >&2
+		printf '[INFO] Docker Compose was retained as a shared host runtime. Run the same command again to retry.\n' >&2
+	elif ((rc != 0 && DOCKER_PACKAGE_INSTALL_ATTEMPTED == 1 && DOCKER_BOOTSTRAPPED == 0)); then
 		printf '\n[WARN] Docker CE package installation did not complete and may have left partially installed packages.\n' >&2
 		printf '[INFO] Review dpkg --audit and repair the Docker package state manually before retrying.\n' >&2
 	elif ((rc != 0 && DOCKER_BOOTSTRAPPED == 1)); then
@@ -286,16 +307,43 @@ docker_compose_version() {
 }
 
 docker_packages_present() {
-	local package status
+	local package
 	for package in \
 		docker-ce docker-ce-cli docker-buildx-plugin docker-compose-plugin \
 		docker-ce-rootless-extras docker.io docker-compose-v2 docker-compose \
 		containerd.io containerd runc moby-engine moby-cli moby-containerd \
 		moby-compose podman-docker; do
-		status="$(dpkg-query -W -f='${db:Status-Abbrev}' "${package}" 2>/dev/null || true)"
-		[[ -n "${status}" && "${status}" != un* ]] && return 0
+		docker_package_payload_present "${package}" && return 0
 	done
 	return 1
+}
+
+docker_package_payload_present() {
+	local status state
+	status="$(dpkg-query -W -f='${db:Status-Abbrev}' "$1" 2>/dev/null || true)"
+	state="${status:1:1}"
+	[[ -n "${state}" && "${state}" != n && "${state}" != c ]]
+}
+
+foreign_docker_runtime_present() {
+	local package docker_path
+	for package in docker.io moby-engine moby-cli moby-containerd moby-compose podman-docker; do
+		docker_package_installed "${package}" && return 0
+	done
+	docker_path="$(command -v docker 2>/dev/null || true)"
+	[[ "${docker_path}" == /snap/* ]] && return 0
+	return 1
+}
+
+docker_package_installed() {
+	local status
+	status="$(dpkg-query -W -f='${db:Status-Abbrev}' "$1" 2>/dev/null || true)"
+	[[ "${status:1:1}" == i ]]
+}
+
+docker_ce_runtime_present() {
+	docker_package_installed docker-ce \
+		&& docker_package_installed docker-ce-cli
 }
 
 docker_residual_state_present() {
@@ -314,13 +362,78 @@ docker_residual_state_present() {
 }
 
 foreign_docker_apt_source_present() {
+	local apt_root="${1:-/etc/apt}"
 	local file
 	while IFS= read -r file; do
-		[[ "${file}" == /etc/apt/sources.list.d/hyperfilelens-docker.list ]] && continue
-		if grep -Eqs 'download\.docker\.com/linux/ubuntu|/docker-ce/linux/ubuntu' "${file}"; then
+		[[ "${file}" == "${apt_root%/}/sources.list.d/hyperfilelens-docker.list" ]] && continue
+		[[ -f "${file}" && -r "${file}" ]] || continue
+		if apt_source_has_enabled_value "${file}" "download.docker.com/linux/ubuntu" \
+			|| apt_source_has_enabled_value "${file}" "/docker-ce/linux/ubuntu"; then
 			return 0
 		fi
-	done < <(find /etc/apt -maxdepth 2 -type f \
+	done < <(find "${apt_root}" -maxdepth 2 \( -type f -o -type l \) \
+		\( -name 'sources.list' -o -name '*.list' -o -name '*.sources' \) \
+		-print 2>/dev/null)
+	return 1
+}
+
+apt_source_has_enabled_value() {
+	local file=$1 value=$2
+	if [[ "${file}" == *.sources ]]; then
+		awk -v value="${value}" '
+			BEGIN { RS="" }
+			{
+				enabled=1
+				has_deb=0
+				has_uri=0
+				field=""
+				count=split($0, lines, "\n")
+				for (i=1; i<=count; i++) {
+					line=lines[i]
+					if (line ~ /^[[:space:]]*#/) continue
+					lower=tolower(line)
+					if (lower ~ /^[[:space:]]*enabled:[[:space:]]*no([[:space:]]|$)/) enabled=0
+					if (line ~ /^[A-Za-z][A-Za-z0-9-]*:/) {
+						field=lower
+						sub(/^[[:space:]]*/, "", field)
+						sub(/:.*/, "", field)
+						data=line
+						sub(/^[^:]*:[[:space:]]*/, "", data)
+					} else if (line ~ /^[[:space:]]+/) {
+						data=line
+						sub(/^[[:space:]]+/, "", data)
+					} else {
+						field=""
+						data=""
+					}
+					if (field == "types") {
+						type_count=split(tolower(data), types, /[[:space:]]+/)
+						for (type_index=1; type_index<=type_count; type_index++) {
+							if (types[type_index] == "deb") has_deb=1
+						}
+					}
+					if (field == "uris" && index(data, value)) has_uri=1
+				}
+				if (enabled && has_deb && has_uri) found=1
+			}
+			END { exit !found }
+		' "${file}"
+	else
+		awk -v value="${value}" \
+			'$1 == "deb" {line=$0; sub(/[[:space:]]+#.*/, "", line); if (index(line, value)) found=1} END {exit !found}' "${file}"
+	fi
+}
+
+docker_apt_source_present() {
+	local apt_root="${1:-/etc/apt}"
+	local file
+	while IFS= read -r file; do
+		[[ -f "${file}" && -r "${file}" ]] || continue
+		if apt_source_has_enabled_value "${file}" "download.docker.com/linux/ubuntu" \
+			|| apt_source_has_enabled_value "${file}" "/docker-ce/linux/ubuntu"; then
+			return 0
+		fi
+	done < <(find "${apt_root}" -maxdepth 2 \( -type f -o -type l \) \
 		\( -name 'sources.list' -o -name '*.list' -o -name '*.sources' \) \
 		-print 2>/dev/null)
 	return 1
@@ -330,6 +443,9 @@ inspect_docker_runtime() {
 	DOCKER_ENGINE_VERSION=""
 	DOCKER_COMPOSE_VERSION=""
 	if command -v docker >/dev/null 2>&1; then
+		if foreign_docker_runtime_present || ! docker_ce_runtime_present; then
+			fail "the existing Docker runtime is not a Docker CE installation; install Docker CE and Compose V2 manually, then rerun this installer"
+		fi
 		docker info >/dev/null 2>&1 \
 			|| fail "Docker is installed but its daemon is unavailable; start or repair Docker manually, then rerun this installer"
 		DOCKER_ENGINE_VERSION="$(docker_engine_version)"
@@ -338,8 +454,13 @@ inspect_docker_runtime() {
 		docker_version_ge "${DOCKER_ENGINE_VERSION}" "${MIN_DOCKER_ENGINE_VERSION}" \
 			|| fail "Docker Engine ${DOCKER_ENGINE_VERSION} does not meet the minimum required version ${MIN_DOCKER_ENGINE_VERSION}; upgrade Docker manually, then rerun this installer"
 		DOCKER_COMPOSE_VERSION="$(docker_compose_version)"
-		[[ -n "${DOCKER_COMPOSE_VERSION}" ]] \
-			|| fail "Docker Compose V2 is missing; install the Compose V2 plugin manually, then rerun this installer"
+		if [[ -z "${DOCKER_COMPOSE_VERSION}" ]]; then
+			if ! selected_docker_apt_source_present && docker_apt_source_present; then
+				DOCKER_CE_SOURCE_NAME="Existing Docker CE apt source"
+			fi
+			DOCKER_RUNTIME_ACTION="install-compose"
+			return 0
+		fi
 		docker_version_ge "${DOCKER_COMPOSE_VERSION}" "${MIN_DOCKER_COMPOSE_VERSION}" \
 			|| fail "Docker Compose ${DOCKER_COMPOSE_VERSION} does not meet the minimum required version ${MIN_DOCKER_COMPOSE_VERSION}; upgrade the Compose V2 plugin manually, then rerun this installer"
 		DOCKER_RUNTIME_ACTION="reuse"
@@ -526,11 +647,51 @@ configure_docker_apt_source() {
 	printf '[ OK ] Docker CE package source is ready\n'
 }
 
+selected_docker_apt_source_present() {
+	local apt_root="${1:-/etc/apt}"
+	local file
+	[[ -n "${DOCKER_CE_APT_BASE}" ]] || return 1
+	while IFS= read -r file; do
+		[[ -f "${file}" && -r "${file}" ]] || continue
+		apt_source_has_enabled_value "${file}" "${DOCKER_CE_APT_BASE}" && return 0
+	done < <(find "${apt_root}" -maxdepth 2 \( -type f -o -type l \) \
+		\( -name 'sources.list' -o -name '*.list' -o -name '*.sources' \) \
+		-print 2>/dev/null)
+	return 1
+}
+
+ensure_docker_apt_source() {
+	local apt_root="${1:-/etc/apt}"
+	if selected_docker_apt_source_present "${apt_root}"; then
+		printf '[ OK ] Existing %s will be reused\n' "${DOCKER_CE_SOURCE_NAME}"
+		return 0
+	fi
+	if docker_apt_source_present "${apt_root}"; then
+		printf '[ OK ] Existing Docker CE apt source will be reused\n'
+		return 0
+	fi
+	install_docker_prerequisites
+	configure_docker_apt_source
+}
+
 validate_apt_install_plan() {
 	local plan=$1 operation=${2:-"automatic host-package installation"}
 	if grep -Eq '^The following packages will be (REMOVED|DOWNGRADED):|^[[:space:]]*[1-9][0-9]* upgraded,| [1-9][0-9]* to remove' "${plan}"; then
 		cat "${plan}" >&2
 		fail "${operation} would upgrade, downgrade, or remove existing host packages; install the required packages manually"
+	fi
+}
+
+validate_compose_only_install_plan() {
+	local plan=$1
+	local package
+	local -a packages=()
+	mapfile -t packages < <(awk '$1 == "Inst" {print $2}' "${plan}")
+	package="${packages[0]:-}"
+	package="${package%%:*}"
+	if [[ "${#packages[@]}" -ne 1 || "${package}" != docker-compose-plugin ]]; then
+		cat "${plan}" >&2
+		fail "Docker Compose V2 cannot be installed safely without changing the existing Docker runtime; install a compatible Compose V2 plugin manually, then rerun this installer"
 	fi
 }
 
@@ -595,13 +756,66 @@ install_online_docker_runtime() {
 		"${DOCKER_ENGINE_VERSION}" "${DOCKER_COMPOSE_VERSION}"
 }
 
+install_online_compose_plugin() {
+	local plan="${SESSION_DIR}/compose-apt-plan.log"
+	local install_log="${SESSION_DIR}/compose-apt-install.log"
+	local original_engine_version="${DOCKER_ENGINE_VERSION}"
+	[[ -n "${DOCKER_COMPOSE_PACKAGE_VERSION}" ]] \
+		|| fail "Docker Compose V2 package version was not resolved"
+	assert_clean_dpkg_state
+	if ! selected_docker_apt_source_present; then
+		if ! docker_apt_source_present; then
+			command -v gpg >/dev/null 2>&1 \
+				|| fail "GnuPG is required to add the Docker CE source for Compose V2; install it manually, then rerun this installer"
+			[[ -f /etc/ssl/certs/ca-certificates.crt ]] \
+				|| fail "CA certificates are required to add the Docker CE source for Compose V2; install them manually, then rerun this installer"
+		fi
+	fi
+	ensure_docker_apt_source
+	printf '[....] Resolving Docker Compose V2 package\n'
+	apt-get "${APT_RETRY_ARGS[@]}" update \
+		|| fail "could not update the selected Docker CE package source"
+	if ! LC_ALL=C apt-get "${APT_RETRY_ARGS[@]}" --simulate --no-remove --no-upgrade \
+		--no-install-recommends install \
+		"docker-compose-plugin=${DOCKER_COMPOSE_PACKAGE_VERSION}" >"${plan}" 2>&1; then
+		tail -n 20 "${plan}" >&2 || true
+		fail "Docker Compose V2 package dependencies could not be resolved without changing the existing Docker runtime"
+	fi
+	validate_apt_install_plan "${plan}" "Docker Compose V2 installation"
+	validate_compose_only_install_plan "${plan}"
+	printf '[ OK ] Docker Compose V2 package plan is safe\n'
+	printf '[....] Installing Docker Compose V2 plugin\n'
+	COMPOSE_PACKAGE_INSTALL_ATTEMPTED=1
+	if ! DEBIAN_FRONTEND=noninteractive LC_ALL=C apt-get "${APT_RETRY_ARGS[@]}" \
+		install -y --no-remove --no-upgrade --no-install-recommends \
+		"docker-compose-plugin=${DOCKER_COMPOSE_PACKAGE_VERSION}" >"${install_log}" 2>&1; then
+		tail -n 20 "${install_log}" >&2 || true
+		fail "Docker Compose V2 plugin installation failed"
+	fi
+	COMPOSE_BOOTSTRAPPED=1
+	docker info >/dev/null 2>&1 \
+		|| fail "Docker daemon became unavailable after the Compose V2 plugin installation"
+	DOCKER_ENGINE_VERSION="$(docker_engine_version)"
+	[[ "${DOCKER_ENGINE_VERSION}" == "${original_engine_version}" ]] \
+		|| fail "Docker Engine changed unexpectedly while installing the Compose V2 plugin"
+	DOCKER_COMPOSE_VERSION="$(docker_compose_version)"
+	docker_version_ge "${DOCKER_COMPOSE_VERSION}" "${MIN_DOCKER_COMPOSE_VERSION}" \
+		|| fail "installed Docker Compose ${DOCKER_COMPOSE_VERSION:-unknown} does not meet the minimum required version ${MIN_DOCKER_COMPOSE_VERSION}"
+	DOCKER_RUNTIME_ACTION="reuse"
+	printf '[ OK ] Docker Compose %s is ready; Docker Engine %s was reused unchanged\n' \
+		"${DOCKER_COMPOSE_VERSION}" "${DOCKER_ENGINE_VERSION}"
+}
+
 ensure_online_docker_runtime() {
-	if [[ "${DOCKER_RUNTIME_ACTION}" == reuse ]]; then
+	case "${DOCKER_RUNTIME_ACTION}" in
+	reuse)
 		printf '[ OK ] Existing Docker Engine %s and Docker Compose %s are supported\n' \
 			"${DOCKER_ENGINE_VERSION}" "${DOCKER_COMPOSE_VERSION}"
-		return 0
-	fi
-	install_online_docker_runtime
+		;;
+	install-compose) install_online_compose_plugin ;;
+	install) install_online_docker_runtime ;;
+	*) fail "internal Docker runtime action is invalid" ;;
+	esac
 }
 
 inspect_existing_installation() {
@@ -910,6 +1124,8 @@ resolve_tag
 inspect_docker_runtime
 if [[ "${DOCKER_RUNTIME_ACTION}" == install ]]; then
 	assert_docker_service_manager
+fi
+if [[ "${DOCKER_RUNTIME_ACTION}" != reuse ]]; then
 	download_source_archive
 	load_docker_runtime_contract
 fi

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -39,6 +39,12 @@ grep -Fq 'load_docker_runtime_contract' "${online}/install.sh"
 grep -Fq 'Releases published before the per-OS contract' "${online}/install.sh"
 grep -Fq 'assert_docker_service_manager' "${online}/install.sh"
 grep -Fq 'DOCKER_PACKAGE_INSTALL_ATTEMPTED' "${online}/install.sh"
+grep -Fq 'COMPOSE_PACKAGE_INSTALL_ATTEMPTED' "${online}/install.sh"
+grep -Fq 'validate_compose_only_install_plan' "${online}/install.sh"
+grep -Fq 'selected_docker_apt_source_present' "${online}/install.sh"
+grep -Fq 'foreign_docker_runtime_present' "${online}/install.sh"
+grep -Fq 'docker_ce_runtime_present' "${online}/install.sh"
+grep -Fq 'docker_apt_source_present' "${online}/install.sh"
 grep -Fq 'Acquire::Retries=3' "${online}/install.sh"
 grep -Fq 'DPkg::Lock::Timeout=120' "${online}/install.sh"
 grep -Fq -- '--no-upgrade' "${online}/install.sh"
@@ -407,6 +413,16 @@ case "${1:-} ${2:-}" in
 esac
 SH
 chmod 755 "${fake_bin}/curl" "${fake_bin}/docker"
+cat >"${fake_bin}/dpkg-query" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${*: -1}" == docker-ce || "${*: -1}" == docker-ce-cli ]]; then
+	printf 'ii '
+	exit 0
+fi
+exit 1
+SH
+chmod 755 "${fake_bin}/dpkg-query"
 
 online_functions="${tmp}/online-install-functions.sh"
 python3 - "${online}/install.sh" "${online_functions}" <<'PY'
@@ -437,6 +453,108 @@ PY
 	configure_mirror
 	[[ "${DOCKER_CE_APT_BASE}" == "https://download.docker.com/linux/ubuntu" ]]
 	[[ "${DOCKER_CE_GPG_URL}" == "https://download.docker.com/linux/ubuntu/gpg" ]]
+)
+apt_source_fixture="${tmp}/apt-source-fixture"
+mkdir -p "${apt_source_fixture}/sources.list.d"
+printf '# deb https://download.docker.com/linux/ubuntu noble stable\n' \
+	>"${apt_source_fixture}/sources.list.d/docker.list"
+(
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	DOCKER_CE_APT_BASE=https://download.docker.com/linux/ubuntu
+	! selected_docker_apt_source_present "${apt_source_fixture}"
+)
+printf 'deb https://example.test/ubuntu noble main # https://download.docker.com/linux/ubuntu\n' \
+	>"${apt_source_fixture}/sources.list.d/docker.list"
+(
+	# A Docker URL in a one-line source comment is not an active package source.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	DOCKER_CE_APT_BASE=https://download.docker.com/linux/ubuntu
+	! selected_docker_apt_source_present "${apt_source_fixture}"
+	! docker_apt_source_present "${apt_source_fixture}"
+)
+printf 'deb [arch=amd64] https://download.docker.com/linux/ubuntu noble stable\n' \
+	>"${apt_source_fixture}/sources.list.d/docker.list"
+(
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	DOCKER_CE_APT_BASE=https://download.docker.com/linux/ubuntu
+	selected_docker_apt_source_present "${apt_source_fixture}"
+	DOCKER_CE_SOURCE_NAME='Docker CE test source'
+	install_docker_prerequisites() {
+		printf 'ERROR: existing Docker source unexpectedly installed prerequisites\n' >&2
+		return 1
+	}
+	configure_docker_apt_source() {
+		printf 'ERROR: existing Docker source was configured again\n' >&2
+		return 1
+	}
+	ensure_docker_apt_source "${apt_source_fixture}"
+)
+cat >"${apt_source_fixture}/sources.list.d/docker.sources" <<'SOURCES'
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: noble
+Components: stable
+Enabled: no
+SOURCES
+rm "${apt_source_fixture}/sources.list.d/docker.list"
+(
+	# A disabled Deb822 stanza is not an enabled Docker CE source.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	DOCKER_CE_APT_BASE=https://download.docker.com/linux/ubuntu
+	! selected_docker_apt_source_present "${apt_source_fixture}"
+	! docker_apt_source_present "${apt_source_fixture}"
+)
+cat >"${apt_source_fixture}/sources.list.d/docker.sources" <<'SOURCES'
+Types: deb-src
+URIs: https://download.docker.com/linux/ubuntu
+Suites: noble
+Components: stable
+
+Types: deb
+URIs: https://example.test/ubuntu
+Suites: noble
+Components: stable
+Description: Documentation at https://download.docker.com/linux/ubuntu
+SOURCES
+(
+	# Source-only entries and URLs outside a Deb822 URIs field are not usable
+	# Docker CE binary package sources.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	DOCKER_CE_APT_BASE=https://download.docker.com/linux/ubuntu
+	! selected_docker_apt_source_present "${apt_source_fixture}"
+	! docker_apt_source_present "${apt_source_fixture}"
+)
+cat >"${apt_source_fixture}/sources.list.d/docker.sources" <<'SOURCES'
+Types: deb deb-src
+URIs:
+ https://download.docker.com/linux/ubuntu
+Suites: noble
+Components: stable
+SOURCES
+(
+	# Enabled Deb822 binary sources and continuation fields are recognized.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	DOCKER_CE_APT_BASE=https://download.docker.com/linux/ubuntu
+	selected_docker_apt_source_present "${apt_source_fixture}"
+	docker_apt_source_present "${apt_source_fixture}"
+)
+linked_source="${tmp}/linked-docker.sources"
+mv "${apt_source_fixture}/sources.list.d/docker.sources" "${linked_source}"
+ln -s "${linked_source}" "${apt_source_fixture}/sources.list.d/docker.sources"
+(
+	# Apt accepts source files through symlinks; an enabled linked source must be
+	# reused instead of adding a duplicate HFL-managed source.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	DOCKER_CE_APT_BASE=https://download.docker.com/linux/ubuntu
+	selected_docker_apt_source_present "${apt_source_fixture}"
+	docker_apt_source_present "${apt_source_fixture}"
 )
 runtime_contract_session="${tmp}/runtime-contract"
 mkdir -p "${runtime_contract_session}/source/deploy/online"
@@ -528,6 +646,154 @@ mkdir -p "${legacy_runtime_session}/source/deploy/online"
 	[[ "${DOCKER_RUNTIME_ACTION}" == install ]]
 )
 (
+	# Removed Docker packages with config-files-only (dpkg "rc") state do not
+	# represent installed package payloads on an otherwise clean host.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	dpkg-query() {
+		[[ "${*: -1}" == docker.io ]] || return 1
+		printf 'rc '
+	}
+	! docker_packages_present
+)
+(
+	# A healthy, supported Docker Engine with no Compose V2 plugin selects the
+	# narrowly scoped plugin bootstrap instead of changing the Engine runtime.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	docker() {
+		case "${1:-} ${2:-}" in
+		"info ") return 0 ;;
+		"version --format") printf '29.2.1\n' ;;
+		"compose version") return 1 ;;
+		esac
+		return 1
+	}
+	dpkg-query() {
+		[[ "${*: -1}" == docker-ce || "${*: -1}" == docker-ce-cli ]] || return 1
+		printf 'ii '
+	}
+	inspect_docker_runtime
+	[[ "${DOCKER_RUNTIME_ACTION}" == install-compose ]]
+	[[ "${DOCKER_ENGINE_VERSION}" == 29.2.1 ]]
+)
+(
+	# An Engine package without its Docker CE CLI package is not a complete
+	# Docker CE runtime that can receive a managed Compose plugin.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	dpkg-query() {
+		[[ "${*: -1}" == docker-ce ]] || return 1
+		printf 'ii '
+	}
+	! docker_ce_runtime_present
+)
+foreign_runtime_log="${tmp}/foreign-runtime-compose.log"
+if (
+	# A Docker runtime supplied by Ubuntu/Moby/Snap must not be converted to
+	# Docker CE merely to add Compose V2.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	docker() {
+		case "${1:-} ${2:-}" in
+		"info ") return 0 ;;
+		"version --format") printf '29.2.1\n' ;;
+		"compose version") return 1 ;;
+		esac
+		return 1
+	}
+	dpkg-query() {
+		[[ "${*: -1}" == docker.io ]] || return 1
+		printf 'ii '
+	}
+	inspect_docker_runtime
+) >"${foreign_runtime_log}" 2>&1; then
+	printf 'ERROR: foreign Docker runtime was accepted for Compose-only bootstrap\n' >&2
+	exit 1
+fi
+grep -Fq 'not a Docker CE installation' "${foreign_runtime_log}"
+foreign_complete_runtime_log="${tmp}/foreign-complete-runtime.log"
+if (
+	# A non-Docker-CE runtime is rejected even when it already exposes Compose;
+	# the online installer only supports Docker CE for its managed contract.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	docker() {
+		case "${1:-} ${2:-}" in
+		"info ") return 0 ;;
+		"version --format") printf '29.2.1\n' ;;
+		"compose version") printf '2.39.1\n' ;;
+		esac
+		return 1
+	}
+	dpkg-query() {
+		[[ "${*: -1}" == docker.io ]] || return 1
+		printf 'ii '
+	}
+	inspect_docker_runtime
+) >"${foreign_complete_runtime_log}" 2>&1; then
+	printf 'ERROR: complete foreign Docker runtime was accepted\n' >&2
+	exit 1
+fi
+grep -Fq 'not a Docker CE installation' "${foreign_complete_runtime_log}"
+unrecognized_runtime_log="${tmp}/unrecognized-runtime-compose.log"
+if (
+	# A healthy static or otherwise unrecognized Docker binary is not sufficient
+	# evidence that the Docker CE apt plugin can be added safely.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	docker() {
+		case "${1:-} ${2:-}" in
+		"info ") return 0 ;;
+		"version --format") printf '29.2.1\n' ;;
+		"compose version") return 1 ;;
+		esac
+		return 1
+	}
+	dpkg-query() { return 1; }
+	inspect_docker_runtime
+) >"${unrecognized_runtime_log}" 2>&1; then
+	printf 'ERROR: unrecognized Docker runtime was accepted for Compose-only bootstrap\n' >&2
+	exit 1
+fi
+grep -Fq 'not a Docker CE installation' "${unrecognized_runtime_log}"
+(
+	# A removed docker.io package with residual configuration (dpkg "rc") does
+	# not identify the active Docker Engine as Ubuntu's runtime.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	dpkg-query() {
+		[[ "${*: -1}" == docker.io ]] || return 1
+		printf 'rc '
+	}
+	command() {
+		if [[ "${1:-}" == -v && "${2:-}" == docker ]]; then
+			printf '/usr/bin/docker\n'
+			return 0
+		fi
+		builtin command "$@"
+	}
+	! foreign_docker_runtime_present
+)
+compose_target_log="${tmp}/compose-target.log"
+(
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	TAG=v1.2.3
+	SOURCE_NAME=GitHub
+	REGISTRY_NAME='Docker Hub'
+	ONLINE_LOG_FILE=/opt/hyperfilelens/logs/install-test.log
+	DOCKER_RUNTIME_ACTION=install-compose
+	DOCKER_ENGINE_VERSION=29.2.1
+	DOCKER_COMPOSE_PACKAGE_VERSION='5.0.2-1~ubuntu.24.04~noble'
+	DOCKER_CE_SOURCE_NAME='Docker CE · https://download.docker.com/linux/ubuntu'
+	print_target
+) >"${compose_target_log}"
+grep -Fq 'Docker Engine  29.2.1 · reuse' "${compose_target_log}"
+grep -Fq 'Docker Compose not installed → install docker-compose-plugin 5.0.2-1~ubuntu.24.04~noble' \
+	"${compose_target_log}"
+grep -Fq 'Install scope  Compose V2 plugin only' "${compose_target_log}"
+(
 	# shellcheck disable=SC1090
 	source "${online_functions}"
 	dpkg-query() {
@@ -581,6 +847,21 @@ fi
 grep -Fq 'may have left partially installed packages' "${partial_install_log}"
 grep -Fq 'dpkg --audit' "${partial_install_log}"
 
+partial_compose_log="${tmp}/compose-partial-install-warning.log"
+if (
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	SESSION_DIR=""
+	COMPOSE_PACKAGE_INSTALL_ATTEMPTED=1
+	COMPOSE_BOOTSTRAPPED=0
+	false || cleanup
+) >"${partial_compose_log}" 2>&1; then
+	printf 'ERROR: partial Compose plugin installation cleanup returned success\n' >&2
+	exit 1
+fi
+grep -Fq 'Compose V2 plugin installation did not complete' "${partial_compose_log}"
+grep -Fq 'existing Docker Engine was not replaced' "${partial_compose_log}"
+
 dpkg_audit_error_log="${tmp}/docker-dpkg-audit-error.log"
 if (
 	# shellcheck disable=SC1090
@@ -615,6 +896,102 @@ if (
 	exit 1
 fi
 grep -Fq 'would upgrade, downgrade, or remove existing host packages' "${unsafe_apt_log}"
+
+safe_compose_plan="${tmp}/compose-safe.plan"
+cat >"${safe_compose_plan}" <<'PLAN'
+Inst docker-compose-plugin (5.0.2-1~ubuntu.24.04~noble Docker CE:stable [amd64])
+Conf docker-compose-plugin (5.0.2-1~ubuntu.24.04~noble Docker CE:stable [amd64])
+0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
+PLAN
+(
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	validate_apt_install_plan "${safe_compose_plan}" "Docker Compose V2 installation"
+	validate_compose_only_install_plan "${safe_compose_plan}"
+)
+unsafe_compose_plan="${tmp}/compose-unsafe.plan"
+cat >"${unsafe_compose_plan}" <<'PLAN'
+Inst docker-ce-cli (5:29.2.1-1~ubuntu.24.04~noble Docker CE:stable [amd64])
+Inst docker-compose-plugin (5.0.2-1~ubuntu.24.04~noble Docker CE:stable [amd64])
+0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
+PLAN
+unsafe_compose_log="${tmp}/compose-unsafe.log"
+if (
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	validate_compose_only_install_plan "${unsafe_compose_plan}"
+) >"${unsafe_compose_log}" 2>&1; then
+	printf 'ERROR: Compose-only bootstrap accepted a Docker CLI package change\n' >&2
+	exit 1
+fi
+grep -Fq 'cannot be installed safely without changing the existing Docker runtime' \
+	"${unsafe_compose_log}"
+empty_compose_plan="${tmp}/compose-empty.plan"
+: >"${empty_compose_plan}"
+empty_compose_log="${tmp}/compose-empty.log"
+if (
+	# An empty or unexpected apt plan must fail with the controlled diagnostic,
+	# not an unbound-array error under `set -u`.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	validate_compose_only_install_plan "${empty_compose_plan}"
+) >"${empty_compose_log}" 2>&1; then
+	printf 'ERROR: empty Compose-only apt plan was accepted\n' >&2
+	exit 1
+fi
+grep -Fq 'cannot be installed safely without changing the existing Docker runtime' \
+	"${empty_compose_log}"
+
+foreign_source_fixture="${tmp}/foreign-apt-source-fixture"
+mkdir -p "${foreign_source_fixture}/sources.list.d"
+printf 'deb https://download.docker.com/linux/ubuntu noble stable\n' \
+	>"${foreign_source_fixture}/sources.list.d/docker.list"
+(
+	# A different Docker source must not be combined with the selected mirror
+	# during Compose-only installation.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	DOCKER_CE_APT_BASE=https://mirrors.aliyun.com/docker-ce/linux/ubuntu
+	if ! foreign_docker_apt_source_present "${foreign_source_fixture}"; then
+		printf 'ERROR: foreign Docker source fixture was not detected\n' >&2
+		exit 1
+	fi
+	docker_apt_source_present "${foreign_source_fixture}"
+	DOCKER_CE_SOURCE_NAME='Selected Docker CE test source'
+	install_docker_prerequisites() {
+		printf 'ERROR: alternate Docker source unexpectedly installed prerequisites\n' >&2
+		return 1
+	}
+	configure_docker_apt_source() {
+		printf 'ERROR: alternate Docker source was replaced\n' >&2
+		return 1
+	}
+	ensure_docker_apt_source "${foreign_source_fixture}"
+)
+printf '# deb https://download.docker.com/linux/ubuntu noble stable\n' \
+	>"${foreign_source_fixture}/sources.list.d/docker.list"
+(
+	# Commented-out Docker sources are not active conflicts.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	! foreign_docker_apt_source_present "${foreign_source_fixture}"
+	! docker_apt_source_present "${foreign_source_fixture}"
+)
+cat >"${foreign_source_fixture}/sources.list.d/docker.sources" <<'SOURCES'
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: noble
+Components: stable
+Enabled: no
+SOURCES
+rm "${foreign_source_fixture}/sources.list.d/docker.list"
+(
+	# Disabled Deb822 Docker sources are not active conflicts.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	! foreign_docker_apt_source_present "${foreign_source_fixture}"
+	! docker_apt_source_present "${foreign_source_fixture}"
+)
 
 bootstrap_apt_log="${tmp}/docker-bootstrap-apt.log"
 bootstrap_systemctl_log="${tmp}/docker-bootstrap-systemctl.log"
@@ -660,6 +1037,46 @@ grep -Fq -- 'install -y --no-remove --no-upgrade --no-install-recommends docker-
 grep -Fxq 'enable --now docker' "${bootstrap_systemctl_log}"
 grep -Fxq 'is-active --quiet docker' "${bootstrap_systemctl_log}"
 grep -Fxq 'is-enabled --quiet docker' "${bootstrap_systemctl_log}"
+
+compose_apt_log="${tmp}/compose-bootstrap-apt.log"
+(
+	# Exercise the Compose-only branch with command fakes. Only the pinned
+	# plugin package may be planned or installed, and the Engine must not change.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	SESSION_DIR="${tmp}/compose-bootstrap"
+	mkdir -p "${SESSION_DIR}"
+	DOCKER_RUNTIME_ACTION=install-compose
+	DOCKER_ENGINE_VERSION=29.2.1
+	DOCKER_COMPOSE_PACKAGE_VERSION='5.0.2-test'
+	assert_clean_dpkg_state() { :; }
+	ensure_docker_apt_source() { :; }
+	selected_docker_apt_source_present() { return 0; }
+	apt-get() {
+		printf '%s\n' "$*" >>"${compose_apt_log}"
+		if [[ " $* " == *' --simulate '* ]]; then
+			printf 'Inst docker-compose-plugin (5.0.2-test Docker CE:stable [amd64])\n'
+			printf 'Conf docker-compose-plugin (5.0.2-test Docker CE:stable [amd64])\n'
+			printf '0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.\n'
+		fi
+	}
+	docker() {
+		[[ "${1:-}" == info ]]
+	}
+	docker_engine_version() { printf '29.2.1'; }
+	docker_compose_version() { printf '5.0.2'; }
+	install_online_compose_plugin
+	[[ "${COMPOSE_BOOTSTRAPPED}" -eq 1 ]]
+	[[ "${DOCKER_RUNTIME_ACTION}" == reuse ]]
+)
+grep -Fq -- '--simulate --no-remove --no-upgrade --no-install-recommends install docker-compose-plugin=5.0.2-test' \
+	"${compose_apt_log}"
+grep -Fq -- 'install -y --no-remove --no-upgrade --no-install-recommends docker-compose-plugin=5.0.2-test' \
+	"${compose_apt_log}"
+if grep -Eq 'docker-ce=|docker-ce-cli=|containerd.io=' "${compose_apt_log}"; then
+	printf 'ERROR: Compose-only bootstrap attempted to change Docker Engine packages\n' >&2
+	exit 1
+fi
 
 atomic_target="${tmp}/atomic-download.json"
 printf 'preserved response\n' >"${atomic_target}"
@@ -796,8 +1213,8 @@ for runtime_case in daemon engine compose; do
 		runtime_message='does not meet the minimum required version 24.0.0'
 		;;
 	compose)
-		runtime_env=(HFL_TEST_DOCKER_COMPOSE_MISSING=1)
-		runtime_message='Docker Compose V2 is missing'
+		runtime_env=(HFL_TEST_DOCKER_COMPOSE_VERSION=2.19.9)
+		runtime_message='does not meet the minimum required version 2.20.0'
 		;;
 	esac
 	if env PATH="${fake_bin}:${PATH}" HFL_TEST_TAG_FIXTURE="${tag_fixture}" \

--- a/website/en/docs/getting-started/install.md
+++ b/website/en/docs/getting-started/install.md
@@ -12,12 +12,12 @@ HyperFileLens Community runs on an Ubuntu host that you manage. The online insta
 - Ubuntu 20.04, 22.04, or 24.04 on amd64.
 - At least 2 CPU cores and 4 GiB of memory. For regular use, 4 cores and 8 GiB or more are recommended.
 - At least 20 GiB of free space on the disk that contains `/opt`.
-- Docker Engine 24.0.0 or later and Docker Compose V2 2.20.0 or later, with the Docker daemon running. If Docker is entirely absent, the online installer can install Docker CE and Compose V2 from the selected regional package source.
+- Docker Engine 24.0.0 or later and Docker Compose V2 2.20.0 or later, with the Docker daemon running. If Docker is entirely absent, the online installer can install Docker CE and Compose V2 from the selected regional package source. If a supported, healthy Docker CE runtime is present but Compose V2 is missing, the installer can add only the pinned Compose plugin when the package plan leaves the existing Docker runtime unchanged.
 - `curl`, Python 3, and `sudo` access.
-- Network access to GitHub, the container registry, the selected Docker CE source, and the Ubuntu package repositories.
+- Network access to GitHub, the container registry, the selected or existing Docker CE source, and the Ubuntu package repositories.
 - Ports `11442–11445` available on the installation host.
 
-An existing Docker installation is reused when it meets these requirements. If its version is too old, Compose V2 is missing, or the daemon is unavailable, repair or upgrade Docker manually before continuing. The installer does not replace or repair an existing Docker runtime, and uninstalling HyperFileLens does not remove Docker, Compose, or containerd.
+The online installer supports Docker CE only; Ubuntu `docker.io`, Moby, Snap, and other unrecognized runtimes must be repaired or replaced manually. An existing Docker CE installation is reused when it meets these requirements. If its version is too old, the daemon is unavailable, or Compose V2 cannot be added without changing existing Docker packages, repair or upgrade Docker manually before continuing. The installer does not replace or repair an existing Docker Engine, and uninstalling HyperFileLens does not remove Docker, Compose, containerd, or a Docker CE apt source created by the installer.
 
 ## Run the installer
 

--- a/website/zh/docs/getting-started/install.md
+++ b/website/zh/docs/getting-started/install.md
@@ -12,12 +12,12 @@ HyperFileLens 社区版可部署在自有 Ubuntu 主机上。在线安装程序�
 - Ubuntu 20.04、22.04 或 24.04，amd64 架构。
 - 至少 2 核 CPU 和 4 GiB 内存，建议使用 4 核 CPU 和 8 GiB 以上内存。
 - `/opt` 所在磁盘至少有 20 GiB 可用空间。
-- Docker Engine 24.0.0 及以上版本、Docker Compose V2 2.20.0 及以上版本，并且 Docker daemon 正常运行。如果主机完全没有安装 Docker，在线安装程序可以通过所选区域的软件源安装 Docker CE 和 Compose V2。
+- Docker Engine 24.0.0 及以上版本、Docker Compose V2 2.20.0 及以上版本，并且 Docker daemon 正常运行。如果主机完全没有安装 Docker，在线安装程序可以通过所选区域的软件源安装 Docker CE 和 Compose V2。如果主机已有受支持且运行正常的 Docker CE 运行时，但缺少 Compose V2，在线安装程序仅会在软件包计划不改变现有 Docker 运行时的情况下安装固定版本的 Compose 插件。
 - 已安装 `curl` 和 Python 3，并具备 `sudo` 权限。
-- 能够访问 Gitee、镜像仓库、所选 Docker CE 软件源和 Ubuntu 软件源。
+- 能够访问 Gitee、镜像仓库、所选或已有的 Docker CE 软件源和 Ubuntu 软件源。
 - 默认服务端口 `11442–11445` 未被其他程序占用。
 
-已有 Docker 符合上述要求时将直接复用。如果版本过低、缺少 Compose V2 或 daemon 不可用，需要先手动修复或升级。安装程序不会替换或修复已有 Docker，卸载 HyperFileLens 也不会卸载 Docker、Compose 或 containerd。
+在线安装程序仅支持 Docker CE；Ubuntu `docker.io`、Moby、Snap 以及其他无法识别的运行时需要手动修复或替换。已有 Docker CE 符合上述要求时将直接复用。如果版本过低、daemon 不可用，或者无法在不改变现有 Docker 软件包的情况下补装 Compose V2，需要先手动修复或升级。安装程序不会替换或修复已有 Docker Engine，卸载 HyperFileLens 也不会卸载 Docker、Compose、containerd，或删除安装程序创建的 Docker CE apt 软件源。
 
 详细配置和网络要求请查看[系统要求](/zh/docs/deployment/requirements)与[网络和端口](/zh/docs/deployment/network)。
 


### PR DESCRIPTION
## Summary

- install only the pinned Docker Compose V2 plugin when a healthy Docker CE host is missing Compose
- validate the apt simulation so Docker Engine, CLI, containerd, and unrelated packages cannot be changed
- reuse enabled Docker CE sources and preserve Docker runtime assets on HyperFileLens uninstall
- reject non-Docker-CE and unrecognized runtimes with actionable manual-repair guidance
- document the supported runtime matrix and add Ubuntu-compatible regression coverage

## Validation

- `bash -n deploy/online/install.sh`
- `bash -n tools/quality/test-online-community-install.sh`
- `git diff --check`
- `./tools/quality/test-online-community-install.sh`
- `./tools/quality/check-release-contracts.sh`

Refs #921