### PR TITLE
Sync Restore Records table headers

### DIFF
--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
@@ -259,6 +259,17 @@ describe('FlowBackupSourceDetailDrawer snapshot expansion state', () => {
     expect(drawer).toContain('max-width: calc(100cqw - 49px); overflow-x: hidden; margin-left: 35px;')
   })
 
+  it('keeps restore record headers aligned while horizontally scrolling resized columns', () => {
+    const restoreTab = sourceBetween(
+      '<el-tab-pane :label="t(\'protection.backupsPage.flowSourceDetailTabRestoreRecords\')" name="restoreRecords">',
+      '<el-tab-pane :label="t(\'protection.backupDetail.tabTasks\')" name="tasks">',
+    )
+
+    expect(restoreTab).toContain("v-table-column-resize=\"'protection.flowBackupSource.restoreRecords'\"")
+    expect(restoreTab).toContain('v-table-header-scroll-sync')
+    expect(restoreTab).toContain(':fit="false"')
+  })
+
   it('adds a single restore record search field and ordered status filters without advanced filtering', () => {
     const restoreTab = sourceBetween(
       '<el-tab-pane :label="t(\'protection.backupsPage.flowSourceDetailTabRestoreRecords\')" name="restoreRecords">',

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -4348,6 +4348,7 @@ function onClosed() {
             v-if="displayedRestoreRecords.length || restoreRecordsLoading"
             ref="restoreTableRef"
             v-table-column-resize="'protection.flowBackupSource.restoreRecords'"
+            v-table-header-scroll-sync
             v-table-overflow-title
             v-loading="restoreRecordsLoading"
             :data="displayedRestoreRecords"


### PR DESCRIPTION
## Summary

- Keep Restore Records headers aligned with horizontal body scrolling after column resize
- Enable the existing shared header scroll synchronization directive for the detail table
- Add coverage for the resize/scroll contract

Closes #961

## Testing

- Targeted Vitest tests passed before branch isolation
- Vue TypeScript check passed before branch isolation
- ESLint passed before branch isolation