### PR TITLE
fix: align backup and operational behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -555,6 +555,10 @@ GOSUMDB=sum.golang.org
 # Enable periodic storage maintenance.
 # STORAGE_MAINTENANCE_ENABLED=true
 
+# Run Quick Maintenance every 6 hours and Full Maintenance every 24 hours.
+# STORAGE_MAINTENANCE_QUICK_INTERVAL_SECONDS=21600
+# STORAGE_MAINTENANCE_FULL_INTERVAL_SECONDS=86400
+
 # Repository online-status check interval in seconds (minimum 60).
 # STORAGE_REPOSITORY_HEALTH_INTERVAL_SECONDS=300
 

--- a/src/agent/internal/engine/lifecycle.go
+++ b/src/agent/internal/engine/lifecycle.go
@@ -89,6 +89,9 @@ func (e *Engine) runAgentUpgrade(ctx context.Context, rep ReporterSink, taskID s
 		stagedArchive,
 		stagedInstaller,
 		logDir,
+		string(cfg.InstallationMode),
+		cfg.RunAsUser,
+		cfg.RunAsHome,
 		cfg.InstallationMode == model.InstallationModeUser || cfg.InstallationMode == model.InstallationModeUserContinuous,
 	); err != nil {
 		slog.Warn("detached upgrade schedule failed", "err", err, "upgrade_log", upgradeLog)

--- a/src/agent/internal/platform/install/detached_run_unix_test.go
+++ b/src/agent/internal/platform/install/detached_run_unix_test.go
@@ -126,6 +126,9 @@ func TestUnixUserUpgradeScriptUsesUserLifecycleForRecovery(t *testing.T) {
 		filepath.Join(dir, "package.tar.gz"),
 		filepath.Join(dir, "installer", "install.sh"),
 		filepath.Join(dir, "logs"),
+		"user",
+		"",
+		"",
 		true,
 		scriptPath,
 	)
@@ -139,6 +142,7 @@ func TestUnixUserUpgradeScriptUsesUserLifecycleForRecovery(t *testing.T) {
 	text := string(body)
 	for _, expected := range []string{
 		"USER_INSTALL=1",
+		`HFL_INSTALLATION_MODE="$INSTALLATION_MODE"`,
 		`systemctl --user "$@"`,
 		"hfl_systemctl start hyperfilelens-agent.service",
 	} {

--- a/src/agent/internal/platform/install/install_ps1_test.go
+++ b/src/agent/internal/platform/install/install_ps1_test.go
@@ -250,6 +250,18 @@ func TestInstallPs1UpgradePersistsMissingInstallationMode(t *testing.T) {
 	}
 }
 
+func TestInstallPs1RecoversModeForStagedUpgradeInstaller(t *testing.T) {
+	source := readPackagingInstallScript(t)
+	for _, want := range []string{
+		`$stagedInstallerSuffix = "\lifecycle\upgrade\installer"`,
+		`$existingEnvs += (Join-Path $stagedAgentRoot "config\agent.env")`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("staged install.ps1 must recover the persisted mode using %q", want)
+		}
+	}
+}
+
 func TestInstallPs1ValidatesPurgePathBeforeUninstallLogging(t *testing.T) {
 	source := readPackagingInstallScript(t)
 	uninstallStart := strings.Index(source, "function Invoke-Uninstall")

--- a/src/agent/internal/platform/install/install_sh_test.go
+++ b/src/agent/internal/platform/install/install_sh_test.go
@@ -163,6 +163,19 @@ func TestInstallShellDetectsUserModeFromCustomXDGDataHome(t *testing.T) {
 	}
 }
 
+func TestInstallShellRecoversModeForStagedUpgradeInstaller(t *testing.T) {
+	body := readPackagingInstallShell(t)
+	for _, want := range []string{
+		`*/lifecycle/upgrade/installer)`,
+		`PERSISTED_ENV="${BUNDLE_ROOT%/lifecycle/upgrade/installer}/config/agent.env"`,
+		`"${BUNDLE_ROOT}" != */lifecycle/upgrade/installer`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("staged install.sh must recover the persisted mode using %q", want)
+		}
+	}
+}
+
 func TestInstallShellSupportsSpecifiedUserContinuousMode(t *testing.T) {
 	body := readPackagingInstallShell(t)
 	for _, want := range []string{

--- a/src/agent/internal/platform/install/local_upgrade_unix.go
+++ b/src/agent/internal/platform/install/local_upgrade_unix.go
@@ -14,7 +14,7 @@ const upgradeDelaySecond = 5
 // ScheduleDetachedUpgrade runs install.sh upgrade after a short delay so the agent
 // can report task.result before stop_service terminates the process.
 func ScheduleDetachedUpgrade(
-	archivePath, installerPath, logDir string,
+	archivePath, installerPath, logDir, installationMode, runAsUser, runAsHome string,
 	userInstall bool,
 ) error {
 	if archivePath = strings.TrimSpace(archivePath); archivePath == "" {
@@ -34,6 +34,9 @@ func ScheduleDetachedUpgrade(
 		archivePath,
 		installerPath,
 		logDir,
+		installationMode,
+		runAsUser,
+		runAsHome,
 		userInstall,
 		scriptPath,
 	); err != nil {
@@ -59,7 +62,7 @@ func ScheduleDetachedUpgrade(
 }
 
 func writeUnixUpgradeScript(
-	archivePath, installerPath, logDir string,
+	archivePath, installerPath, logDir, installationMode, runAsUser, runAsHome string,
 	userInstall bool,
 	scriptPath string,
 ) error {
@@ -75,6 +78,9 @@ ARCHIVE=%q
 INSTALL_SH=%q
 LOG_FILE=%q
 PENDING_DIR=%q
+INSTALLATION_MODE=%q
+RUN_AS_USER=%q
+RUN_AS_HOME=%q
 USER_INSTALL=%s
 SLEEP_SECONDS=%d
 
@@ -116,7 +122,8 @@ if [[ ! -f "$ARCHIVE" ]]; then
 fi
 
 set +e
-bash "$INSTALL_SH" upgrade --from "$ARCHIVE" --yes --quiet-footer
+HFL_INSTALLATION_MODE="$INSTALLATION_MODE" HFL_RUN_AS_USER="$RUN_AS_USER" \
+HFL_RUN_AS_HOME="$RUN_AS_HOME" bash "$INSTALL_SH" upgrade --from "$ARCHIVE" --yes --quiet-footer
 rc=$?
 set -e
 if [[ "$rc" -eq 0 ]]; then
@@ -145,6 +152,9 @@ exit "$rc"
 		installerPath,
 		logFile,
 		pendingDir,
+		installationMode,
+		runAsUser,
+		runAsHome,
 		userInstallFlag,
 		upgradeDelaySecond,
 		unixGatewaySidecarUpgradeHook,

--- a/src/agent/internal/platform/install/local_upgrade_windows.go
+++ b/src/agent/internal/platform/install/local_upgrade_windows.go
@@ -17,7 +17,7 @@ const (
 // ScheduleDetachedUpgrade runs install.ps1 upgrade after a short delay so the agent
 // can report task.result before the service stops.
 func ScheduleDetachedUpgrade(
-	archivePath, installerPath, logDir string,
+	archivePath, installerPath, logDir, installationMode, runAsUser, runAsHome string,
 	userInstall bool,
 ) error {
 	archivePath = strings.TrimSpace(archivePath)
@@ -38,6 +38,9 @@ func ScheduleDetachedUpgrade(
 		archivePath,
 		installerPath,
 		logDir,
+		installationMode,
+		runAsUser,
+		runAsHome,
 		userInstall,
 		scriptPath,
 	); err != nil {
@@ -63,7 +66,7 @@ func ScheduleDetachedUpgrade(
 }
 
 func writeWindowsUpgradeScript(
-	archivePath, installerPath, logDir string,
+	archivePath, installerPath, logDir, installationMode, runAsUser, runAsHome string,
 	userInstall bool,
 	scriptPath string,
 ) error {
@@ -77,6 +80,9 @@ func writeWindowsUpgradeScript(
 $install = %q
 $archive = %q
 $pending = %q
+$installationMode = %q
+$runAsUser = %q
+$runAsHome = %q
 $userInstall = %s
 $currentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
 $runtimeTaskName = if ($userInstall) { "HyperFileLensAgent.User.$currentSid" } else { 'HyperFileLensAgent' }
@@ -105,6 +111,9 @@ try {
   }
 
   Log "running install.ps1 upgrade"
+  $env:HFL_INSTALLATION_MODE = $installationMode
+  $env:HFL_RUN_AS_USER = $runAsUser
+  $env:HFL_RUN_AS_HOME = $runAsHome
   $upgradeArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $install, 'upgrade', '-From', $archive, '-Yes', '-QuietFooter')
   & powershell.exe @upgradeArgs 2>&1 | ForEach-Object {
     $line = ($_.ToString()).TrimEnd()
@@ -135,6 +144,9 @@ exit $rc
 		installerPath,
 		archivePath,
 		pendingDir,
+		installationMode,
+		runAsUser,
+		runAsHome,
 		userInstallFlag,
 		upgradeDelaySecond,
 	)

--- a/src/agent/internal/platform/pathsize/pathsize.go
+++ b/src/agent/internal/platform/pathsize/pathsize.go
@@ -15,14 +15,15 @@ import (
 
 var errDuUnsupported = errors.New("du does not support the requested options")
 
-// Estimate returns logical byte size for a file or directory path.
+// Estimate returns a byte-size estimate for a file or directory path.
 func Estimate(path string, pathType string) (uint64, error) {
 	return EstimateWithExclusions(path, pathType, nil)
 }
 
 // EstimateWithExclusions returns a size estimate without traversing the
-// supplied absolute paths. Unix uses du when its exclusion support is
-// available; other platforms and minimal du implementations use WalkDir.
+// supplied absolute paths. Unix uses allocated size from du when its required
+// options are available; other platforms and minimal du implementations use
+// logical file sizes from WalkDir.
 func EstimateWithExclusions(path string, pathType string, exclusions []string) (uint64, error) {
 	return EstimateWithExclusionsContext(context.Background(), path, pathType, exclusions)
 }
@@ -58,7 +59,15 @@ func EstimateWithExclusionsContext(ctx context.Context, path string, pathType st
 }
 
 func duBytes(ctx context.Context, path string, exclusions []string) (uint64, error) {
+	// BSD du (macOS) has no -b flag. -k reports allocated disk usage in KiB,
+	// which is the capacity reference requested by HFL. GNU du keeps the
+	// existing byte mode for Linux and other Unix platforms.
 	args := []string{"-sb"}
+	unitBytes := uint64(1)
+	if runtime.GOOS == "darwin" {
+		args = []string{"-sk"}
+		unitBytes = 1024
+	}
 	for _, excluded := range exclusions {
 		if value := strings.TrimSpace(excluded); value != "" {
 			args = append(args, "--exclude="+filepath.Clean(value))
@@ -81,14 +90,30 @@ func duBytes(ctx context.Context, path string, exclusions []string) (uint64, err
 		stderrText := strings.ToLower(string(exitErr.Stderr))
 		if strings.Contains(stderrText, "unrecognized option") ||
 			strings.Contains(stderrText, "illegal option") ||
+			strings.Contains(stderrText, "invalid option") ||
 			strings.Contains(stderrText, "unknown option") {
 			return 0, errDuUnsupported
 		}
 		if strings.Contains(stderrText, "permission denied") {
+			if size, parseErr := parseDuBytes(output, unitBytes); parseErr == nil {
+				// du emits a valid summary but exits non-zero when macOS privacy
+				// controls hide part of a tree. Keep the usable partial total.
+				return size, nil
+			}
+			return 0, fs.ErrPermission
+		}
+		if strings.Contains(stderrText, "operation not permitted") {
+			if size, parseErr := parseDuBytes(output, unitBytes); parseErr == nil {
+				return size, nil
+			}
 			return 0, fs.ErrPermission
 		}
 		return 0, fmt.Errorf("du: %w", err)
 	}
+	return parseDuBytes(output, unitBytes)
+}
+
+func parseDuBytes(output []byte, unitBytes uint64) (uint64, error) {
 	fields := strings.Fields(strings.TrimSpace(string(output)))
 	if len(fields) == 0 {
 		return 0, fmt.Errorf("du returned empty output")
@@ -97,7 +122,10 @@ func duBytes(ctx context.Context, path string, exclusions []string) (uint64, err
 	if err != nil {
 		return 0, fmt.Errorf("parse du output: %w", err)
 	}
-	return parsed, nil
+	if unitBytes == 0 || parsed > ^uint64(0)/unitBytes {
+		return 0, fmt.Errorf("du output overflows byte count")
+	}
+	return parsed * unitBytes, nil
 }
 
 func walkBytes(ctx context.Context, root string, exclusions []string) (uint64, error) {
@@ -115,6 +143,11 @@ func walkBytes(ctx context.Context, root string, exclusions []string) (uint64, e
 			}
 		}
 		if walkErr != nil {
+			if path != root && os.IsPermission(walkErr) {
+				// macOS privacy controls can hide isolated subtrees. Skip those
+				// paths while retaining the readable portion of the estimate.
+				return nil
+			}
 			return walkErr
 		}
 		if entry.IsDir() {
@@ -122,6 +155,9 @@ func walkBytes(ctx context.Context, root string, exclusions []string) (uint64, e
 		}
 		info, infoErr := entry.Info()
 		if infoErr != nil {
+			if path != root && os.IsPermission(infoErr) {
+				return nil
+			}
 			return infoErr
 		}
 		if info.Size() > 0 {

--- a/src/agent/internal/platform/pathsize/pathsize_test.go
+++ b/src/agent/internal/platform/pathsize/pathsize_test.go
@@ -99,6 +99,71 @@ func TestDuErrorDoesNotTriggerSecondWalk(t *testing.T) {
 	}
 }
 
+func TestEstimateFallsBackWhenBSDDuRejectsGNUByteOption(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("du is not used on Windows")
+	}
+	root := t.TempDir()
+	writeSizeFile(t, filepath.Join(root, "file"), 7)
+	bin := t.TempDir()
+	du := filepath.Join(bin, "du")
+	if err := os.WriteFile(
+		du,
+		[]byte("#!/bin/sh\necho 'du: invalid option -- b' >&2\nexit 64\n"),
+		0o700,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+
+	size, err := EstimateWithExclusionsContext(context.Background(), root, "directory", nil)
+	if err != nil {
+		t.Fatalf("expected WalkDir fallback, got %v", err)
+	}
+	if size != 7 {
+		t.Fatalf("expected fallback size 7, got %d", size)
+	}
+}
+
+func TestEstimateUsesPartialDuSummaryWhenPrivacyBlocksPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("du is not used on Windows")
+	}
+	root := t.TempDir()
+	bin := t.TempDir()
+	du := filepath.Join(bin, "du")
+	if err := os.WriteFile(
+		du,
+		[]byte("#!/bin/sh\necho '7 '$2\necho 'du: Operation not permitted' >&2\nexit 1\n"),
+		0o700,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+
+	size, err := EstimateWithExclusionsContext(context.Background(), root, "directory", nil)
+	if err != nil {
+		t.Fatalf("expected partial du summary, got %v", err)
+	}
+	expected := uint64(7)
+	if runtime.GOOS == "darwin" {
+		expected *= 1024
+	}
+	if size != expected {
+		t.Fatalf("expected partial size %d, got %d", expected, size)
+	}
+}
+
+func TestParseDuBytesConvertsKiBToBytes(t *testing.T) {
+	size, err := parseDuBytes([]byte("111531404\t/Users/ghw\n"), 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != 114208157696 {
+		t.Fatalf("unexpected byte size %d", size)
+	}
+}
+
 func writeSizeFile(t *testing.T, path string, size int) {
 	t.Helper()
 	if err := os.WriteFile(path, make([]byte, size), 0o600); err != nil {

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -54,11 +54,23 @@ elseif ($BundleRoot.TrimEnd('\') -eq (Join-Path $userAgentRoot "bin").TrimEnd('\
 else {
   "system"
 }
-if (-not $env:HFL_INSTALLATION_MODE -and $BundleRoot.TrimEnd('\') -ne (Join-Path $userAgentRoot "bin").TrimEnd('\')) {
-  foreach ($existingEnv in @(
+if (-not $env:HFL_INSTALLATION_MODE) {
+  $existingEnvs = @()
+  $stagedInstallerSuffix = "\lifecycle\upgrade\installer"
+  $normalizedBundleRoot = $BundleRoot.TrimEnd('\')
+  if ($normalizedBundleRoot.EndsWith($stagedInstallerSuffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+    # Older Agents cannot pass their installation mode to the detached
+    # runner. Recover it from the Agent Root that owns the staged installer.
+    $stagedAgentRoot = $normalizedBundleRoot.Substring(0, $normalizedBundleRoot.Length - $stagedInstallerSuffix.Length)
+    $existingEnvs += (Join-Path $stagedAgentRoot "config\agent.env")
+  }
+  if ($normalizedBundleRoot -ne (Join-Path $userAgentRoot "bin").TrimEnd('\')) {
+    $existingEnvs += @(
       (Join-Path $machineAgentRoot "config\agent.env"),
       (Join-Path $legacyDataRoot "agent.env")
-    )) {
+    )
+  }
+  foreach ($existingEnv in $existingEnvs) {
     if (Test-Path -LiteralPath $existingEnv) {
       foreach ($line in Get-Content -LiteralPath $existingEnv) {
         if ($line -match '^HFL_INSTALLATION_MODE=(.+)$') { $InstallationMode = $Matches[1].Trim().ToLowerInvariant() }

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -38,12 +38,25 @@ unquote_env_value() {
 	fi
 	printf '%s' "${value}"
 }
-if [[ -z "${HFL_INSTALLATION_MODE:-}" && ( "${BUNDLE_ROOT}" == "/opt/hyperfilelens-agent" || "${BUNDLE_ROOT}" == "/opt/hyperfilelens-agent/bin" || "${BUNDLE_ROOT}" == "/Library/Application Support/HyperFileLens/Agent/bin" ) ]]; then
-	PERSISTED_ENV="/opt/hyperfilelens-agent/config/agent.env"
-	if [[ "$(uname -s)" == "Darwin" ]]; then
+if [[ -z "${HFL_INSTALLATION_MODE:-}" ]]; then
+	PERSISTED_ENV=""
+	case "${BUNDLE_ROOT}" in
+	*/lifecycle/upgrade/installer)
+		# Older Agents cannot pass their installation mode to the detached
+		# runner. The staged installer still has a trustworthy location below
+		# the persisted Agent Root, so bootstrap the mode from that root.
+		PERSISTED_ENV="${BUNDLE_ROOT%/lifecycle/upgrade/installer}/config/agent.env"
+		;;
+	/opt/hyperfilelens-agent | /opt/hyperfilelens-agent/bin)
+		PERSISTED_ENV="/opt/hyperfilelens-agent/config/agent.env"
+		;;
+	"/Library/Application Support/HyperFileLens/Agent/bin")
 		PERSISTED_ENV="/Library/Application Support/HyperFileLens/Agent/config/agent.env"
+		;;
+	esac
+	if [[ -n "${PERSISTED_ENV}" && ! -f "${PERSISTED_ENV}" && "${BUNDLE_ROOT}" != */lifecycle/upgrade/installer ]]; then
+		PERSISTED_ENV="/var/lib/hyperfilelens-agent/agent.env"
 	fi
-	[[ -f "${PERSISTED_ENV}" ]] || PERSISTED_ENV="/var/lib/hyperfilelens-agent/agent.env"
 	if [[ -f "${PERSISTED_ENV}" ]]; then
 		while IFS='=' read -r key value; do
 			value="$(unquote_env_value "${value}")"

--- a/src/backend/apps/protection/services/progress/step3_progress.py
+++ b/src/backend/apps/protection/services/progress/step3_progress.py
@@ -224,6 +224,17 @@ def compute_step3_display_percent(
     return round(raw, 2)
 
 
+def _safe_progress_total(*, bytes_done: int, candidate_total: int) -> int:
+    """Keep a running progress denominator strictly ahead of its numerator."""
+    if candidate_total <= 0 or bytes_done <= candidate_total:
+        return candidate_total
+    # A reference/estimate can be smaller than the logical bytes processed
+    # (for example du -sk counts allocated blocks). Keep the row meaningful
+    # without ever presenting 100% before the task reaches a terminal state.
+    adjusted = (bytes_done * 100 + 98) // 99
+    return max(candidate_total, adjusted, bytes_done + 1)
+
+
 _MIN_STEP3_SPEED_BPS = 100
 
 
@@ -389,18 +400,42 @@ def enrich_step3_backup_transfer(
         switch_latched = True
         kopia_total_locked = estimated_bytes
 
+    total_source = ""
+    total_adjusted = False
     if schema_version >= 2:
         # Schema-v2 reports the logical estimate independently from lane
-        # completeness. Keep a usable aggregate estimate visible while one
-        # lane is still sampling, without treating it as an exact total.
-        effective_total = (
-            _int(aggregate.get("bytes_total"))
-            if aggregate.get("bytes_total_known")
-            else estimated_bytes
+        # completeness. Prefer Kopia's estimate, then use the preflight du
+        # total as a clearly-marked reference when Kopia has no estimate yet.
+        kopia_total_known = bool(aggregate.get("bytes_total_known"))
+        kopia_total = _int(aggregate.get("bytes_total")) if kopia_total_known else estimated_bytes
+        previous_total = max(
+            _int(prev.get("bytes_total")),
+            _int(prev.get("kopia_total_locked")),
         )
+        if kopia_total > 0:
+            # A du fallback is only a temporary reference. As soon as Kopia
+            # reports a positive logical estimate, do not let a larger du
+            # value keep overriding it while claiming the source is Kopia.
+            previous_kopia_total = (
+                previous_total
+                if str(prev.get("bytes_total_source") or "").lower() == "kopia"
+                and not bool(prev.get("bytes_total_adjusted"))
+                else 0
+            )
+            effective_total = max(kopia_total, previous_kopia_total)
+            total_source = "kopia"
+        else:
+            effective_total = max(_int(du_total), previous_total)
+            total_source = "du_reference" if effective_total > 0 else ""
+        safe_total = _safe_progress_total(
+            bytes_done=processed_bytes,
+            candidate_total=effective_total,
+        )
+        total_adjusted = safe_total > effective_total
+        effective_total = safe_total
         switch_latched = effective_total > 0
         kopia_total_locked = effective_total
-        merged["bytes_total_estimated"] = not bool(aggregate.get("bytes_total_known"))
+        merged["bytes_total_estimated"] = total_source != "kopia" or not kopia_total_known
     elif switch_latched:
         effective_total = estimated_bytes if estimated_bytes > 0 else kopia_total_locked
         if not bool(aggregate.get("bytes_total_known")) and kopia_total_locked > 0:
@@ -418,11 +453,15 @@ def enrich_step3_backup_transfer(
     if effective_total > 0:
         merged["bytes_total"] = effective_total
         merged["bytes_total_known"] = True
-        merged["bytes_total_reference"] = not switch_latched
+        merged["bytes_total_reference"] = total_source == "du_reference" or total_adjusted
+        merged["bytes_total_source"] = total_source or "unknown"
+        merged["bytes_total_adjusted"] = total_adjusted
     else:
         merged.pop("bytes_total", None)
         merged["bytes_total_known"] = False
         merged["bytes_total_reference"] = False
+        merged.pop("bytes_total_source", None)
+        merged.pop("bytes_total_adjusted", None)
 
     phase = str(merged.get("phase") or "").lower()
     if schema_version >= 2 and effective_total <= 0:

--- a/src/backend/apps/protection/tests/test_step3_progress.py
+++ b/src/backend/apps/protection/tests/test_step3_progress.py
@@ -304,11 +304,66 @@ class Step3ProgressTests(SimpleTestCase):
                 "bytes_total_known": False,
                 "processing_speed_bps": 100_000_000,
             },
-            du_total=9_000_000_000,
+            du_total=0,
         )
         self.assertFalse(transfer["bytes_total_known"])
         self.assertIsNone(transfer.get("step3_display_percent"))
         self.assertIsNone(transfer.get("eta_seconds"))
+
+    def test_schema_v2_falls_back_to_du_and_adjusts_when_processed_exceeds_it(self):
+        processed = 104 * 1024 * 1024 * 1024
+        du_total = int(99.9 * 1024 * 1024 * 1024)
+        transfer = enrich_step3_backup_transfer(
+            transfer={"phase": "transferring"},
+            previous={},
+            aggregate={
+                "progress_schema_version": 2,
+                "processed_bytes": processed,
+                "bytes_done": processed,
+                "bytes_total_known": False,
+                "estimated_bytes": 0,
+                "processing_speed_bps": 10 * 1024 * 1024,
+            },
+            du_total=du_total,
+        )
+
+        self.assertEqual(transfer["bytes_total_source"], "du_reference")
+        self.assertTrue(transfer["bytes_total_adjusted"])
+        self.assertGreater(transfer["bytes_total"], processed)
+        self.assertEqual(transfer["step3_display_percent"], 99.0)
+
+    def test_schema_v2_replaces_larger_du_reference_with_kopia_estimate(self):
+        gib = 1024 * 1024 * 1024
+        transfer = enrich_step3_backup_transfer(
+            transfer={"phase": "transferring"},
+            previous={
+                "phase": "transferring",
+                "progress_schema_version": 2,
+                "processed_bytes": 40 * gib,
+                "bytes_done": 40 * gib,
+                "bytes_total": 89 * gib,
+                "bytes_total_known": True,
+                "bytes_total_source": "du_reference",
+                "bytes_total_reference": True,
+                "kopia_total_locked": 89 * gib,
+                "du_total": 89 * gib,
+            },
+            aggregate={
+                "progress_schema_version": 2,
+                "processed_bytes": 41 * gib,
+                "bytes_done": 41 * gib,
+                "estimated_bytes": 56 * gib,
+                "bytes_total_known": False,
+                "processing_speed_bps": 10 * 1024 * 1024,
+            },
+            du_total=89 * gib,
+        )
+
+        self.assertEqual(transfer["bytes_total"], 56 * gib)
+        self.assertEqual(transfer["bytes_total_source"], "kopia")
+        self.assertFalse(transfer["bytes_total_reference"])
+        self.assertFalse(transfer["bytes_total_adjusted"])
+        self.assertEqual(transfer["kopia_total_locked"], 56 * gib)
 
     def test_schema_v2_uses_partial_lane_estimate_for_progress_and_eta(self):
         transfer = enrich_step3_backup_transfer(

--- a/src/backend/apps/storage/services/internal/repository_operations.py
+++ b/src/backend/apps/storage/services/internal/repository_operations.py
@@ -101,7 +101,11 @@ def maintenance_settings() -> MaintenanceSettings:
         )
     return MaintenanceSettings(
         enabled=enabled,
-        quick_interval=timedelta(seconds=positive_int("STORAGE_MAINTENANCE_QUICK_INTERVAL_SECONDS", 3600)),
+        # Run Quick Maintenance every 6 hours by default.  The interval is
+        # still overrideable through STORAGE_MAINTENANCE_QUICK_INTERVAL_SECONDS.
+        quick_interval=timedelta(
+            seconds=positive_int("STORAGE_MAINTENANCE_QUICK_INTERVAL_SECONDS", 21600)
+        ),
         full_interval=timedelta(seconds=positive_int("STORAGE_MAINTENANCE_FULL_INTERVAL_SECONDS", 86400)),
         scan_interval=timedelta(seconds=positive_int("STORAGE_MAINTENANCE_SCAN_INTERVAL_SECONDS", 60)),
         window_start=window_start,

--- a/src/backend/apps/storage/tests/test_repository_maintenance_settings.py
+++ b/src/backend/apps/storage/tests/test_repository_maintenance_settings.py
@@ -1,0 +1,26 @@
+import os
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from apps.storage.services.internal.repository_operations import maintenance_settings
+
+
+class RepositoryMaintenanceSettingsTests(SimpleTestCase):
+    def test_quick_maintenance_defaults_to_six_hours(self):
+        with patch.dict(os.environ):
+            os.environ.pop("STORAGE_MAINTENANCE_QUICK_INTERVAL_SECONDS", None)
+
+            settings = maintenance_settings()
+
+        self.assertEqual(settings.quick_interval, timedelta(hours=6))
+
+    def test_quick_maintenance_interval_remains_configurable(self):
+        with patch.dict(
+            os.environ,
+            {"STORAGE_MAINTENANCE_QUICK_INTERVAL_SECONDS": "7200"},
+        ):
+            settings = maintenance_settings()
+
+        self.assertEqual(settings.quick_interval, timedelta(hours=2))

--- a/src/frontend/src/directives/tableOverflowTitle.test.ts
+++ b/src/frontend/src/directives/tableOverflowTitle.test.ts
@@ -113,6 +113,59 @@ describe('tableOverflowTitle', () => {
     delete secondaryContent.dataset.tableOverflowTitle
   })
 
+  it('preserves a structured metric title when only the table cell is clipped', () => {
+    content.dataset.tableOverflowTitle = 'Processed: 12.0 GB\nProcessing speed: 8.74 MB/s'
+    const cellBody = cell.querySelector<HTMLElement>('.cell')!
+    Object.defineProperty(cellBody, 'clientWidth', { configurable: true, value: 80 })
+    Object.defineProperty(cellBody, 'scrollWidth', { configurable: true, value: 81 })
+    Object.defineProperty(content, 'clientWidth', { configurable: true, value: 80 })
+    Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 80 })
+    Object.defineProperty(secondaryContent, 'clientWidth', { configurable: true, value: 80 })
+    Object.defineProperty(secondaryContent, 'scrollWidth', { configurable: true, value: 80 })
+
+    content.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    vi.advanceTimersByTime(300)
+
+    expect(document.querySelector<HTMLElement>('#hfl-table-overflow-tooltip')?.textContent).toBe(
+      'Processed: 12.0 GB\nProcessing speed: 8.74 MB/s',
+    )
+    delete content.dataset.tableOverflowTitle
+    delete cellBody.clientWidth
+    delete cellBody.scrollWidth
+  })
+
+  it('always shows explicitly marked progress detail even when it is not clipped', () => {
+    content.dataset.tableOverflowTitle = 'Processed: 53.6 GB / 55.7 GB\nProcessing speed: 2.47 MB/s\n15 min left'
+    content.setAttribute('data-table-overflow-title-always', '')
+    Object.defineProperty(content, 'clientWidth', { configurable: true, value: 200 })
+    Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 80 })
+    Object.defineProperty(secondaryContent, 'clientWidth', { configurable: true, value: 200 })
+    Object.defineProperty(secondaryContent, 'scrollWidth', { configurable: true, value: 80 })
+
+    content.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    vi.advanceTimersByTime(300)
+
+    expect(document.querySelector<HTMLElement>('#hfl-table-overflow-tooltip')?.textContent).toBe(
+      'Processed: 53.6 GB / 55.7 GB\nProcessing speed: 2.47 MB/s\n15 min left',
+    )
+    delete content.dataset.tableOverflowTitle
+    content.removeAttribute('data-table-overflow-title-always')
+  })
+
+  it('does not fall back to a visible status label for explicit-only cells', () => {
+    content.innerText = 'Preparing backup…'
+    content.setAttribute('data-table-overflow-explicit-only', '')
+    Object.defineProperty(content, 'clientWidth', { configurable: true, value: 80 })
+    Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 200 })
+
+    content.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    vi.advanceTimersByTime(300)
+
+    expect(document.querySelector<HTMLElement>('#hfl-table-overflow-tooltip')?.style.display).toBe('none')
+    content.removeAttribute('data-table-overflow-explicit-only')
+    content.innerText = 'notification.channel.create'
+  })
+
   it('shows the tooltip when content overflows by exactly one pixel', () => {
     Object.defineProperty(content, 'clientWidth', { configurable: true, value: 80 })
     Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 81 })

--- a/src/frontend/src/directives/tableOverflowTitle.ts
+++ b/src/frontend/src/directives/tableOverflowTitle.ts
@@ -135,11 +135,28 @@ function overflowCandidates(cell: HTMLElement) {
 
 function titleTextForCell(cell: HTMLElement) {
   const explicitTargets = Array.from(cell.querySelectorAll<HTMLElement>('[data-table-overflow-title]'))
+  const alwaysExplicitTitle = explicitTargets.find((target) => {
+    return target.hasAttribute('data-table-overflow-title-always')
+      && Boolean(target.dataset.tableOverflowTitle?.trim())
+  })?.dataset.tableOverflowTitle?.trim()
+  if (alwaysExplicitTitle) return alwaysExplicitTitle
+
   const overflowingExplicitTarget = explicitTargets.find((target) => {
     return Boolean(target.dataset.tableOverflowTitle?.trim()) && isOverflowing(target)
   })
   const explicitTitle = overflowingExplicitTarget?.dataset.tableOverflowTitle?.trim()
   if (explicitTitle) return explicitTitle
+
+  // If the table cell itself is clipped but its explicitly titled child does
+  // not report overflow independently (common with flex layouts), preserve
+  // the structured title instead of falling back to all visible cell text.
+  const structuredTitle = explicitTargets.find((target) => target.dataset.tableOverflowTitle?.trim())
+    ?.dataset.tableOverflowTitle?.trim()
+  if (structuredTitle && isOverflowing(cell)) return structuredTitle
+
+  // Some compound cells intentionally expose only their structured detail
+  // text. Do not fall back to duplicating visible status labels in a tooltip.
+  if (cell.querySelector('[data-table-overflow-explicit-only]')) return ''
 
   const candidates = overflowCandidates(cell)
   const overflowingCandidates = candidates.filter(isOverflowing)
@@ -206,7 +223,11 @@ function observeTooltipContent(state: OverflowTitleState, cell: HTMLElement) {
     childList: true,
     characterData: true,
     attributes: true,
-    attributeFilter: ['data-table-overflow-title'],
+    attributeFilter: [
+      'data-table-overflow-title',
+      'data-table-overflow-title-always',
+      'data-table-overflow-explicit-only',
+    ],
   })
   state.contentObserver = observer
 }

--- a/src/frontend/src/lib/kopiaProgress.ts
+++ b/src/frontend/src/lib/kopiaProgress.ts
@@ -53,6 +53,8 @@ export type TransferProgress = {
   bytes_total_known?: boolean
   bytes_total_reference?: boolean
   bytes_total_estimated?: boolean
+  bytes_total_source?: 'kopia' | 'du_reference' | 'unknown'
+  bytes_total_adjusted?: boolean
   uploaded_bytes?: number
   uploaded_count?: number
   hashed_count?: number

--- a/src/frontend/src/lib/protectionPolicyFormModel.test.ts
+++ b/src/frontend/src/lib/protectionPolicyFormModel.test.ts
@@ -8,6 +8,7 @@ import {
   policyFormToWritePayload,
   quickScheduleToCron,
   summarizeSchedule,
+  summarizeScheduleCycle,
   validateRetentionForm,
   validateScheduleForm,
 } from './protectionPolicyFormModel'
@@ -110,6 +111,17 @@ describe('protection policy schedule mapping', () => {
     expect(formatScheduleStartForDisplay(form.scheduleStartsAt)).toBe('2026-08-13 14:30:45')
     expect(summarizeSchedule(form)).toContain('starts 2026-08-13 14:30:45')
     expect(summarizeSchedule(form)).not.toContain('2026-08-13T14:30:45')
+  })
+
+  it('summarizes the schedule cycle without repeating timezone or start time', () => {
+    const form = createEmptyPolicyForm()
+    form.simpleIntervalUnit = 'hour'
+    form.simpleIntervalValue = 3
+    form.scheduleTimezone = 'Asia/Shanghai'
+    form.scheduleStartsAt = '2026-08-31T17:16:23'
+
+    expect(summarizeScheduleCycle(form)).toBe('Every 3 hours')
+    expect(summarizeSchedule(form)).toBe('Every 3 hours (Asia/Shanghai), starts 2026-08-31 17:16:23')
   })
 
   it('serializes hour and day intervals through the shared mapper', () => {

--- a/src/frontend/src/lib/protectionPolicyFormModel.ts
+++ b/src/frontend/src/lib/protectionPolicyFormModel.ts
@@ -357,33 +357,37 @@ export function humanizeCronExpression(raw: string, locale: MessageLocale = 'en'
   return 'Custom schedule'
 }
 
-export function summarizeSchedule(f: BackupPolicyForm, locale: MessageLocale = 'en'): string {
+export function summarizeScheduleCycle(f: BackupPolicyForm, locale: MessageLocale = 'en'): string {
   if (!f.sectionScheduleEnabled) {
     return 'Not configured'
   }
-  let summary: string
   if (f.freqMode === 'simple') {
     if (f.quickScheduleType === 'interval') {
       const unitText = formatSimpleIntervalUnitText(f.simpleIntervalUnit, f.simpleIntervalValue, locale)
-      summary = `Every ${f.simpleIntervalValue} ${unitText}`
-    } else if (f.quickScheduleType === 'daily') {
-      summary = `Daily at ${f.scheduleTime}`
-    } else if (f.quickScheduleType === 'weekly') {
+      return `Every ${f.simpleIntervalValue} ${unitText}`
+    }
+    if (f.quickScheduleType === 'daily') {
+      return `Daily at ${f.scheduleTime}`
+    }
+    if (f.quickScheduleType === 'weekly') {
       const weekdayNames = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
       const weekdays = [...new Set(f.scheduleWeekdays)]
         .sort((a, b) => a - b)
         .map((day) => weekdayNames[day - 1])
-      summary = `Weekly on ${weekdays.join(', ')} at ${f.scheduleTime}`
-    } else {
-      const dates = [...new Set(f.scheduleMonthDays)]
-        .sort((a, b) => a - b)
-        .map(String)
-      if (f.scheduleMonthEnd) dates.push('end of month')
-      summary = `Monthly on ${dates.join(', ')} at ${f.scheduleTime}`
+      return `Weekly on ${weekdays.join(', ')} at ${f.scheduleTime}`
     }
-  } else {
-    summary = humanizeCronExpression(f.cronExpr, locale)
+    const dates = [...new Set(f.scheduleMonthDays)]
+      .sort((a, b) => a - b)
+      .map(String)
+    if (f.scheduleMonthEnd) dates.push('end of month')
+    return `Monthly on ${dates.join(', ')} at ${f.scheduleTime}`
   }
+  return humanizeCronExpression(f.cronExpr, locale)
+}
+
+export function summarizeSchedule(f: BackupPolicyForm, locale: MessageLocale = 'en'): string {
+  let summary = summarizeScheduleCycle(f, locale)
+  if (!f.sectionScheduleEnabled) return summary
   summary = `${summary} (${f.scheduleTimezone || 'UTC'})`
   if (f.scheduleStartsAt) summary = `${summary}, starts ${formatScheduleStartForDisplay(f.scheduleStartsAt)}`
   return summary

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -140,6 +140,7 @@ import {
   backupPolicyToForm,
   compileFilterIgnorePatterns,
   fileFilterRuleToForm,
+  summarizeScheduleCycle,
 } from '../../lib/protectionPolicyFormModel'
 import {
   getStorageRepository,
@@ -3621,7 +3622,7 @@ type FlowPolicyRetentionDetailLine = {
 function flowPolicyScheduleValue(policy: BackupPolicy | null | undefined) {
   if (!policy) return t('protection.backupDetail.durationDash')
   if (policy.schedule?.enabled === false) return t('protection.backupsPage.policyConfigNotConfigured')
-  return policy.schedule_summary || policy.schedule?.cron_expr || t('protection.backupsPage.policyConfigNotConfigured')
+  return summarizeScheduleCycle(backupPolicyToForm(policy))
 }
 
 function flowPolicyDetailRows(policy: BackupPolicy | null | undefined) {

--- a/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
@@ -104,6 +104,7 @@ describe('backup wizard step 3 More Actions refresh', () => {
 
   it('aligns step-three policy and file-filter detail popovers with the create wizard', () => {
     expect(page).toMatch(/flowPolicyDetailRows[\s\S]*scheduleCycle[\s\S]*scheduleTimezone[\s\S]*scheduleStartsAt/)
+    expect(page).toMatch(/flowPolicyScheduleValue[\s\S]*summarizeScheduleCycle\(backupPolicyToForm\(policy\)\)/)
     expect(page).toMatch(/:width="400"[\s\S]*flow-binding-detail-popper/)
     expect(page).toMatch(/:width="380"[\s\S]*flow-binding-detail-popper/)
     expect(page).toContain("t('protection.policiesPage.shortDesc'")

--- a/src/frontend/src/pages/protection/components/TaskProgressCell.test.ts
+++ b/src/frontend/src/pages/protection/components/TaskProgressCell.test.ts
@@ -87,6 +87,7 @@ describe('TaskProgressCell', () => {
     expect(wrapper.get('.task-progress-cell__percent').text()).toBe('0.28%')
     expect(wrapper.get('.el-progress-stub').attributes('data-percentage')).toBe('0.28')
     expect(wrapper.get('.task-progress-cell__label-text').text()).toBe('Backing up')
+    expect(wrapper.get('.task-progress-cell__label').attributes('title')).toBeUndefined()
     expect(wrapper.text()).not.toContain('947')
   })
 
@@ -137,7 +138,7 @@ describe('TaskProgressCell', () => {
     expect(wrapper.get('.el-progress-stub').attributes('data-percentage')).toBe('10.2')
   })
 
-  it('labels hash throughput and includes it in either overflow target tooltip', () => {
+  it('labels hash throughput and exposes only the metric tooltip', () => {
     const wrapper = mountCell(14.55, {
       progress_schema_version: 1,
       bytes_done: 0,
@@ -152,7 +153,7 @@ describe('TaskProgressCell', () => {
     const expectedTitle = 'Scanning: 375 MB/s'
 
     expect(wrapper.get('.task-progress-cell__metric-line').text()).toBe('Scanning: 375 MB/s')
-    expect(wrapper.get('.task-progress-cell__label-text').attributes('data-table-overflow-title')).toBe(expectedTitle)
+    expect(wrapper.get('.task-progress-cell__label-text').attributes('data-table-overflow-title')).toBeUndefined()
     expect(wrapper.get('.task-progress-cell__metric-line').attributes('data-table-overflow-title')).toBe(expectedTitle)
   })
 
@@ -169,11 +170,31 @@ describe('TaskProgressCell', () => {
 
   it('provides structured overflow tooltip text without standalone separators', () => {
     const wrapper = mountCell(59.1)
+    const metric = wrapper.get('.task-progress-cell__metric-line')
 
-    expect(wrapper.get('.task-progress-cell__metric-line').attributes('data-table-overflow-title')).toBe([
+    expect(wrapper.get('.task-progress-cell').attributes()).toHaveProperty('data-table-overflow-explicit-only')
+    expect(metric.attributes()).toHaveProperty('data-table-overflow-title-always')
+    expect(metric.attributes('data-table-overflow-title')).toBe([
       'Processed: 858 MB / 300 GB',
       'Processing speed: 18.4 MB/s',
       '15 min left',
+    ].join('\n'))
+  })
+
+  it('keeps processed bytes and speed in the hover text when the total is unknown', () => {
+    const wrapper = mountCell(24.75, {
+      bytes_total: null,
+      bytes_total_known: false,
+      processing_speed_bps: 8.74 * 1024 * 1024,
+      upload_speed_bps: null,
+      eta_seconds: null,
+      step3_display_percent: null,
+    })
+
+    expect(wrapper.get('.task-progress-cell__label-text').attributes('data-table-overflow-title')).toBeUndefined()
+    expect(wrapper.get('.task-progress-cell__metric-line').attributes('data-table-overflow-title')).toBe([
+      'Processed: 858 MB',
+      'Processing speed: 8.74 MB/s',
     ].join('\n'))
   })
 })

--- a/src/frontend/src/pages/protection/components/TaskProgressCell.vue
+++ b/src/frontend/src/pages/protection/components/TaskProgressCell.vue
@@ -80,16 +80,13 @@ const overflowTitle = computed(() => {
     .filter(Boolean)
     .join('\n')
 })
-const labelTitle = computed(() => {
-  const label = orchestrationLabel.value
-  return label.length > 48 ? label : undefined
-})
 </script>
 
 <template>
   <div
     class="task-progress-cell"
     :class="{ 'is-compact': compact, 'is-failed': failed, 'is-stopping': stopping }"
+    data-table-overflow-explicit-only
   >
     <div
       v-if="orchestrationLabel || showRightPercent"
@@ -98,7 +95,6 @@ const labelTitle = computed(() => {
       <p
         v-if="orchestrationLabel"
         class="task-progress-cell__label"
-        :title="labelTitle"
       >
         <span
           v-if="showSpinner"
@@ -107,7 +103,6 @@ const labelTitle = computed(() => {
         />
         <span
           class="task-progress-cell__label-text"
-          :data-table-overflow-title="overflowTitle || undefined"
         >{{ orchestrationLabel }}</span>
       </p>
       <span
@@ -130,6 +125,7 @@ const labelTitle = computed(() => {
         v-if="metricLine"
         class="task-progress-cell__metric-line"
         :data-table-overflow-title="overflowTitle || undefined"
+        data-table-overflow-title-always
       >{{ metricLine }}</span>
     </p>
   </div>

--- a/tools/kopia/common.sh
+++ b/tools/kopia/common.sh
@@ -18,6 +18,7 @@ KOPIA_PATCH_FILES=(
 	"${KOPIA_TOOLS_DIR}/patches/0001-add-s3-url-style.patch"
 	"${KOPIA_TOOLS_DIR}/patches/0002-add-structured-progress.patch"
 	"${KOPIA_TOOLS_DIR}/patches/0003-disable-managed-dot-ignore.patch"
+	"${KOPIA_TOOLS_DIR}/patches/0004-snapshot-estimator-best-effort-errors.patch"
 )
 KOPIA_DEFAULT_MATRIX="linux:amd64 linux:arm64 darwin:amd64 darwin:arm64 windows:amd64"
 

--- a/tools/kopia/patches/0004-snapshot-estimator-best-effort-errors.patch
+++ b/tools/kopia/patches/0004-snapshot-estimator-best-effort-errors.patch
@@ -1,0 +1,248 @@
+diff --git a/snapshot/upload/estimate.go b/snapshot/upload/estimate.go
+index 38c83bb8..379c2e9a 100644
+--- a/snapshot/upload/estimate.go
++++ b/snapshot/upload/estimate.go
+@@ -2,6 +2,7 @@
+ 
+ import (
+ 	"context"
++	"errors"
+ 	"fmt"
+ 	"path/filepath"
+ 	"sync/atomic"
+@@ -72,9 +73,17 @@ type EstimateProgress interface {
+ 	Stats(ctx context.Context, s *snapshot.Stats, includedFiles, excludedFiles SampleBuckets, excludedDirs []string, final bool)
+ }
+ 
++type estimateOptions struct {
++	bestEffortErrors bool
++}
++
+ // Estimate walks the provided directory tree and invokes provided progress callback as it discovers
+ // items to be snapshotted.
+ func Estimate(ctx context.Context, entry fs.Directory, policyTree *policy.Tree, progress EstimateProgress, maxExamplesPerBucket int) error {
++	return estimateWithOptions(ctx, entry, policyTree, progress, maxExamplesPerBucket, estimateOptions{})
++}
++
++func estimateWithOptions(ctx context.Context, entry fs.Directory, policyTree *policy.Tree, progress EstimateProgress, maxExamplesPerBucket int, options estimateOptions) error {
+ 	stats := &snapshot.Stats{}
+ 	ed := []string{}
+ 	ib := makeBuckets()
+@@ -106,10 +115,10 @@ func Estimate(ctx context.Context, entry fs.Directory, policyTree *policy.Tree,
+ 
+ 	entry = ignorefs.New(entry, policyTree, ignorefs.ReportIgnoredFiles(onIgnoredFile))
+ 
+-	return estimate(ctx, ".", entry, policyTree, stats, ib, eb, &ed, progress, maxExamplesPerBucket)
++	return estimate(ctx, ".", entry, policyTree, stats, ib, eb, &ed, progress, maxExamplesPerBucket, options)
+ }
+ 
+-func estimate(ctx context.Context, relativePath string, entry fs.Entry, policyTree *policy.Tree, stats *snapshot.Stats, ib, eb SampleBuckets, ed *[]string, progress EstimateProgress, maxExamplesPerBucket int) error {
++func estimate(ctx context.Context, relativePath string, entry fs.Entry, policyTree *policy.Tree, stats *snapshot.Stats, ib, eb SampleBuckets, ed *[]string, progress EstimateProgress, maxExamplesPerBucket int, options estimateOptions) error {
+ 	// see if the context got canceled
+ 	select {
+ 	case <-ctx.Done():
+@@ -137,11 +146,14 @@ func estimate(ctx context.Context, relativePath string, entry fs.Entry, policyTr
+ 
+ 			child, err = iter.Next(ctx)
+ 			for child != nil {
+-				if err = estimate(ctx, filepath.Join(relativePath, child.Name()), child, policyTree.Child(child.Name()), stats, ib, eb, ed, progress, maxExamplesPerBucket); err != nil {
++				childErr := estimate(ctx, filepath.Join(relativePath, child.Name()), child, policyTree.Child(child.Name()), stats, ib, eb, ed, progress, maxExamplesPerBucket, options)
++				child.Close()
++
++				if childErr != nil {
++					err = childErr
+ 					break
+ 				}
+ 
+-				child.Close()
+ 				child, err = iter.Next(ctx)
+ 			}
+ 		}
+@@ -149,6 +161,15 @@ func estimate(ctx context.Context, relativePath string, entry fs.Entry, policyTr
+ 		progress.Stats(ctx, stats, ib, eb, *ed, false)
+ 
+ 		if err != nil {
++			if options.bestEffortErrors &&
++				relativePath != "." &&
++				!errors.Is(err, context.Canceled) &&
++				!errors.Is(err, context.DeadlineExceeded) {
++				estimateLog(ctx).Debugf("Skipping unreadable subtree %v during best-effort estimation: %v", relativePath, err)
++
++				return nil
++			}
++
+ 			isIgnored := policyTree.EffectivePolicy().ErrorHandlingPolicy.IgnoreDirectoryErrors.OrDefault(false)
+ 
+ 			if isIgnored {
+diff --git a/snapshot/upload/upload.go b/snapshot/upload/upload.go
+index c6975b53..89d3bbc3 100644
+--- a/snapshot/upload/upload.go
++++ b/snapshot/upload/upload.go
+@@ -1376,7 +1376,13 @@ func (u *Uploader) startDataSizeEstimation(
+ 		return noOpEstimationCtrl
+ 	}
+ 
+-	estimator := NewEstimator(wrapped, policyTree, u.Progress.EstimationParameters(), logger)
++	estimator := NewEstimator(
++		wrapped,
++		policyTree,
++		u.Progress.EstimationParameters(),
++		logger,
++		withBestEffortErrorHandling(),
++	)
+ 
+ 	estimator.StartEstimation(ctx, func(filesCount, totalFileSize int64) {
+ 		u.Progress.EstimatedDataSize(filesCount, totalFileSize)
+diff --git a/snapshot/upload/upload_estimator.go b/snapshot/upload/upload_estimator.go
+index e8985be1..50026957 100644
+--- a/snapshot/upload/upload_estimator.go
++++ b/snapshot/upload/upload_estimator.go
+@@ -52,6 +52,7 @@ type estimator struct {
+ 	logger               logging.Logger
+ 	entry                fs.Directory
+ 	policyTree           *policy.Tree
++	bestEffortErrors     bool
+ 
+ 	scanWG              sync.WaitGroup
+ 	cancelCtx           context.CancelFunc
+@@ -72,6 +73,13 @@ func WithVolumeSizeInfoFn(fn VolumeSizeInfoFn) EstimatorOption {
+ 	}
+ }
+ 
++func withBestEffortErrorHandling() EstimatorOption {
++	return func(e Estimator) {
++		est, _ := e.(*estimator)
++		est.bestEffortErrors = true
++	}
++}
++
+ // NewEstimator returns instance of estimator.
+ func NewEstimator(
+ 	entry fs.Directory,
+@@ -171,7 +179,9 @@ func (e *estimator) doRoughEstimation() (filesCount, totalFileSize int64, err er
+ func (e *estimator) doClassicEstimation(ctx context.Context) (filesCount, totalFileSize int64, err error) {
+ 	var res scanResults
+ 
+-	err = Estimate(ctx, e.entry, e.policyTree, &res, 1)
++	err = estimateWithOptions(ctx, e.entry, e.policyTree, &res, 1, estimateOptions{
++		bestEffortErrors: e.bestEffortErrors,
++	})
+ 	if err != nil {
+ 		return 0, 0, errors.Wrap(err, "Unable to scan directory")
+ 	}
+diff --git a/snapshot/upload/upload_estimator_best_effort_test.go b/snapshot/upload/upload_estimator_best_effort_test.go
+new file mode 100644
+index 00000000..24b4fb2c
+--- /dev/null
++++ b/snapshot/upload/upload_estimator_best_effort_test.go
+@@ -0,0 +1,110 @@
++package upload
++
++import (
++	"context"
++	"errors"
++	"testing"
++
++	"github.com/stretchr/testify/require"
++
++	"github.com/kopia/kopia/internal/mockfs"
++	"github.com/kopia/kopia/internal/testlogging"
++	"github.com/kopia/kopia/snapshot/policy"
++)
++
++var errEstimationAccessDenied = errors.New("access denied during estimation")
++
++type estimationCaptureProgress struct {
++	NullUploadProgress
++
++	called bool
++	files  int64
++	bytes  int64
++}
++
++func (p *estimationCaptureProgress) Enabled() bool {
++	return true
++}
++
++func (p *estimationCaptureProgress) EstimatedDataSize(files, bytes int64) {
++	p.called = true
++	p.files = files
++	p.bytes = bytes
++}
++
++func newPartiallyUnreadableEstimationTree() *mockfs.Directory {
++	root := mockfs.NewDirectory()
++	root.AddFile("a-readable", []byte{1, 2, 3}, 0o644)
++	root.AddDir("m-unreadable", 0o755).FailReaddir(errEstimationAccessDenied)
++	root.AddErrorEntryFile("n-unreadable-file", 0o000, errEstimationAccessDenied)
++	root.AddFile("z-readable", []byte{4, 5, 6, 7}, 0o644)
++
++	return root
++}
++
++func TestSnapshotCreateEstimatorSkipsUnreadableSubdirectory(t *testing.T) {
++	ctx := testlogging.Context(t)
++	progress := &estimationCaptureProgress{}
++	uploader := &Uploader{Progress: progress}
++	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
++
++	controller := uploader.startDataSizeEstimation(
++		ctx,
++		newPartiallyUnreadableEstimationTree(),
++		policyTree,
++	)
++	controller.Wait()
++
++	require.True(t, progress.called)
++	require.Equal(t, int64(2), progress.files)
++	require.Equal(t, int64(7), progress.bytes)
++}
++
++func TestPublicEstimateKeepsStrictUnreadableSubdirectoryBehavior(t *testing.T) {
++	ctx := testlogging.Context(t)
++	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
++	var result scanResults
++
++	err := Estimate(ctx, newPartiallyUnreadableEstimationTree(), policyTree, &result, 1)
++
++	require.ErrorIs(t, err, errEstimationAccessDenied)
++}
++
++func TestSnapshotCreateEstimatorStillFailsWhenRootIsUnreadable(t *testing.T) {
++	ctx := testlogging.Context(t)
++	root := mockfs.NewDirectory()
++	root.FailReaddir(errEstimationAccessDenied)
++	progress := &estimationCaptureProgress{}
++	uploader := &Uploader{Progress: progress}
++
++	controller := uploader.startDataSizeEstimation(
++		ctx,
++		root,
++		policy.BuildTree(nil, policy.DefaultPolicy),
++	)
++	controller.Wait()
++
++	require.True(t, progress.called)
++	require.Zero(t, progress.files)
++	require.Zero(t, progress.bytes)
++}
++
++func TestSnapshotCreateEstimatorDoesNotSwallowCancellation(t *testing.T) {
++	ctx, cancel := context.WithCancel(testlogging.Context(t))
++	root := mockfs.NewDirectory()
++	root.AddDir("a-cancel", 0o755).OnReaddir(cancel)
++	root.AddFile("z-readable", []byte{1, 2, 3}, 0o644)
++	progress := &estimationCaptureProgress{}
++	uploader := &Uploader{Progress: progress}
++
++	controller := uploader.startDataSizeEstimation(
++		ctx,
++		root,
++		policy.BuildTree(nil, policy.DefaultPolicy),
++	)
++	controller.Wait()
++
++	require.True(t, progress.called)
++	require.Zero(t, progress.files)
++	require.Zero(t, progress.bytes)
++}

--- a/tools/quality/test-kopia-build-config.sh
+++ b/tools/quality/test-kopia-build-config.sh
@@ -130,10 +130,12 @@ if grep -E -n 'build/dependencies/kopia|kopia_linux_amd64[.]deb' "${ROOT}/.docke
 	printf 'ERROR: obsolete Kopia Docker context paths are still configured\n' >&2
 	exit 1
 fi
-if grep -R -n -E --exclude-dir=build --exclude-dir=data --exclude-dir=.git \
-	--exclude='test-kopia-build-config.sh' -- \
-	'--kopia-version|KOPIA_DEB|kopia_linux_amd64[.]deb|tools/dependencies/versions/kopia[.]env' \
-	"${ROOT}" >/dev/null; then
+# Search tracked product files only. Local .env files and ignored developer
+# notes may legitimately describe older configurations and must not make this
+# repository contract nondeterministic.
+if git -C "${ROOT}" grep -n -E \
+	-e '--kopia-version|KOPIA_DEB|kopia_linux_amd64[.]deb|tools/dependencies/versions/kopia[.]env' \
+	-- ':!tools/quality/test-kopia-build-config.sh' >/dev/null; then
 	printf 'ERROR: obsolete Kopia version or deb configuration is still referenced\n' >&2
 	exit 1
 fi
@@ -152,10 +154,14 @@ grep -F 'policySetDisableDotIgnore' \
 	"${ROOT}/tools/kopia/patches/0003-disable-managed-dot-ignore.patch" >/dev/null
 grep -F 'NoParentDotIgnoreFiles' \
 	"${ROOT}/tools/kopia/patches/0003-disable-managed-dot-ignore.patch" >/dev/null
+grep -F 'withBestEffortErrorHandling()' \
+	"${ROOT}/tools/kopia/patches/0004-snapshot-estimator-best-effort-errors.patch" >/dev/null
+grep -F 'TestSnapshotCreateEstimatorSkipsUnreadableSubdirectory' \
+	"${ROOT}/tools/kopia/patches/0004-snapshot-estimator-best-effort-errors.patch" >/dev/null
 
-[[ "${#KOPIA_PATCH_FILES[@]}" -eq 3 ]]
+[[ "${#KOPIA_PATCH_FILES[@]}" -eq 4 ]]
 patch_set_digest="$(patch_set_sha256)"
 [[ "${patch_set_digest}" =~ ^[0-9a-f]{64}$ ]]
-[[ "$(patch_names)" == '0001-add-s3-url-style.patch 0002-add-structured-progress.patch 0003-disable-managed-dot-ignore.patch ' ]]
+[[ "$(patch_names)" == '0001-add-s3-url-style.patch 0002-add-structured-progress.patch 0003-disable-managed-dot-ignore.patch 0004-snapshot-estimator-best-effort-errors.patch ' ]]
 
 printf 'Kopia build configuration checks passed.\n'


### PR DESCRIPTION
## Problem and root cause

Backup progress could lose its total when Kopia's classic estimator met an
unreadable child, and the macOS fallback used GNU `du` behavior that BSD `du`
does not provide. A stale total could also fall behind processed bytes, while
task hover content was coupled to overflow and duplicated orchestration text.

The same development tree contained related operational defects: detached
Agent upgrades did not preserve installation identity, Quick Maintenance used
an overly frequent default, and policy details repeated schedule timezone and
start information.

## Solution

- make only the internal `snapshot create` estimator skip unreadable non-root
  children while preserving strict public estimation, cancellation, root
  errors, and uploader policy behavior;
- use `du -sk` as the macOS capacity reference, retain parseable partial
  summaries, prefer positive Kopia estimates, and keep running progress below
  100 percent by expanding undersized totals;
- expose metrics-only hover details independently of visual overflow;
- forward or recover Agent installation mode and run-as identity during
  detached upgrades on Unix and Windows;
- default Quick Maintenance to six hours while retaining environment
  overrides; and
- show a cycle-only policy schedule value where timezone and start time already
  have dedicated fields.

## Validation

- Manual testing: passed
- Backend focused tests: 22 passed
- Backend affected application suites: 912 passed
- Backend Ruff and migration drift checks: passed
- Frontend focused tests: 65 passed
- Frontend full suite: 255 files and 1,391 tests passed
- Frontend lint: passed with zero errors and three pre-existing warnings
- Frontend production build: passed
- Agent affected packages: passed on Go 1.25.10 Linux/amd64
- Agent full suite: baseline-equivalent; only
  `internal/platform/disk.TestHostStorageUsage` failed with the same fixture
  identity on canonical base `863bb3ecbe77dd6510a9015257496a7115bf7827`
- Kopia v0.23.1 patch application, estimator regressions, race tests, build
  configuration, and Linux/amd64 build: passed
- Shell syntax, English-source boundary, and `git diff --check`: passed
- Complete Community Backend Suite: skipped by explicit user instruction

## Risks and compatibility

`du -sk` reports allocated capacity and may differ from Kopia logical bytes, so
it remains a temporary reference until a positive Kopia estimate is available.
Best-effort estimation does not change actual snapshot upload error policy.
Existing Agents remain upgradeable because staged installers recover persisted
identity when older detached runners cannot forward the new variables. No
schema migration or incompatible API change is introduced.

Fixes #966
Fixes #704
