### PR TITLE
fix(frontend): refresh backup wizard edits

### DIFF
--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -2313,7 +2313,12 @@ function onCreateBackupPartial(payload: BackupCreateResultPayload) {
 
 function onEditBackupCompleted(payload: { sourceIds: string[] }) {
   closeCreate()
-  reconcileCreatedBackupConfigs(payload.sourceIds)
+  void refreshStep3AfterMoreAction({
+    focusIds: payload.sourceIds,
+    showLoading: true,
+  }).catch((err) => {
+    if (!pageRequests.isAbortError(err)) showApiError(err)
+  })
 }
 
 

--- a/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
@@ -219,7 +219,7 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(toolbarRefresh).not.toContain('loadStep3Selectable({ signal: signal ?? undefined })')
   })
 
-  it('separates create and edit completion while reconciling Step 3 in the background', () => {
+  it('refreshes expanded Step 3 details after edits without slowing the create transition', () => {
     const editStart = wizard.indexOf('async function runEditBackupConfig')
     const editEnd = wizard.indexOf('function submitCreateWizard', editStart)
     const editHandler = wizard.slice(editStart, editEnd)
@@ -227,6 +227,7 @@ describe('backup wizard step 3 More Actions refresh', () => {
       'function finishCreateAndGoToStep3',
       'function onCreateBackupPartial',
     )
+    const createReconciliation = functionSource('reconcileCreatedBackupConfigs', 'finishCreateAndGoToStep3')
 
     expect(editStart).toBeGreaterThan(-1)
     expect(editEnd).toBeGreaterThan(editStart)
@@ -235,6 +236,13 @@ describe('backup wizard step 3 More Actions refresh', () => {
     expect(page).toContain('@create-completed="finishCreateAndGoToStep3"')
     expect(page).toContain('@edit-completed="onEditBackupCompleted"')
     expect(handler.indexOf('enterStartBackupStep')).toBeLessThan(handler.indexOf('reconcileCreatedBackupConfigs'))
+    expect(createReconciliation).toContain('preserveExpandedState: true')
+
+    const editCompletion = sourceBetween('function onEditBackupCompleted', 'const addSourceOpen')
+    expect(editCompletion).toContain('refreshStep3AfterMoreAction({')
+    expect(editCompletion).toContain('focusIds: payload.sourceIds')
+    expect(editCompletion).not.toContain('reconcileCreatedBackupConfigs')
+    expect(editCompletion).not.toContain('preserveExpandedState: true')
   })
 
   it('keeps backup refresh synchronous and restore refresh in the background after stopping', () => {


### PR DESCRIPTION
## Problem and root cause

After editing backup paths, backup policy, or restore plan in Backup Wizard Step 3, the list continued rendering stale expanded configuration details. Edit completion reused the create-flow reconciliation option that skipped expanded-detail synchronization.

## Solution

Refresh Step 3 through the full expanded configuration synchronization path after edit completion, while keeping the create transition fast path unchanged. Add regression assertions covering all edit completion behavior.

## Validation

- Targeted Vitest: `DataProtectionStep3MoreActions.test.ts` (22/22 passed)
- ESLint on changed frontend files
- `git diff --check`
- English source boundary check
- Manual testing: passed for Edit Backup Paths, Edit Backup Policy, and Edit Restore Plan without a page reload
- Optional Community backend full suite: skipped at user request

## Risks and compatibility

Frontend-only change with no API, schema, persistence, translation, or deployment contract changes. Create-flow reconciliation remains unchanged.

Fixes #958
