### PR TITLE
Show running restore duration

### DIFF
--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
@@ -259,6 +259,25 @@ describe('FlowBackupSourceDetailDrawer snapshot expansion state', () => {
     expect(drawer).toContain('max-width: calc(100cqw - 49px); overflow-x: hidden; margin-left: 35px;')
   })
 
+  it('updates running restore durations and stops the clock outside the active records tab', () => {
+    const duration = sourceBetween(
+      'function restoreRecordDuration(record: RestoreRecord)',
+      'function restoreRecordConflictLabel',
+    )
+    const timer = sourceBetween(
+      'function stopRestoreRecordDurationTimer()',
+      'function syncRestoreRecordPolling()',
+    )
+
+    expect(duration).toContain("status === 'running'")
+    expect(duration).toContain('restoreRecordDurationNow.value')
+    expect(duration).toContain('record.task_summary?.finished_at')
+    expect(timer).toContain("activeTab.value !== 'restoreRecords'")
+    expect(timer).toContain('!hasRunningRestoreRecords.value')
+    expect(timer).toContain('RESTORE_RECORD_DURATION_INTERVAL_MS')
+    expect(drawer).toContain('stopRestoreRecordDurationTimer()')
+  })
+
   it('adds a single restore record search field and ordered status filters without advanced filtering', () => {
     const restoreTab = sourceBetween(
       '<el-tab-pane :label="t(\'protection.backupsPage.flowSourceDetailTabRestoreRecords\')" name="restoreRecords">',

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -300,7 +300,9 @@ const targetedRestoreRecord = ref<RestoreRecord | null>(null)
 const appliedRestoreRecordTargetId = ref<number | null>(null)
 const restoreRecordRuntimeById = ref<Map<number, TaskRuntimePayload>>(new Map())
 const restoreRecordRuntimeLoadingIds = ref<Set<number>>(new Set())
+const restoreRecordDurationNow = ref(Date.now())
 let restoreRecordPollingTimer: ReturnType<typeof setInterval> | null = null
+let restoreRecordDurationTimer: ReturnType<typeof setInterval> | null = null
 let provisionPollingTimer: ReturnType<typeof setInterval> | null = null
 let provisionPollingInFlight = false
 let provisionPollingAttempts = 0
@@ -354,6 +356,7 @@ const {
 const DETAIL_PAGE_SIZE = 10
 const DETAIL_PAGE_SIZE_OPTIONS = [10, 20, 30, 50, 100]
 const RESTORE_RECORD_POLL_INTERVAL_MS = 3000
+const RESTORE_RECORD_DURATION_INTERVAL_MS = 1000
 const PROVISION_POLL_INTERVAL_MS = 3000
 const PROVISION_POLL_MAX_ATTEMPTS = 60
 const HIDDEN_SOURCE_SNAPSHOT_STATUSES = ['failed']
@@ -571,6 +574,9 @@ const hasActiveRestoreRecords = computed(() => displayedRestoreRecords.value.som
   const status = String(record.task_summary?.status || '').toLowerCase()
   return status === 'pending' || status === 'running'
 }))
+const hasRunningRestoreRecords = computed(() => displayedRestoreRecords.value.some((record) => (
+  String(record.task_summary?.status || '').toLowerCase() === 'running'
+)))
 const sourceRelatedTasks = computed(() => sourceTaskRows.value)
 watch(
   () => [sourceSnapshotTotal.value, snapshotPagination.pageSize] as const,
@@ -1058,9 +1064,14 @@ function restoreRecordProgressText(record: RestoreRecord) {
 }
 
 function restoreRecordDuration(record: RestoreRecord) {
+  const status = String(record.task_summary?.status || '').toLowerCase()
+  const finishedAt = record.task_summary?.finished_at
+  const end = finishedAt || (status === 'running'
+    ? new Date(restoreRecordDurationNow.value).toISOString()
+    : null)
   return durationText(
     record.task_summary?.started_at || record.created_at,
-    record.task_summary?.finished_at,
+    end,
   )
 }
 
@@ -2414,6 +2425,21 @@ function stopRestoreRecordPolling() {
   restoreRecordPollingTimer = null
 }
 
+function stopRestoreRecordDurationTimer() {
+  if (!restoreRecordDurationTimer) return
+  clearInterval(restoreRecordDurationTimer)
+  restoreRecordDurationTimer = null
+}
+
+function syncRestoreRecordDurationTimer() {
+  stopRestoreRecordDurationTimer()
+  if (!props.modelValue || activeTab.value !== 'restoreRecords' || !hasRunningRestoreRecords.value) return
+  restoreRecordDurationNow.value = Date.now()
+  restoreRecordDurationTimer = setInterval(() => {
+    restoreRecordDurationNow.value = Date.now()
+  }, RESTORE_RECORD_DURATION_INTERVAL_MS)
+}
+
 function syncRestoreRecordPolling() {
   stopRestoreRecordPolling()
   if (!props.modelValue || activeTab.value !== 'restoreRecords' || !hasActiveRestoreRecords.value) return
@@ -2568,8 +2594,11 @@ watch(activeTab, async () => {
 })
 
 watch(
-  () => [props.modelValue, activeTab.value, hasActiveRestoreRecords.value] as const,
-  syncRestoreRecordPolling,
+  () => [props.modelValue, activeTab.value, hasActiveRestoreRecords.value, hasRunningRestoreRecords.value] as const,
+  () => {
+    syncRestoreRecordPolling()
+    syncRestoreRecordDurationTimer()
+  },
   { immediate: true },
 )
 
@@ -2760,11 +2789,13 @@ watch(
 onUnmounted(() => {
   if (activeTransferProgressTimer) clearInterval(activeTransferProgressTimer)
   stopRestoreRecordPolling()
+  stopRestoreRecordDurationTimer()
   stopProvisionPolling()
 })
 
 function onClosed() {
   stopRestoreRecordPolling()
+  stopRestoreRecordDurationTimer()
   stopProvisionPolling()
   requests.abortScope('flow-source-overview')
   requests.abortScope('flow-source-snapshots')


### PR DESCRIPTION
## Summary

- Compute elapsed Duration from the restore start until the current time while running
- Stop the lightweight duration timer when leaving the active Restore Records view
- Add coverage for running duration and timer lifecycle behavior

Closes #962

## Testing

- Targeted Vitest tests passed before branch isolation
- Vue TypeScript check passed before branch isolation
- ESLint passed before branch isolation