### PR TITLE
Harden alert evaluation

### DIFF
--- a/src/backend/apps/alert/api/serializers/policy.py
+++ b/src/backend/apps/alert/api/serializers/policy.py
@@ -10,6 +10,9 @@ from apps.alert.models import AlertPolicy
 from apps.alert.selectors.interface import notification_channels_for_policy
 from apps.alert.services.internal.metadata_resources import selected_resource_options
 
+_DEFAULT_EVALUATION_INTERVAL_SECONDS = 60
+
+
 class AlertPolicySerializer(serializers.ModelSerializer):
     notification_channels = serializers.SerializerMethodField(read_only=True)
     monitoring_resources = serializers.SerializerMethodField(read_only=True)
@@ -98,6 +101,28 @@ class AlertPolicySerializer(serializers.ModelSerializer):
             if recovery_duration < 0:
                 raise serializers.ValidationError(
                     {"recovery_rule": "Recovery duration must be zero or greater."}
+                )
+
+        if alert_type == AlertType.METRIC:
+            # Legacy policies predate this field. Normalize the default on write
+            # so old and new evaluators share the same cadence.
+            if trigger_rule.get("evaluation_interval_seconds") in (None, ""):
+                trigger_rule = {
+                    **trigger_rule,
+                    "evaluation_interval_seconds": _DEFAULT_EVALUATION_INTERVAL_SECONDS,
+                }
+                data["trigger_rule"] = trigger_rule
+                attrs["trigger_rule"] = trigger_rule
+            try:
+                evaluation_interval = int(
+                    trigger_rule.get("evaluation_interval_seconds")
+                    or _DEFAULT_EVALUATION_INTERVAL_SECONDS
+                )
+            except (TypeError, ValueError):
+                evaluation_interval = 0
+            if evaluation_interval < _DEFAULT_EVALUATION_INTERVAL_SECONDS:
+                raise serializers.ValidationError(
+                    {"trigger_rule": "Evaluation interval must be at least 60 seconds."}
                 )
 
         if not resource_type:

--- a/src/backend/apps/alert/migrations/0004_alertpolicy_last_evaluated_at.py
+++ b/src/backend/apps/alert/migrations/0004_alertpolicy_last_evaluated_at.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("alerts", "0003_remove_alert_notification_log"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="alertpolicy",
+            name="last_evaluated_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True),
+        ),
+    ]

--- a/src/backend/apps/alert/models/alert_policy.py
+++ b/src/backend/apps/alert/models/alert_policy.py
@@ -36,6 +36,7 @@ class AlertPolicy(models.Model):
     trigger_rule = models.JSONField(default=dict)
     recovery_rule = models.JSONField(null=True, blank=True)
     notification_channel_ids = models.JSONField(default=list, blank=True)
+    last_evaluated_at = models.DateTimeField(null=True, blank=True, db_index=True)
     created_by = models.BigIntegerField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/src/backend/apps/alert/services/internal/evaluation.py
+++ b/src/backend/apps/alert/services/internal/evaluation.py
@@ -18,11 +18,13 @@ from apps.monitor.services.internal.metric_values import (
     value_from_resource_metrics,
     value_from_system_metric,
 )
-from apps.monitor.services.internal.resource_metrics import latest_resource_metric
 from apps.node.models import Node
 from apps.node.models.base import NodeRole
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_EVALUATION_INTERVAL_SECONDS = 60
+_DEFAULT_SAMPLE_FRESHNESS_SECONDS = 600
 
 _NODE_RESOURCE_BY_ROLE = {
     NodeRole.PROXY: ResourceType.SYNC_PROXY,
@@ -70,33 +72,167 @@ def _compare(operator: str, value: float, threshold: float) -> bool:
     return fn(value, threshold)
 
 
-def _duration_satisfied(
+def _rule_seconds(rule: dict, key: str, default: int) -> int:
+    try:
+        return max(0, int(rule.get(key, default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _sample_freshness_seconds(rule: dict) -> int:
+    """Return the maximum accepted sample age.
+
+    Resource and Control Plane metrics are currently collected at up to five-minute
+    intervals. A ten-minute compatibility window tolerates collector/scheduler skew
+    without treating an offline resource's final sample as current indefinitely.
+    """
+    return max(
+        _DEFAULT_EVALUATION_INTERVAL_SECONDS,
+        _rule_seconds(
+            rule,
+            "sample_freshness_seconds",
+            _DEFAULT_SAMPLE_FRESHNESS_SECONDS,
+        ),
+    )
+
+
+def _condition_state(
     *,
-    organization_id: int,
-    resource_type: str,
-    resource_id: str,
+    samples: list,
+    value_getter,
     metric_key: str,
     operator: str,
     threshold: float,
     duration_seconds: int,
-) -> bool:
+    now,
+    freshness_seconds: int,
+) -> tuple[bool | None, bool]:
+    """Return ``(current_match, sustained_match)`` for ordered samples.
+
+    ``current_match`` is ``None`` when the latest sample is absent, stale, or has
+    no usable value. A positive duration requires at least two matching samples
+    whose timestamps cover the configured duration; one observation is never
+    treated as proof of a sustained condition.
+    """
+    if not samples:
+        return None, False
+    latest = samples[-1]
+    if (now - latest.timestamp).total_seconds() > freshness_seconds:
+        return None, False
+    latest_value = value_getter(latest, metric_key)
+    if latest_value is None:
+        return None, False
+    current_match = _compare(operator, latest_value, threshold)
+    if not current_match:
+        return False, False
+
     duration = max(0, int(duration_seconds or 0))
     if duration <= 0:
-        return True
-    since = timezone.now() - timedelta(seconds=duration)
-    samples = ResourceMetric.objects.filter(
-        organization_id=organization_id,
-        resource_type=resource_type,
-        resource_id=str(resource_id),
-        timestamp__gte=since,
-    ).order_by("timestamp")
-    if not samples.exists():
-        return False
-    for sample in samples:
-        value = value_from_resource_metrics(sample.metrics or {}, metric_key)
+        return True, True
+
+    matching_tail = []
+    for sample in reversed(samples):
+        value = value_getter(sample, metric_key)
         if value is None or not _compare(operator, value, threshold):
-            return False
-    return True
+            break
+        matching_tail.append(sample)
+    if len(matching_tail) < 2:
+        return True, False
+    covered_seconds = (
+        matching_tail[0].timestamp - matching_tail[-1].timestamp
+    ).total_seconds()
+    return True, covered_seconds >= duration
+
+
+def _resource_samples(policy: AlertPolicy, resource_id: str, rule: dict, now) -> list:
+    duration = max(
+        _rule_seconds(rule, "duration_seconds", 0),
+        _rule_seconds(policy.recovery_rule or {}, "duration_seconds", 0),
+    )
+    since = now - timedelta(
+        seconds=duration + _sample_freshness_seconds(rule)
+    )
+    return list(
+        ResourceMetric.objects.filter(
+            organization_id=policy.organization_id,
+            resource_type=policy.resource_type,
+            resource_id=str(resource_id),
+            timestamp__gte=since,
+        ).order_by("timestamp")
+    )
+
+
+def _system_samples(rule: dict, recovery_rule: dict, now) -> tuple[list, object | None]:
+    latest = SystemMetric.objects.select_related("host").order_by("-timestamp").first()
+    if latest is None:
+        return [], None
+    duration = max(
+        _rule_seconds(rule, "duration_seconds", 0),
+        _rule_seconds(recovery_rule, "duration_seconds", 0),
+    )
+    since = now - timedelta(
+        seconds=duration + _sample_freshness_seconds(rule)
+    )
+    qs = SystemMetric.objects.filter(timestamp__gte=since)
+    if latest.host_id is not None:
+        qs = qs.filter(host_id=latest.host_id)
+    else:
+        qs = qs.filter(host__isnull=True)
+    return list(qs.order_by("timestamp")), latest.host
+
+
+def _resource_value(sample: ResourceMetric, metric_key: str) -> float | None:
+    return value_from_resource_metrics(sample.metrics or {}, metric_key)
+
+
+def _system_value(sample: SystemMetric, metric_key: str) -> float | None:
+    return value_from_system_metric(sample, metric_key)
+
+
+def _recovery_satisfied(
+    *,
+    policy: AlertPolicy,
+    samples: list,
+    value_getter,
+    metric_key: str,
+    now,
+    freshness_seconds: int,
+) -> bool:
+    recovery = policy.recovery_rule
+    if not recovery:
+        # Compatibility for policies created before recovery controls existed:
+        # resolve immediately when the firing condition no longer matches.
+        return True
+    if recovery.get("enabled") is False:
+        return False
+    trigger = policy.trigger_rule or {}
+    operator = str(recovery.get("operator") or _inverse_operator(trigger.get("operator")))
+    try:
+        threshold = float(recovery.get("threshold", trigger.get("threshold", 0)))
+    except (TypeError, ValueError):
+        return False
+    current, sustained = _condition_state(
+        samples=samples,
+        value_getter=value_getter,
+        metric_key=metric_key,
+        operator=operator,
+        threshold=threshold,
+        duration_seconds=_rule_seconds(recovery, "duration_seconds", 0),
+        now=now,
+        freshness_seconds=freshness_seconds,
+    )
+    return current is True and sustained
+
+
+def _inverse_operator(operator: object) -> str:
+    return {
+        ">": "<=",
+        ">=": "<",
+        "<": ">=",
+        "<=": ">",
+        "==": "!=",
+        "!=": "==",
+    }.get(str(operator or ">"), "<=")
 
 
 def _evaluate_metric_policy(policy: AlertPolicy) -> None:
@@ -108,40 +244,60 @@ def _evaluate_metric_policy(policy: AlertPolicy) -> None:
     if not metric_key:
         return
 
+    now = timezone.now()
+    freshness_seconds = _sample_freshness_seconds(rule)
     for resource_id in _policy_resource_ids(policy):
         if policy.resource_type == ResourceType.SYSTEM:
-            system = SystemMetric.objects.order_by("-timestamp").first()
-            if system is None:
+            samples, _host = _system_samples(rule, policy.recovery_rule or {}, now)
+            if not samples:
+                logger.info(
+                    "alert metric sample unavailable or stale policy=%s resource_type=%s resource_id=%s",
+                    policy.id,
+                    policy.resource_type,
+                    resource_id,
+                )
                 continue
-            value = value_from_system_metric(system, metric_key)
+            latest = samples[-1]
+            value = _system_value(latest, metric_key)
             resource_name = "Control Plane"
+            value_getter = _system_value
         else:
-            sample = latest_resource_metric(
-                organization_id=policy.organization_id,
-                resource_type=policy.resource_type,
-                resource_id=resource_id,
-            )
-            if sample is None:
-                _maybe_resolve_metric(policy, resource_id)
+            samples = _resource_samples(policy, resource_id, rule, now)
+            if not samples:
+                logger.info(
+                    "alert metric sample unavailable or stale policy=%s resource_type=%s resource_id=%s",
+                    policy.id,
+                    policy.resource_type,
+                    resource_id,
+                )
                 continue
-            value = value_from_resource_metrics(sample.metrics or {}, metric_key)
-            resource_name = sample.resource_name or resource_id
-            if duration_seconds > 0 and not _duration_satisfied(
-                organization_id=policy.organization_id,
-                resource_type=policy.resource_type,
-                resource_id=resource_id,
-                metric_key=metric_key,
-                operator=operator,
-                threshold=threshold,
-                duration_seconds=duration_seconds,
-            ):
-                _maybe_resolve_metric(policy, resource_id)
-                continue
+            latest = samples[-1]
+            value = _resource_value(latest, metric_key)
+            resource_name = latest.resource_name or resource_id
+            value_getter = _resource_value
 
         if value is None:
             continue
 
-        if _compare(operator, value, threshold):
+        current_match, sustained_match = _condition_state(
+            samples=samples,
+            value_getter=value_getter,
+            metric_key=metric_key,
+            operator=operator,
+            threshold=threshold,
+            duration_seconds=duration_seconds,
+            now=now,
+            freshness_seconds=freshness_seconds,
+        )
+        if current_match is None:
+            logger.info(
+                "alert metric sample unavailable or stale policy=%s resource_type=%s resource_id=%s",
+                policy.id,
+                policy.resource_type,
+                resource_id,
+            )
+            continue
+        if sustained_match:
             fire_alert(
                 policy,
                 resource=_ResourceStub(resource_id, resource_name),
@@ -151,7 +307,14 @@ def _evaluate_metric_policy(policy: AlertPolicy) -> None:
                 alert_key=metric_key,
                 metadata={"metric_key": metric_key, "value": value},
             )
-        else:
+        elif current_match is False and _recovery_satisfied(
+            policy=policy,
+            samples=samples,
+            value_getter=value_getter,
+            metric_key=metric_key,
+            now=now,
+            freshness_seconds=freshness_seconds,
+        ):
             _maybe_resolve_metric(policy, resource_id)
 
 
@@ -233,6 +396,24 @@ def _evaluate_system_policy(policy: AlertPolicy) -> None:
         _evaluate_metric_policy(policy)
 
 
+def _evaluation_interval_seconds(policy: AlertPolicy) -> int:
+    return max(
+        _DEFAULT_EVALUATION_INTERVAL_SECONDS,
+        _rule_seconds(
+            policy.trigger_rule or {},
+            "evaluation_interval_seconds",
+            _DEFAULT_EVALUATION_INTERVAL_SECONDS,
+        ),
+    )
+
+
+def _evaluation_due(policy: AlertPolicy, now) -> bool:
+    if policy.last_evaluated_at is None:
+        return True
+    elapsed = (now - policy.last_evaluated_at).total_seconds()
+    return elapsed >= _evaluation_interval_seconds(policy)
+
+
 def evaluate_organization_policies(*, organization_id: int | None = None) -> dict:
     qs = AlertPolicy.objects.filter(enabled=True).exclude(type=AlertType.TASK).exclude(
         type=AlertType.EVENT
@@ -245,6 +426,22 @@ def evaluate_organization_policies(*, organization_id: int | None = None) -> dic
         if _policy_silenced(policy):
             counts["skipped"] += 1
             continue
+        evaluated_at = timezone.now()
+        if not _evaluation_due(policy, evaluated_at):
+            counts["skipped"] += 1
+            continue
+        # Persist the attempt before evaluation so a failing policy cannot be
+        # retried in a tight loop by overlapping scheduler runs.
+        claimed = AlertPolicy.objects.filter(
+            pk=policy.pk,
+            last_evaluated_at=policy.last_evaluated_at,
+        ).update(
+            last_evaluated_at=evaluated_at
+        )
+        if not claimed:
+            counts["skipped"] += 1
+            continue
+        policy.last_evaluated_at = evaluated_at
         try:
             if policy.type == AlertType.METRIC:
                 _evaluate_metric_policy(policy)

--- a/src/backend/apps/alert/tests/test_api.py
+++ b/src/backend/apps/alert/tests/test_api.py
@@ -27,6 +27,39 @@ def org_user_client(db):
 
 
 @pytest.mark.django_db
+def test_legacy_metric_policy_can_be_read_and_saved_without_interval(org_user_client):
+    client, org = org_user_client
+    policy = AlertPolicy.objects.create(
+        organization=org,
+        name="Legacy CPU",
+        type=AlertType.METRIC,
+        severity=AlertSeverity.WARNING,
+        enabled=True,
+        resource_type="system",
+        scope="all",
+        trigger_rule={
+            "metric_key": "cpu_usage",
+            "operator": ">=",
+            "threshold": 80,
+            "duration_seconds": 0,
+        },
+    )
+
+    response = client.patch(
+        f"/api/v1/alerts/policies/{policy.id}/",
+        {"description": "Updated legacy policy"},
+        format="json",
+        HTTP_X_ORG_KEY=org.key,
+    )
+
+    assert response.status_code == 200, response.content
+    policy.refresh_from_db()
+    assert policy.description == "Updated legacy policy"
+    assert policy.trigger_rule["evaluation_interval_seconds"] == 60
+    assert response.data["trigger_rule"]["evaluation_interval_seconds"] == 60
+
+
+@pytest.mark.django_db
 def test_policy_crud_and_record_actions(org_user_client):
     client, org = org_user_client
     headers = {"HTTP_X_ORG_KEY": org.key}

--- a/src/backend/apps/alert/tests/test_evaluation.py
+++ b/src/backend/apps/alert/tests/test_evaluation.py
@@ -9,6 +9,7 @@ from apps.alert.constants import AlertType, ResourceType
 from apps.alert.models import AlertPolicy, AlertRecord
 from apps.alert.services.internal.evaluation import evaluate_organization_policies
 from apps.iam.models import Organization
+from apps.monitor.models import DeploymentHost, ResourceMetric, SystemMetric
 from apps.monitor.services.internal.resource_metrics import record_resource_metric
 from apps.node.models import Node
 from apps.node.models.base import NodeRole
@@ -47,6 +48,84 @@ def test_metric_policy_fires_on_high_cpu(db):
 
 
 @pytest.mark.django_db
+def test_source_host_memory_policy_uses_agent_resource_metrics(db):
+    org = Organization.objects.create(key="source-host-memory", name="Source Host Memory")
+    node = Node.objects.create(
+        organization=org,
+        name="DESKTOP-LPMO3SJ",
+        role=NodeRole.AGENT,
+    )
+    policy = AlertPolicy.objects.create(
+        organization=org,
+        name="Source host memory",
+        type=AlertType.METRIC,
+        severity="critical",
+        enabled=True,
+        resource_type=ResourceType.AGENT_PROXY,
+        scope="selected",
+        resource_ids=[str(node.id)],
+        trigger_rule={
+            "metric_key": "memory_usage",
+            "operator": ">=",
+            "threshold": 39,
+            "duration_seconds": 0,
+            "evaluation_interval_seconds": 60,
+        },
+    )
+    record_resource_metric(
+        organization_id=org.id,
+        resource_type=ResourceType.AGENT_PROXY,
+        resource_id=str(node.id),
+        metrics={"memory_usage": 40},
+        resource_name=node.name,
+    )
+
+    evaluate_organization_policies(organization_id=org.id)
+
+    alert = AlertRecord.objects.get(organization=org, policy_id=policy.id)
+    assert alert.resource_type == ResourceType.AGENT_PROXY
+    assert alert.resource_id == str(node.id)
+    assert alert.resource_name == node.name
+
+
+@pytest.mark.django_db
+def test_control_plane_policy_does_not_read_source_host_metrics(db):
+    org = Organization.objects.create(key="control-plane-memory", name="Control Plane Memory")
+    node = Node.objects.create(
+        organization=org,
+        name="DESKTOP-LPMO3SJ",
+        role=NodeRole.AGENT,
+    )
+    policy = AlertPolicy.objects.create(
+        organization=org,
+        name="Control plane memory",
+        type=AlertType.METRIC,
+        severity="critical",
+        enabled=True,
+        resource_type=ResourceType.SYSTEM,
+        scope="all",
+        trigger_rule={
+            "metric_key": "memory_usage",
+            "operator": ">=",
+            "threshold": 39,
+            "duration_seconds": 0,
+            "evaluation_interval_seconds": 60,
+        },
+    )
+    record_resource_metric(
+        organization_id=org.id,
+        resource_type=ResourceType.AGENT_PROXY,
+        resource_id=str(node.id),
+        metrics={"memory_usage": 40},
+        resource_name=node.name,
+    )
+
+    evaluate_organization_policies(organization_id=org.id)
+
+    assert not AlertRecord.objects.filter(organization=org, policy_id=policy.id).exists()
+
+
+@pytest.mark.django_db
 def test_availability_policy_fires_on_stale_node(db):
     org = Organization.objects.create(key="eval-org-2", name="Eval Org 2")
     node = Node.objects.create(
@@ -69,3 +148,256 @@ def test_availability_policy_fires_on_stale_node(db):
     )
     evaluate_organization_policies(organization_id=org.id)
     assert AlertRecord.objects.filter(organization=org, resource_id=str(node.id)).exists()
+
+
+@pytest.mark.django_db
+def test_duration_uses_consecutive_fresh_samples_at_collector_cadence(db):
+    org = Organization.objects.create(key="duration-org", name="Duration Org")
+    policy = AlertPolicy.objects.create(
+        organization=org,
+        name="Memory",
+        type=AlertType.METRIC,
+        severity="warning",
+        resource_type=ResourceType.AGENT_PROXY,
+        scope="selected",
+        resource_ids=["14"],
+        trigger_rule={
+            "metric_key": "memory_usage",
+            "operator": ">=",
+            "threshold": 6,
+            "duration_seconds": 60,
+            "evaluation_interval_seconds": 60,
+        },
+    )
+    older = record_resource_metric(
+        organization_id=org.id,
+        resource_type=ResourceType.AGENT_PROXY,
+        resource_id="14",
+        resource_name="hfl-source-test-whx-1",
+        metrics={"memory_usage": 14},
+    )
+    latest = record_resource_metric(
+        organization_id=org.id,
+        resource_type=ResourceType.AGENT_PROXY,
+        resource_id="14",
+        resource_name="hfl-source-test-whx-1",
+        metrics={"memory_usage": 15},
+    )
+    now = timezone.now()
+    ResourceMetric.objects.filter(pk=older.pk).update(timestamp=now - timedelta(minutes=7))
+    ResourceMetric.objects.filter(pk=latest.pk).update(timestamp=now - timedelta(minutes=2))
+
+    evaluate_organization_policies(organization_id=org.id)
+
+    alert = AlertRecord.objects.get(policy_id=policy.id)
+    assert alert.resource_name == "hfl-source-test-whx-1"
+
+
+@pytest.mark.django_db
+def test_stale_metric_neither_fires_nor_resolves(db):
+    org = Organization.objects.create(key="stale-org", name="Stale Org")
+    policy = AlertPolicy.objects.create(
+        organization=org,
+        name="Stale memory",
+        type=AlertType.METRIC,
+        severity="warning",
+        resource_type=ResourceType.AGENT_PROXY,
+        scope="selected",
+        resource_ids=["14"],
+        trigger_rule={
+            "metric_key": "memory_usage",
+            "operator": ">=",
+            "threshold": 50,
+            "duration_seconds": 0,
+            "evaluation_interval_seconds": 60,
+        },
+    )
+    sample = record_resource_metric(
+        organization_id=org.id,
+        resource_type=ResourceType.AGENT_PROXY,
+        resource_id="14",
+        metrics={"memory_usage": 10},
+    )
+    ResourceMetric.objects.filter(pk=sample.pk).update(
+        timestamp=timezone.now() - timedelta(minutes=11)
+    )
+    existing = AlertRecord.objects.create(
+        organization=org,
+        policy_id=policy.id,
+        type=AlertType.METRIC,
+        severity="warning",
+        status="firing",
+        resource_type=ResourceType.AGENT_PROXY,
+        resource_id="14",
+        title="existing",
+        fingerprint=f"{policy.id}|{org.id}|14|memory_usage",
+    )
+
+    evaluate_organization_policies(organization_id=org.id)
+
+    existing.refresh_from_db()
+    assert existing.status == "firing"
+
+
+@pytest.mark.django_db
+def test_recovery_requires_configured_threshold_and_duration(db):
+    org = Organization.objects.create(key="recovery-org", name="Recovery Org")
+    policy = AlertPolicy.objects.create(
+        organization=org,
+        name="Recover memory",
+        type=AlertType.METRIC,
+        severity="warning",
+        resource_type=ResourceType.AGENT_PROXY,
+        scope="selected",
+        resource_ids=["14"],
+        trigger_rule={
+            "metric_key": "memory_usage",
+            "operator": ">=",
+            "threshold": 80,
+            "duration_seconds": 0,
+            "evaluation_interval_seconds": 60,
+        },
+        recovery_rule={
+            "enabled": True,
+            "operator": "<",
+            "threshold": 70,
+            "duration_seconds": 180,
+        },
+    )
+    alert = AlertRecord.objects.create(
+        organization=org,
+        policy_id=policy.id,
+        type=AlertType.METRIC,
+        severity="warning",
+        status="firing",
+        resource_type=ResourceType.AGENT_PROXY,
+        resource_id="14",
+        title="existing",
+        fingerprint=f"{policy.id}|{org.id}|14|memory_usage",
+    )
+    older = record_resource_metric(
+        organization_id=org.id,
+        resource_type=ResourceType.AGENT_PROXY,
+        resource_id="14",
+        metrics={"memory_usage": 65},
+    )
+    latest = record_resource_metric(
+        organization_id=org.id,
+        resource_type=ResourceType.AGENT_PROXY,
+        resource_id="14",
+        metrics={"memory_usage": 60},
+    )
+    now = timezone.now()
+    ResourceMetric.objects.filter(pk=older.pk).update(timestamp=now - timedelta(minutes=2))
+    ResourceMetric.objects.filter(pk=latest.pk).update(timestamp=now - timedelta(minutes=1))
+
+    evaluate_organization_policies(organization_id=org.id)
+
+    alert.refresh_from_db()
+    assert alert.status == "firing"
+
+    ResourceMetric.objects.filter(pk=older.pk).update(timestamp=now - timedelta(minutes=5))
+    AlertPolicy.objects.filter(pk=policy.pk).update(last_evaluated_at=None)
+    evaluate_organization_policies(organization_id=org.id)
+
+    alert.refresh_from_db()
+    assert alert.status == "resolved"
+
+
+@pytest.mark.django_db
+def test_policy_evaluation_interval_is_enforced(db):
+    org = Organization.objects.create(key="interval-org", name="Interval Org")
+    policy = AlertPolicy.objects.create(
+        organization=org,
+        name="Interval CPU",
+        type=AlertType.METRIC,
+        severity="warning",
+        resource_type=ResourceType.SYNC_PROXY,
+        scope="selected",
+        resource_ids=["1"],
+        trigger_rule={
+            "metric_key": "cpu_usage",
+            "operator": ">",
+            "threshold": 80,
+            "duration_seconds": 0,
+            "evaluation_interval_seconds": 300,
+        },
+    )
+    record_resource_metric(
+        organization_id=org.id,
+        resource_type=ResourceType.SYNC_PROXY,
+        resource_id="1",
+        metrics={"cpu_usage": 10},
+    )
+    evaluate_organization_policies(organization_id=org.id)
+    record_resource_metric(
+        organization_id=org.id,
+        resource_type=ResourceType.SYNC_PROXY,
+        resource_id="1",
+        metrics={"cpu_usage": 95},
+    )
+
+    result = evaluate_organization_policies(organization_id=org.id)
+
+    assert result["skipped"] == 1
+    assert not AlertRecord.objects.filter(policy_id=policy.id).exists()
+
+
+@pytest.mark.django_db
+def test_legacy_metric_policy_uses_default_evaluation_interval(db):
+    org = Organization.objects.create(key="legacy-interval-org", name="Legacy Interval Org")
+    policy = AlertPolicy.objects.create(
+        organization=org,
+        name="Legacy CPU",
+        type=AlertType.METRIC,
+        severity="warning",
+        resource_type=ResourceType.SYNC_PROXY,
+        scope="selected",
+        resource_ids=["1"],
+        trigger_rule={
+            "metric_key": "cpu_usage",
+            "operator": ">",
+            "threshold": 80,
+            "duration_seconds": 0,
+        },
+    )
+    record_resource_metric(
+        organization_id=org.id,
+        resource_type=ResourceType.SYNC_PROXY,
+        resource_id="1",
+        metrics={"cpu_usage": 95},
+    )
+
+    result = evaluate_organization_policies(organization_id=org.id)
+
+    assert result["metric"] == 1
+    assert AlertRecord.objects.filter(policy_id=policy.id).exists()
+
+
+@pytest.mark.django_db
+def test_control_plane_metrics_are_shared_but_alerts_are_tenant_scoped(db):
+    first_org = Organization.objects.create(key="system-one", name="System One")
+    second_org = Organization.objects.create(key="system-two", name="System Two")
+    for org in (first_org, second_org):
+        AlertPolicy.objects.create(
+            organization=org,
+            name="Control Plane CPU",
+            type=AlertType.METRIC,
+            severity="warning",
+            resource_type=ResourceType.SYSTEM,
+            scope="all",
+            trigger_rule={
+                "metric_key": "cpu_usage",
+                "operator": ">",
+                "threshold": 80,
+                "duration_seconds": 0,
+                "evaluation_interval_seconds": 60,
+            },
+        )
+    host = DeploymentHost.objects.create(hostname="control-plane-1")
+    SystemMetric.objects.create(host=host, cpu={"usage_percent": 95})
+
+    evaluate_organization_policies()
+
+    assert AlertRecord.objects.filter(organization=first_org).count() == 1
+    assert AlertRecord.objects.filter(organization=second_org).count() == 1


### PR DESCRIPTION
## Summary

- Enforce evaluation intervals with a safe default for legacy metric policies
- Require fresh consecutive samples for sustained firing and recovery
- Preserve unknown state for stale samples and isolate shared Control Plane alerts by tenant
- Add an additive `last_evaluated_at` migration and compatibility coverage

Closes #963

## Testing

- Backend alert API and evaluator tests passed: 18 tests
- Frontend full suite passed: 255 files, 1388 tests
- Frontend production build passed
- `git diff --check` passed

Note: backend API verification was run with HTTPS redirect disabled only for the test process because the repository environment enables `SECURE_SSL_REDIRECT`.