### PR TITLE
Unify Operations status colors

### DIFF
--- a/src/frontend/src/components/monitor/SystemMonitorDashboard.vue
+++ b/src/frontend/src/components/monitor/SystemMonitorDashboard.vue
@@ -15,7 +15,7 @@ defineProps<{
     label: string
     value: string
     sub: string
-    accent: 'indigo' | 'green' | 'orange' | 'pink'
+    tone: 'primary' | 'success' | 'warning' | 'danger' | 'info' | 'firing' | 'neutral'
     icon: unknown
   }>
   hasChartData: (option: unknown) => boolean
@@ -51,7 +51,7 @@ const { t } = useI18n()
         :label="card.label"
         :value="card.value"
         :sub="card.sub"
-        :accent="card.accent"
+        :tone="card.tone"
         accent-side="left"
       >
         <template #icon>

--- a/src/frontend/src/components/ops/OpsStatCard.vue
+++ b/src/frontend/src/components/ops/OpsStatCard.vue
@@ -4,16 +4,14 @@ withDefaults(
     label: string
     value: string | number
     sub?: string
-    accent?: 'red' | 'yellow' | 'green' | 'blue' | 'indigo' | 'orange' | 'pink' | 'gray'
+    tone?: 'primary' | 'success' | 'warning' | 'danger' | 'info' | 'firing' | 'neutral'
     accentSide?: 'left' | 'top'
-    valueClass?: string
     pulse?: boolean
   }>(),
   {
-    accent: 'indigo',
+    tone: 'primary',
     accentSide: 'top',
     sub: '',
-    valueClass: '',
     pulse: false,
   },
 )
@@ -23,7 +21,7 @@ withDefaults(
   <div
     class="hfl-ops-stat-card"
     :class="[
-      `hfl-ops-stat-card--${accent}`,
+      `hfl-ops-stat-card--tone-${tone}`,
       accentSide === 'left' ? 'hfl-ops-stat-card--side-left' : 'hfl-ops-stat-card--side-top',
     ]"
   >
@@ -40,10 +38,7 @@ withDefaults(
       </div>
     </div>
     <div class="hfl-ops-stat-card__value-row">
-      <div
-        class="hfl-ops-stat-card__value"
-        :class="valueClass"
-      >
+      <div class="hfl-ops-stat-card__value">
         {{ value }}
       </div>
       <span

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -28,6 +28,7 @@ html {
   --color-primary-hover: #5546D8;
   --color-primary-active: #4536BD;
   --color-primary-light: #F2F0FE;
+  --color-primary-border: #DCD5FB;
   --color-primary-disabled-gradient-start: #E3DFFF;
   --color-primary-disabled-bg: #D2CBFA;
   --color-primary-disabled-border: #D2CBFA;
@@ -46,13 +47,19 @@ html {
   --color-warning-text: #925400;
   --color-warning-light: #FCF3E1;
   --color-warning-border: #F2DBA8;
+  --color-firing: #C2410C;
+  --color-firing-text: #9A3412;
+  --color-firing-light: #FFF7ED;
+  --color-firing-border: #FDBA74;
   --color-error: #E0413E;
   --color-error-text: #B42318;
   --color-error-light: #FDEDEC;
   --color-error-border: #F6C9C7;
-  --color-info: #6D5EF6;
-  --color-info-light: #F2F0FE;
-  --color-info-border: #DCD5FB;
+  --color-info: #2563EB;
+  --color-info-text: #1D4ED8;
+  --color-info-light: #EFF6FF;
+  --color-info-border: #BFDBFE;
+  --color-text-inverse: #FFFFFF;
 
   /* ----------------------------------------
      Text Colors
@@ -140,9 +147,22 @@ html {
 }
 
 html[data-theme='dark'] {
+  --color-primary-border: color-mix(in srgb, var(--color-primary) 40%, transparent);
   --color-success-text: #4ADE80;
+  --color-success-light: color-mix(in srgb, var(--color-success) 14%, transparent);
+  --color-success-border: color-mix(in srgb, var(--color-success) 38%, transparent);
   --color-warning-text: #F6B84A;
+  --color-warning-light: color-mix(in srgb, var(--color-warning) 14%, transparent);
+  --color-warning-border: color-mix(in srgb, var(--color-warning) 38%, transparent);
+  --color-firing-text: #FDBA74;
+  --color-firing-light: color-mix(in srgb, var(--color-firing) 14%, transparent);
+  --color-firing-border: color-mix(in srgb, var(--color-firing) 38%, transparent);
   --color-error-text: #FF8581;
+  --color-error-light: color-mix(in srgb, var(--color-error) 14%, transparent);
+  --color-error-border: color-mix(in srgb, var(--color-error) 38%, transparent);
+  --color-info-text: #60A5FA;
+  --color-info-light: color-mix(in srgb, var(--color-info) 16%, transparent);
+  --color-info-border: color-mix(in srgb, var(--color-info) 40%, transparent);
 }
 
 html[data-theme='hybrid'] {
@@ -206,13 +226,13 @@ html[data-theme='hybrid'] {
   --el-color-error-light-9: var(--color-error-light) !important;
   --el-color-error-dark-2: #C73532 !important;
   --el-color-info: var(--color-info) !important;
-  --el-color-info-rgb: 109, 94, 246 !important;
+  --el-color-info-rgb: 37, 99, 235 !important;
   --el-color-info-light-3: var(--color-info-border) !important;
   --el-color-info-light-5: var(--color-info-border) !important;
   --el-color-info-light-7: var(--color-info-border) !important;
   --el-color-info-light-8: var(--color-info-light) !important;
   --el-color-info-light-9: var(--color-info-light) !important;
-  --el-color-info-dark-2: #5546D8 !important;
+  --el-color-info-dark-2: #1D4ED8 !important;
   --el-font-weight-primary: 400 !important;
   --el-button-font-weight: 400 !important;
   --el-input-focus-border: var(--color-primary) !important;

--- a/src/frontend/src/lib/statusTag.test.ts
+++ b/src/frontend/src/lib/statusTag.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   booleanStatusTag,
+  alertStatusTagAttrs,
   lifecycleStatusTone,
   severityStatusTagAttrs,
   statusTagAttrs,
@@ -53,6 +54,15 @@ describe('status tag semantic helpers', () => {
   it('keeps neutral separate from the purple info tone', () => {
     expect(statusTagAttrs('neutral')).toEqual({ class: 'hfl-tag--neutral' })
     expect(statusTagAttrs('info')).toEqual({ type: 'info' })
+  })
+
+  it.each([
+    ['firing', { class: 'hfl-tag--firing' }],
+    ['acknowledged', { type: 'info' }],
+    ['resolved', { type: 'success' }],
+    ['pending', { class: 'hfl-tag--neutral' }],
+  ])('maps alert status %s to its lifecycle tone', (status, attrs) => {
+    expect(alertStatusTagAttrs(status)).toEqual(attrs)
   })
 
   it.each([

--- a/src/frontend/src/lib/statusTag.ts
+++ b/src/frontend/src/lib/statusTag.ts
@@ -1,7 +1,7 @@
-export type StatusTagTone = 'success' | 'warning' | 'danger' | 'info' | 'primary' | 'neutral'
+export type StatusTagTone = 'success' | 'warning' | 'danger' | 'info' | 'primary' | 'firing' | 'neutral'
 
 export type StatusTagAttrs = {
-  type?: Exclude<StatusTagTone, 'neutral'>
+  type?: Exclude<StatusTagTone, 'neutral' | 'firing'>
   class?: string
 }
 
@@ -17,6 +17,7 @@ const STATUS_TAG_ATTRS: Record<StatusTagTone, StatusTagAttrs> = {
   danger: { type: 'danger' },
   info: { type: 'info' },
   primary: { type: 'primary' },
+  firing: { class: 'hfl-tag--firing' },
   neutral: { class: 'hfl-tag--neutral' },
 }
 
@@ -60,5 +61,13 @@ export function severityStatusTagAttrs(severity?: string | null): StatusTagAttrs
   if (normalized === 'info' || normalized === 'informational' || normalized === 'low') {
     return statusTagAttrs('info')
   }
+  return statusTagAttrs('neutral')
+}
+
+export function alertStatusTagAttrs(status?: string | null): StatusTagAttrs {
+  const normalized = String(status || '').trim().toLowerCase()
+  if (normalized === 'firing') return statusTagAttrs('firing')
+  if (normalized === 'acknowledged') return statusTagAttrs('info')
+  if (normalized === 'resolved') return statusTagAttrs('success')
   return statusTagAttrs('neutral')
 }

--- a/src/frontend/src/lib/taskStatusDisplay.test.ts
+++ b/src/frontend/src/lib/taskStatusDisplay.test.ts
@@ -3,8 +3,8 @@ import { normalizeTaskStatus, taskStatusTone } from './taskStatusDisplay'
 
 describe('taskStatusTone', () => {
   it.each([
-    ['pending', 'neutral'],
-    ['queued', 'neutral'],
+    ['pending', 'warning'],
+    ['queued', 'warning'],
     ['running', 'info'],
     ['in_progress', 'info'],
     ['dispatching', 'info'],

--- a/src/frontend/src/lib/taskStatusDisplay.ts
+++ b/src/frontend/src/lib/taskStatusDisplay.ts
@@ -17,7 +17,7 @@ export function taskStatusTone(status?: string | null): StatusTagTone {
   if (normalized === 'success' || normalized === 'available') return 'success'
   if (normalized === 'running' || normalized === 'dispatching' || normalized === 'creating') return 'info'
   if (normalized === 'failed' || normalized === 'timeout') return 'danger'
-  if (normalized === 'waiting' || normalized === 'blocked' || normalized === 'retrying' || normalized === 'partial' || normalized === 'degraded' || normalized === 'warning') return 'warning'
+  if (normalized === 'pending' || normalized === 'waiting' || normalized === 'blocked' || normalized === 'retrying' || normalized === 'partial' || normalized === 'degraded' || normalized === 'warning') return 'warning'
   return 'neutral'
 }
 

--- a/src/frontend/src/pages/ops/AlertIncidents.vue
+++ b/src/frontend/src/pages/ops/AlertIncidents.vue
@@ -12,7 +12,7 @@ import { useDebouncedAction } from '../../composables/useDebouncedAction'
 import { useResponsiveDrawerWidth } from '../../composables/useResponsiveDrawerWidth'
 import { formatLocalDateTime } from '../../lib/dateTime'
 import { apiErrorMessage } from '../../lib/api'
-import { severityStatusTagAttrs } from '../../lib/statusTag'
+import { alertStatusTagAttrs, severityStatusTagAttrs } from '../../lib/statusTag'
 import {
   acknowledgeRecord,
   listRecords,
@@ -113,12 +113,6 @@ function statusLabel(status: string) {
   if (status === 'acknowledged') return t('ops.alertsCenter.active.acknowledged')
   if (status === 'resolved') return t('ops.alerts.status.resolved')
   return status
-}
-
-function statusTagType(status: string): 'success' | 'warning' | 'info' {
-  if (status === 'resolved') return 'success'
-  if (status === 'firing') return 'warning'
-  return 'info'
 }
 
 async function fetchAlerts() {
@@ -312,31 +306,27 @@ watch(
         <OpsStatCard
           :label="t('ops.alertsCenter.common.critical')"
           :value="stats.critical"
-          accent="red"
+          tone="danger"
           accent-side="left"
-          value-class="text-red-600"
         />
         <OpsStatCard
           :label="t('ops.alertsCenter.common.warning')"
           :value="stats.warning"
-          accent="yellow"
+          tone="warning"
           accent-side="left"
-          value-class="text-amber-600"
         />
         <OpsStatCard
           :label="t('ops.alertsCenter.active.firing')"
           :value="stats.firing"
-          accent="orange"
+          tone="firing"
           accent-side="left"
-          value-class="text-orange-600"
           :pulse="stats.firing > 0"
         />
         <OpsStatCard
           :label="t('ops.alertsCenter.active.acknowledged')"
           :value="stats.acknowledged"
-          accent="blue"
+          tone="info"
           accent-side="left"
-          value-class="text-blue-600"
         />
       </div>
 
@@ -553,7 +543,7 @@ watch(
             >
               <template #default="{ row }">
                 <el-tag
-                  :type="statusTagType(row.status)"
+                  v-bind="alertStatusTagAttrs(row.status)"
                   size="small"
                 >
                   {{ statusLabel(row.status) }}
@@ -633,7 +623,7 @@ watch(
                 <span class="hfl-detail-row__label">{{ t('ops.alertsCenter.common.status') }}</span>
                 <span class="hfl-detail-row__value">
                   <el-tag
-                    :type="statusTagType(selected.status)"
+                    v-bind="alertStatusTagAttrs(selected.status)"
                     size="small"
                   >
                     {{ statusLabel(selected.status) }}

--- a/src/frontend/src/pages/ops/AlertPolicies.vue
+++ b/src/frontend/src/pages/ops/AlertPolicies.vue
@@ -590,22 +590,20 @@ watch(
         <OpsStatCard
           :label="t('ops.alertsCenter.common.policies')"
           :value="stats.total"
-          accent="indigo"
+          tone="primary"
           accent-side="left"
         />
         <OpsStatCard
           :label="t('ops.alertsCenter.common.enabled')"
           :value="stats.enabled"
-          accent="green"
+          tone="success"
           accent-side="left"
-          value-class="text-emerald-600"
         />
         <OpsStatCard
           :label="t('ops.alertsCenter.common.critical')"
           :value="stats.critical"
-          accent="red"
+          tone="danger"
           accent-side="left"
-          value-class="text-red-600"
         />
       </div>
 
@@ -1319,7 +1317,7 @@ watch(
 
 .hfl-alert-policy-detail-drawer__state {
   padding: 24px;
-  color: #64748b;
+  color: var(--color-text-secondary);
   font-size: 13px;
 }
 
@@ -1337,10 +1335,10 @@ watch(
   overflow: auto;
   margin: 0;
   padding: 10px 12px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--color-border);
   border-radius: 6px;
-  background: #f8fafc;
-  color: #334155;
+  background: var(--color-grey-1);
+  color: var(--color-text-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
   font-size: 12px;
   line-height: 1.5;

--- a/src/frontend/src/pages/ops/Audit.vue
+++ b/src/frontend/src/pages/ops/Audit.vue
@@ -421,26 +421,25 @@ watch(
         <OpsStatCard
           :label="t('ops.audit.statTotal')"
           :value="stats.total_count"
-          accent="indigo"
+          tone="primary"
           accent-side="left"
         />
         <OpsStatCard
           :label="t('ops.audit.statToday')"
           :value="stats.today_count"
-          accent="green"
+          tone="info"
           accent-side="left"
         />
         <OpsStatCard
           :label="t('ops.audit.statFailures')"
           :value="stats.failure_count"
-          accent="red"
+          tone="danger"
           accent-side="left"
-          value-class="text-red-600"
         />
         <OpsStatCard
           :label="t('ops.audit.statSuccessRate')"
           :value="`${stats.success_rate}%`"
-          accent="blue"
+          tone="success"
           accent-side="left"
         />
       </div>
@@ -615,7 +614,7 @@ watch(
             >
               <template #default="{ row }">
                 <span class="hfl-ops-user-chip hfl-audit-user-cell">
-                  <span class="hfl-audit-user-cell__name font-medium text-slate-800">
+                  <span class="hfl-audit-user-cell__name font-medium">
                     {{ row.user_display || t('ops.audit.systemUser') }}
                   </span>
                 </span>
@@ -995,7 +994,7 @@ watch(
                 <span class="hfl-detail-row__label">{{ t('ops.audit.errorMessage') }}</span>
                 <span
                   class="hfl-detail-row__value"
-                  :class="{ 'text-red-600': detailLog.error_message, 'hfl-detail-row__empty': !hasDisplayValue(detailLog.error_message) }"
+                  :class="{ 'hfl-audit-detail-error': detailLog.error_message, 'hfl-detail-row__empty': !hasDisplayValue(detailLog.error_message) }"
                 >
                   {{ displayValue(detailLog.error_message) }}
                 </span>
@@ -1091,6 +1090,11 @@ watch(
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--color-text-title);
+}
+
+.hfl-audit-detail-error {
+  color: var(--color-error-text);
 }
 
 .hfl-audit-filter-drawer :deep(.el-drawer__body) {
@@ -1107,10 +1111,10 @@ watch(
   padding: 10px 12px;
   margin: 0;
   overflow: auto;
-  border: 1px solid var(--color-border, #e2e8f0);
+  border: 1px solid var(--color-border);
   border-radius: 6px;
-  background: rgb(248 250 252);
-  color: rgb(51 65 85);
+  background: var(--color-grey-1);
+  color: var(--color-text-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
   font-size: 12px;
   line-height: 1.55;

--- a/src/frontend/src/pages/ops/NotificationChannels.vue
+++ b/src/frontend/src/pages/ops/NotificationChannels.vue
@@ -1047,26 +1047,25 @@ watch(
         <OpsStatCard
           :label="t('ops.notification.filterActive')"
           :value="stats.enabled"
-          accent="green"
+          tone="success"
           accent-side="left"
-          value-class="text-emerald-600"
         />
         <OpsStatCard
           :label="t('ops.notification.channelsTitle')"
           :value="stats.total"
-          accent="indigo"
+          tone="primary"
           accent-side="left"
         />
         <OpsStatCard
           :label="t('ops.notification.filterInactive')"
           :value="stats.disabled"
-          accent="gray"
+          tone="neutral"
           accent-side="left"
         />
         <OpsStatCard
           :label="t('ops.notification.enabledRate')"
           :value="stats.total ? `${Math.round(stats.enabledRate)}%` : '—'"
-          accent="blue"
+          tone="success"
           accent-side="left"
         />
       </div>
@@ -1435,25 +1434,25 @@ watch(
                   <OpsStatCard
                     :label="t('ops.notification.logsCount')"
                     :value="details.stats.logs_count ?? 0"
-                    accent="indigo"
+                    tone="primary"
                     accent-side="left"
                   />
                   <OpsStatCard
                     :label="t('ops.notification.successRate')"
                     :value="`${details.stats.success_rate ?? 0}%`"
-                    accent="green"
+                    tone="success"
                     accent-side="left"
                   />
                   <OpsStatCard
                     :label="t('ops.notification.policiesCount')"
                     :value="details.stats.policies_count ?? 0"
-                    accent="blue"
+                    tone="info"
                     accent-side="left"
                   />
                   <OpsStatCard
                     :label="t('ops.notification.alertsCount')"
                     :value="details.stats.alerts_count ?? 0"
-                    accent="orange"
+                    tone="warning"
                     accent-side="left"
                   />
                 </div>
@@ -1931,13 +1930,13 @@ watch(
 }
 
 .hfl-ops-channel-detail-drawer__loading {
-  background: rgba(148, 163, 184, 0.12);
-  color: rgb(71 85 105);
+  background: var(--color-grey-2);
+  color: var(--color-text-primary);
 }
 
 .hfl-ops-channel-detail-drawer__error {
-  background: rgba(239, 68, 68, 0.08);
-  color: rgb(185 28 28);
+  background: var(--color-error-light);
+  color: var(--color-error-text);
 }
 
 .hfl-ops-channel-detail-drawer__error-text {
@@ -1946,16 +1945,16 @@ watch(
 
 .notification-batch-impact {
   border-radius: 8px;
-  background: var(--el-fill-color-blank, #fafafa);
+  background: var(--el-fill-color-blank);
   overflow: hidden;
 }
 
 .notification-batch-impact__heading {
   padding: 10px 12px 8px;
-  background: var(--el-fill-color-blank, #fafafa);
+  background: var(--el-fill-color-blank);
   font-size: 12px;
   font-weight: 600;
-  color: var(--el-text-color-secondary, #4b5563);
+  color: var(--el-text-color-secondary);
 }
 
 .notification-batch-impact__table {
@@ -1966,7 +1965,7 @@ watch(
 .notification-batch-impact__hint {
   min-width: 0;
   overflow: hidden;
-  color: var(--el-text-color-secondary, #6b7280);
+  color: var(--el-text-color-secondary);
   font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1976,7 +1975,7 @@ watch(
 
 .hfl-ops-channel-detail-drawer__event-title {
   font-weight: 500;
-  color: rgb(15 23 42);
+  color: var(--color-text-title);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1984,7 +1983,7 @@ watch(
 
 .hfl-ops-channel-detail-drawer__event-meta {
   font-size: 11px;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1993,7 +1992,7 @@ watch(
 .hfl-ops-channel-detail-drawer__error-msg {
   margin-top: 4px;
   font-size: 11px;
-  color: rgb(185 28 28);
+  color: var(--color-error-text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/frontend/src/pages/ops/NotificationRecords.vue
+++ b/src/frontend/src/pages/ops/NotificationRecords.vue
@@ -11,7 +11,7 @@ import { useDebouncedAction } from '../../composables/useDebouncedAction'
 import { useResponsiveDrawerWidth } from '../../composables/useResponsiveDrawerWidth'
 import { useAlertPolicyLabels } from '../../composables/useAlertPolicyLabels'
 import { formatLocalDateTime } from '../../lib/dateTime'
-import { lifecycleStatusTagAttrs, severityStatusTagAttrs, statusTagAttrs } from '../../lib/statusTag'
+import { alertStatusTagAttrs, lifecycleStatusTagAttrs, severityStatusTagAttrs } from '../../lib/statusTag'
 import { listChannels, listLogs, logStats, type NotificationLog } from '../../lib/notificationApi'
 
 const { t } = useI18n()
@@ -68,7 +68,7 @@ function notificationTypeLabel(type?: string | null) {
 }
 
 function notificationTypeTagAttrs(type?: string | null) {
-  return statusTagAttrs(type === 'resolved' ? 'success' : type === 'firing' ? 'warning' : 'neutral')
+  return alertStatusTagAttrs(type)
 }
 
 function severityLabel(severity?: string | null) {
@@ -200,27 +200,25 @@ watch(
         <OpsStatCard
           :label="t('ops.notification.logsTotal')"
           :value="stats.total"
-          accent="indigo"
+          tone="primary"
           accent-side="left"
         />
         <OpsStatCard
           :label="t('ops.notification.statusSuccess')"
           :value="stats.success"
-          accent="green"
+          tone="success"
           accent-side="left"
-          value-class="text-emerald-600"
         />
         <OpsStatCard
           :label="t('ops.notification.statusFailed')"
           :value="stats.failed"
-          accent="red"
+          tone="danger"
           accent-side="left"
-          value-class="text-red-600"
         />
         <OpsStatCard
           :label="t('ops.notification.successRate')"
           :value="`${stats.success_rate}%`"
-          accent="blue"
+          tone="success"
           accent-side="left"
         />
       </div>

--- a/src/frontend/src/pages/ops/Tasks.vue
+++ b/src/frontend/src/pages/ops/Tasks.vue
@@ -1028,9 +1028,8 @@ watch(
         <OpsStatCard
           :label="t('ops.task.status.running')"
           :value="stats.running"
-          accent="blue"
+          tone="info"
           accent-side="left"
-          value-class="text-blue-600"
           :pulse="stats.running > 0"
         >
           <template #icon>
@@ -1040,7 +1039,7 @@ watch(
         <OpsStatCard
           :label="t('ops.task.status.pending')"
           :value="stats.by_status?.pending ?? 0"
-          accent="gray"
+          tone="warning"
           accent-side="left"
         >
           <template #icon>
@@ -1050,9 +1049,8 @@ watch(
         <OpsStatCard
           :label="t('ops.task.status.success')"
           :value="stats.success"
-          accent="green"
+          tone="success"
           accent-side="left"
-          value-class="text-emerald-600"
         >
           <template #icon>
             <Check :size="17" />
@@ -1061,9 +1059,8 @@ watch(
         <OpsStatCard
           :label="t('ops.task.status.failedTimedOut')"
           :value="stats.failed + stats.timeout"
-          accent="red"
+          tone="danger"
           accent-side="left"
-          value-class="text-red-600"
         >
           <template #icon>
             <AlertTriangle :size="17" />
@@ -1072,7 +1069,7 @@ watch(
         <OpsStatCard
           :label="t('ops.task.status.cancelled')"
           :value="stats.cancelled"
-          accent="gray"
+          tone="neutral"
           accent-side="left"
         >
           <template #icon>
@@ -2213,8 +2210,8 @@ watch(
 .hfl-task-drawer :deep(.el-drawer__header) {
   margin: 0;
   padding: 10px 24px 8px;
-  border-bottom: 1px solid rgb(241 245 249);
-  background: rgba(255, 255, 255, 0.96);
+  border-bottom: 1px solid var(--color-border-light);
+  background: color-mix(in srgb, var(--color-card-bg) 96%, transparent);
   backdrop-filter: blur(8px);
 }
 
@@ -2239,7 +2236,7 @@ watch(
 
 .hfl-task-drawer :deep(.el-drawer__body) {
   padding: 0;
-  background: #fff;
+  background: var(--color-card-bg);
 }
 
 .hfl-task-drawer__header-bar {
@@ -2266,7 +2263,7 @@ watch(
   font-size: 18px;
   font-weight: 700;
   line-height: 1.25;
-  color: rgb(15 23 42);
+  color: var(--color-text-title);
   overflow-wrap: anywhere;
 }
 
@@ -2278,14 +2275,14 @@ watch(
   margin-top: 6px;
   min-width: 0;
   font-size: 12px;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
 }
 
 .hfl-task-drawer__header-divider {
   align-self: center;
   width: 1px;
   height: 12px;
-  background: rgb(203 213 225);
+  background: var(--color-border);
 }
 
 .hfl-task-drawer__header-actions {
@@ -2316,7 +2313,7 @@ watch(
 .hfl-task-drawer__cancel-button:hover:not(:disabled) {
   border-color: var(--color-error);
   background: var(--color-error);
-  color: #fff;
+  color: var(--color-text-inverse);
 }
 
 .hfl-task-drawer__cancel-button:focus-visible {
@@ -2341,9 +2338,9 @@ watch(
 .hfl-task-drawer__loading {
   min-height: 320px;
   padding: 16px;
-  border: 1px solid var(--color-border, #e2e8f0);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: rgb(248 250 252);
+  background: var(--color-grey-1);
 }
 
 .hfl-task-drawer__hero {
@@ -2352,10 +2349,10 @@ watch(
   gap: 14px;
   margin: 0;
   padding: 16px;
-  border: 1px solid var(--color-border, #e2e8f0);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: rgb(248 250 252);
-  box-shadow: inset 0 1px 1px rgba(15, 23, 42, 0.03);
+  background: var(--color-grey-1);
+  box-shadow: inset 0 1px 1px color-mix(in srgb, var(--color-text-title) 3%, transparent);
 }
 
 .hfl-task-drawer__hero-section-title {
@@ -2363,7 +2360,7 @@ watch(
   font-weight: 800;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
 }
 
 .hfl-task-drawer__uuid {
@@ -2375,7 +2372,7 @@ watch(
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
   font-size: 11px;
   font-weight: 700;
-  color: rgb(71 85 105);
+  color: var(--color-text-primary);
   overflow-wrap: anywhere;
 }
 
@@ -2384,7 +2381,7 @@ watch(
   width: 20px;
   height: 20px;
   padding: 0;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
 }
 
 .hfl-task-drawer__hero-grid {
@@ -2405,10 +2402,10 @@ watch(
   gap: 12px;
   min-width: 0;
   padding: 14px;
-  border: 1px solid var(--color-border-light, #f1f5f9);
+  border: 1px solid var(--color-border-light);
   border-radius: 10px;
-  background: #fff;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.03);
+  background: var(--color-card-bg);
+  box-shadow: var(--shadow-sm);
 }
 
 .hfl-task-drawer__metric--wide {
@@ -2418,15 +2415,15 @@ watch(
 .hfl-task-drawer__metric-icon {
   flex: 0 0 18px;
   margin-top: 2px;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
 }
 
 .hfl-task-drawer__metric-icon--blue {
-  color: rgb(14 165 233);
+  color: var(--color-info);
 }
 
 .hfl-task-drawer__metric-icon--indigo {
-  color: rgb(79 70 229);
+  color: var(--color-primary);
 }
 
 .hfl-task-drawer__metric-copy {
@@ -2437,7 +2434,7 @@ watch(
   display: block;
   font-size: 12px;
   font-weight: 600;
-  color: rgb(148 163 184);
+  color: var(--color-text-tertiary);
 }
 
 .hfl-task-drawer__metric-value {
@@ -2445,7 +2442,7 @@ watch(
   margin-top: 4px;
   font-size: 14px;
   font-weight: 800;
-  color: rgb(15 23 42);
+  color: var(--color-text-title);
 }
 
 .hfl-task-drawer__metric-tags {
@@ -2477,7 +2474,7 @@ watch(
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
   font-size: 12px;
   font-weight: 600;
-  color: rgb(51 65 85);
+  color: var(--color-text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2505,7 +2502,7 @@ watch(
   margin-bottom: 8px;
   font-size: 12px;
   font-weight: 700;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
 }
 
 .hfl-task-drawer__progress-head span:last-child {
@@ -2517,7 +2514,7 @@ watch(
   height: 6px;
   overflow: hidden;
   border-radius: 999px;
-  background-color: rgb(226 232 240);
+  background-color: var(--color-border);
 }
 
 .hfl-task-drawer__progress-fill {
@@ -2543,42 +2540,42 @@ watch(
 
 .hfl-task-drawer__progress-fill--pending,
 .hfl-task-drawer__progress-fill--cancelled {
-  background-color: rgb(100 116 139);
+  background-color: var(--color-text-secondary);
 }
 
 .hfl-task-drawer__timeline-icon--success {
   border-color: var(--color-success);
   background-color: var(--color-success);
-  color: #fff;
+  color: var(--color-text-inverse);
 }
 
 .hfl-task-drawer__timeline-icon--danger {
   border-color: var(--color-error);
   background-color: var(--color-error);
-  color: #fff;
+  color: var(--color-text-inverse);
 }
 
 .hfl-task-drawer__timeline-icon--warning {
   border-color: var(--color-warning);
   background-color: var(--color-warning);
-  color: #fff;
+  color: var(--color-text-inverse);
 }
 
 .hfl-task-drawer__timeline-icon--running {
   border-color: var(--color-info);
   background-color: var(--color-info);
-  color: #fff;
+  color: var(--color-text-inverse);
 }
 
 .hfl-task-drawer__timeline-icon--muted {
-  border-color: rgb(100 116 139);
-  background-color: rgb(100 116 139);
-  color: #fff;
+  border-color: var(--color-text-secondary);
+  background-color: var(--color-text-secondary);
+  color: var(--color-text-inverse);
 }
 
 .hfl-task-drawer__timeline-icon--pending {
-  background-color: rgb(100 116 139);
-  color: #fff;
+  background-color: var(--color-text-secondary);
+  color: var(--color-text-inverse);
 }
 
 .hfl-task-drawer__tabs {
@@ -2594,7 +2591,7 @@ watch(
   border: 1px solid var(--color-warning-border);
   border-radius: 12px;
   background: var(--color-warning-light);
-  color: rgb(120 53 15);
+  color: var(--color-warning-text);
 }
 
 .hfl-task-drawer__cleanup-outcome-head {
@@ -2661,7 +2658,7 @@ watch(
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
   font-size: 12px;
   font-weight: 700;
 }
@@ -2687,7 +2684,7 @@ watch(
   top: 34px;
   bottom: -18px;
   width: 0;
-  border-left: 2px dashed rgb(226 232 240);
+  border-left: 2px dashed var(--color-border);
 }
 
 .hfl-task-drawer__step-item--last::before {
@@ -2703,23 +2700,23 @@ watch(
   width: 26px;
   height: 26px;
   margin-top: 1px;
-  border: 2px solid #fff;
+  border: 2px solid var(--color-card-bg);
   border-radius: 999px;
 }
 
 .hfl-task-drawer__step-card {
   min-width: 0;
   padding: 14px 16px;
-  border: 1px solid var(--color-border, #e2e8f0);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: #fff;
-  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.05);
+  background: var(--color-card-bg);
+  box-shadow: var(--shadow-sm);
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .hfl-task-drawer__step-card:hover {
-  border-color: rgb(203 213 225);
-  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.06);
+  border-color: var(--color-border-light);
+  box-shadow: var(--shadow-md);
 }
 
 .hfl-task-drawer__step-card-head {
@@ -2745,7 +2742,7 @@ watch(
   font-size: 14px;
   font-weight: 800;
   line-height: 1.45;
-  color: rgb(15 23 42);
+  color: var(--color-text-title);
   overflow-wrap: anywhere;
 }
 
@@ -2755,7 +2752,7 @@ watch(
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
   font-size: 11px;
   font-weight: 700;
-  color: rgb(71 85 105);
+  color: var(--color-text-primary);
 }
 
 .hfl-task-drawer__step-duration {
@@ -2764,10 +2761,10 @@ watch(
   gap: 4px;
   flex-shrink: 0;
   padding: 2px 7px;
-  border: 1px solid rgb(241 245 249);
+  border: 1px solid var(--color-border-light);
   border-radius: 6px;
-  background: rgb(248 250 252);
-  color: rgb(100 116 139);
+  background: var(--color-grey-1);
+  color: var(--color-text-secondary);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
   font-size: 11px;
   font-weight: 700;
@@ -2776,7 +2773,7 @@ watch(
 .hfl-task-drawer__step-created {
   font-size: 11px;
   font-weight: 700;
-  color: rgb(148 163 184);
+  color: var(--color-text-tertiary);
 }
 
 .hfl-task-drawer__event-list,
@@ -2786,13 +2783,13 @@ watch(
   gap: 10px;
   margin-top: 14px;
   padding-top: 12px;
-  border-top: 1px solid rgb(241 245 249);
+  border-top: 1px solid var(--color-border-light);
 }
 
 .hfl-task-drawer__event-only {
   margin-top: 0;
   padding: 14px;
-  border: 1px solid var(--color-border, #e2e8f0);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
 }
 
@@ -2813,7 +2810,7 @@ watch(
   margin-top: 3px;
   border-radius: 999px;
   background-color: var(--color-success);
-  color: #fff;
+  color: var(--color-text-inverse);
 }
 
 .hfl-task-drawer__event-dot--danger {
@@ -2829,7 +2826,7 @@ watch(
 }
 
 .hfl-task-drawer__event-dot--muted {
-  background-color: rgb(100 116 139);
+  background-color: var(--color-text-secondary);
 }
 
 .hfl-task-drawer__event-msg {
@@ -2838,7 +2835,7 @@ watch(
   font-size: 12px;
   line-height: 1.55;
   font-weight: 400;
-  color: rgb(51 65 85);
+  color: var(--color-text-primary);
 }
 
 .hfl-task-drawer__event-content {
@@ -2854,11 +2851,11 @@ watch(
   max-width: 100%;
   align-items: flex-start;
   gap: 4px;
-  border: 1px solid rgb(226 232 240);
+  border: 1px solid var(--color-border);
   border-radius: 6px;
-  background: rgb(248 250 252);
+  background: var(--color-grey-1);
   padding: 2px 6px;
-  color: rgb(71 85 105);
+  color: var(--color-text-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
   font-size: 11px;
   line-height: 1.45;
@@ -2868,13 +2865,13 @@ watch(
 .hfl-task-drawer__event-object svg {
   margin-top: 2px;
   flex: 0 0 auto;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
 }
 
 .hfl-task-drawer__event-error {
   display: block;
   max-width: 100%;
-  color: rgb(185 28 28);
+  color: var(--color-error-text);
   font-size: 12px;
   line-height: 1.45;
   overflow-wrap: anywhere;
@@ -2882,11 +2879,11 @@ watch(
 }
 
 .hfl-task-drawer__event-msg--danger {
-  color: rgb(185 28 28);
+  color: var(--color-error-text);
 }
 
 .hfl-task-drawer__event-msg--muted {
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
 }
 
 .hfl-task-drawer__event-time {
@@ -2894,7 +2891,7 @@ watch(
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
   font-size: 11px;
   font-weight: 600;
@@ -2912,13 +2909,13 @@ watch(
   gap: 12px;
   min-width: 0;
   padding: 16px;
-  border: 1px solid var(--color-border, #e2e8f0);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
-  background: #fff;
+  background: var(--color-card-bg);
 }
 
 .hfl-task-drawer__panel--code {
-  background: rgb(248 250 252);
+  background: var(--color-grey-1);
 }
 
 .hfl-task-drawer__panel-head {
@@ -2926,12 +2923,12 @@ watch(
   align-items: center;
   gap: 8px;
   padding-bottom: 10px;
-  border-bottom: 1px solid rgb(241 245 249);
-  color: rgb(15 23 42);
+  border-bottom: 1px solid var(--color-border-light);
+  color: var(--color-text-title);
 }
 
 .hfl-task-drawer__panel-icon {
-  color: rgb(43 125 196);
+  color: var(--color-info);
   flex: 0 0 16px;
 }
 
@@ -2964,10 +2961,10 @@ watch(
   align-items: center;
   gap: 7px;
   padding: 7px 11px;
-  border: 1px solid rgb(226 232 240);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
-  background: #fff;
-  color: rgb(71 85 105);
+  background: var(--color-card-bg);
+  color: var(--color-text-primary);
   font-size: 12px;
   font-weight: 700;
   cursor: pointer;
@@ -2988,10 +2985,10 @@ watch(
 
 .hfl-task-drawer__resource-error {
   padding: 10px 12px;
-  border: 1px solid rgb(254 202 202);
+  border: 1px solid var(--color-error-border);
   border-radius: 8px;
-  background: rgb(254 242 242);
-  color: rgb(185 28 28);
+  background: var(--color-error-light);
+  color: var(--color-error-text);
   font-size: 12px;
   font-weight: 600;
 }
@@ -3004,13 +3001,13 @@ watch(
 .hfl-task-drawer__resource-name {
   font-size: 13px;
   font-weight: 700;
-  color: rgb(15 23 42);
+  color: var(--color-text-title);
 }
 
 .hfl-task-drawer__resource-summary {
   margin-top: 2px;
   font-size: 11px;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
 }
 
 .hfl-task-drawer__resource-card {
@@ -3018,14 +3015,14 @@ watch(
   flex-direction: column;
   gap: 4px;
   padding: 10px 12px;
-  border: 1px solid var(--color-border, #e2e8f0);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
-  background: rgb(248 250 252);
+  background: var(--color-grey-1);
   transition: border-color 0.15s ease;
 }
 
 .hfl-task-drawer__resource-card:hover {
-  border-color: rgb(43 125 196);
+  border-color: var(--color-info);
 }
 
 .hfl-task-drawer__resource-type {
@@ -3033,7 +3030,7 @@ watch(
   align-items: center;
   gap: 4px;
   font-size: 12px;
-  color: rgb(71 85 105);
+  color: var(--color-text-primary);
   font-weight: 600;
 }
 
@@ -3041,13 +3038,13 @@ watch(
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
   font-size: 13px;
   font-weight: 600;
-  color: rgb(15 23 42);
+  color: var(--color-text-title);
 }
 
 .hfl-task-drawer__empty-line {
   padding: 6px 0;
   font-size: 13px;
-  color: rgb(148 163 184);
+  color: var(--color-text-tertiary);
 }
 
 @media (max-width: 760px) {

--- a/src/frontend/src/styles/detail-page-ui.css
+++ b/src/frontend/src/styles/detail-page-ui.css
@@ -694,7 +694,7 @@
   height: 6px;
   overflow: hidden;
   border-radius: 999px;
-  background: #e8edf3;
+  background: var(--color-border);
 }
 
 .hfl-detail-capacity-bar__fill {
@@ -749,7 +749,7 @@
 .hfl-detail-row__empty,
 .detail-page-row__empty,
 .repo-detail-row__empty {
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
   font-family: inherit;
   font-size: 13px;
   font-weight: 400;
@@ -757,7 +757,7 @@
 
 .hfl-empty-mark {
   align-self: flex-start;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
   font-family: inherit;
   font-size: 13px;
   font-weight: 400;
@@ -804,7 +804,7 @@
 .repo-detail-row__edit {
   flex: 0 0 auto;
   margin-left: auto;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
   opacity: 0;
   transition: opacity 0.16s ease, color 0.16s ease;
 }
@@ -841,7 +841,7 @@
 .detail-inline-edit__unit,
 .repo-inline-edit__unit {
   flex: 0 0 auto;
-  color: rgb(100 116 139);
+  color: var(--color-text-secondary);
   font-size: 12px;
 }
 
@@ -1096,7 +1096,7 @@
 
 .hfl-task-step-chevron {
   flex-shrink: 0;
-  color: rgb(148 163 184);
+  color: var(--color-text-tertiary);
 }
 
 .hfl-task-drawer__step-card-head--disabled,

--- a/src/frontend/src/styles/element-plus-tag.css
+++ b/src/frontend/src/styles/element-plus-tag.css
@@ -25,14 +25,31 @@
   border-color: var(--color-error-border);
 }
 
-.el-tag.el-tag--primary:not(.el-tag--dark):not(.el-tag--plain),
+.el-tag.el-tag--primary:not(.el-tag--dark):not(.el-tag--plain) {
+  --el-tag-text-color: var(--color-primary);
+  --el-tag-bg-color: var(--color-primary-light);
+  --el-tag-border-color: var(--color-primary-border);
+  color: var(--color-primary);
+  background-color: var(--color-primary-light);
+  border-color: var(--color-primary-border);
+}
+
 .el-tag.el-tag--info:not(.el-tag--dark):not(.el-tag--plain) {
-  --el-tag-text-color: var(--color-info);
+  --el-tag-text-color: var(--color-info-text);
   --el-tag-bg-color: var(--color-info-light);
   --el-tag-border-color: var(--color-info-border);
-  color: var(--color-info);
+  color: var(--color-info-text);
   background-color: var(--color-info-light);
   border-color: var(--color-info-border);
+}
+
+.el-tag.hfl-tag--firing:not(.el-tag--dark):not(.el-tag--plain) {
+  --el-tag-text-color: var(--color-firing-text);
+  --el-tag-bg-color: var(--color-firing-light);
+  --el-tag-border-color: var(--color-firing-border);
+  color: var(--color-firing-text);
+  background-color: var(--color-firing-light);
+  border-color: var(--color-firing-border);
 }
 
 .el-tag.hfl-tag--neutral:not(.el-tag--dark):not(.el-tag--plain),

--- a/src/frontend/src/styles/emptyValuePresentation.test.ts
+++ b/src/frontend/src/styles/emptyValuePresentation.test.ts
@@ -20,7 +20,7 @@ describe('global empty value presentation', () => {
     const tableRule = styles.match(/\.el-table \.hfl-empty-mark\s*\{([\s\S]*?)\}/)?.[1] ?? ''
 
     for (const rule of [detailRule, emptyMarkRule]) {
-      expect(rule).toContain('color: rgb(100 116 139)')
+      expect(rule).toContain('color: var(--color-text-secondary)')
       expect(rule).toContain('font-family: inherit')
       expect(rule).toContain('font-size: 13px')
       expect(rule).toContain('font-weight: 400')

--- a/src/frontend/src/styles/ops-list-ui.css
+++ b/src/frontend/src/styles/ops-list-ui.css
@@ -24,7 +24,7 @@
   margin: 0;
   font-size: 13px;
   line-height: 1.5;
-  color: var(--color-text-secondary, #64748b);
+  color: var(--color-text-secondary);
 }
 
 .hfl-ops-stats-grid {
@@ -89,67 +89,74 @@
 }
 
 .hfl-ops-stat-card {
+  --hfl-ops-stat-accent: var(--color-primary);
+  --hfl-ops-stat-accent-soft: var(--color-primary-light);
+  --hfl-ops-stat-value: var(--color-primary);
   display: flex;
   flex-direction: column;
   gap: 8px;
   padding: 16px;
-  border: 1px solid var(--color-border, #e2e8f0);
-  border-radius: var(--radius-card, 12px);
-  background: var(--color-card-bg, #fff);
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
-  transition: background-color 0.15s ease, box-shadow 0.15s ease;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  background: var(--color-card-bg);
+  box-shadow: var(--shadow-sm);
+  transition: background-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .hfl-ops-stat-card:hover {
-  background: rgba(248, 250, 252, 0.9);
+  background: var(--color-grey-1);
 }
 
 .hfl-ops-stat-card--side-left {
   border-left-width: 4px;
+  border-left-color: var(--hfl-ops-stat-accent);
 }
 
 .hfl-ops-stat-card--side-top {
   border-top-width: 4px;
+  border-top-color: var(--hfl-ops-stat-accent);
 }
 
-.hfl-ops-stat-card--red {
-  border-left-color: #ef4444;
-  border-top-color: #ef4444;
+.hfl-ops-stat-card--tone-primary {
+  --hfl-ops-stat-accent: var(--color-primary);
+  --hfl-ops-stat-accent-soft: var(--color-primary-light);
+  --hfl-ops-stat-value: var(--color-primary);
 }
 
-.hfl-ops-stat-card--yellow {
-  border-left-color: #eab308;
-  border-top-color: #eab308;
+.hfl-ops-stat-card--tone-success {
+  --hfl-ops-stat-accent: var(--color-success);
+  --hfl-ops-stat-accent-soft: var(--color-success-light);
+  --hfl-ops-stat-value: var(--color-success-text);
 }
 
-.hfl-ops-stat-card--green {
-  border-left-color: #22c55e;
-  border-top-color: #22c55e;
+.hfl-ops-stat-card--tone-warning {
+  --hfl-ops-stat-accent: var(--color-warning);
+  --hfl-ops-stat-accent-soft: var(--color-warning-light);
+  --hfl-ops-stat-value: var(--color-warning-text);
 }
 
-.hfl-ops-stat-card--blue {
-  border-left-color: #3b82f6;
-  border-top-color: #3b82f6;
+.hfl-ops-stat-card--tone-danger {
+  --hfl-ops-stat-accent: var(--color-error);
+  --hfl-ops-stat-accent-soft: var(--color-error-light);
+  --hfl-ops-stat-value: var(--color-error-text);
 }
 
-.hfl-ops-stat-card--indigo {
-  border-left-color: #6366f1;
-  border-top-color: #6366f1;
+.hfl-ops-stat-card--tone-info {
+  --hfl-ops-stat-accent: var(--color-info);
+  --hfl-ops-stat-accent-soft: var(--color-info-light);
+  --hfl-ops-stat-value: var(--color-info-text);
 }
 
-.hfl-ops-stat-card--orange {
-  border-left-color: #d97706;
-  border-top-color: #d97706;
+.hfl-ops-stat-card--tone-firing {
+  --hfl-ops-stat-accent: var(--color-firing);
+  --hfl-ops-stat-accent-soft: var(--color-firing-light);
+  --hfl-ops-stat-value: var(--color-firing-text);
 }
 
-.hfl-ops-stat-card--pink {
-  border-left-color: #ec4899;
-  border-top-color: #ec4899;
-}
-
-.hfl-ops-stat-card--gray {
-  border-left-color: #94a3b8;
-  border-top-color: #94a3b8;
+.hfl-ops-stat-card--tone-neutral {
+  --hfl-ops-stat-accent: var(--color-grey-6);
+  --hfl-ops-stat-accent-soft: var(--color-grey-2);
+  --hfl-ops-stat-value: var(--color-text-secondary);
 }
 
 .hfl-ops-stat-card__head {
@@ -166,7 +173,7 @@
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--color-text-tertiary, #94a3b8);
+  color: var(--color-text-tertiary);
 }
 
 .hfl-ops-stat-card__icon {
@@ -177,48 +184,8 @@
   width: 28px;
   height: 28px;
   border-radius: 8px;
-  background: #f8fafc;
-  color: var(--color-text-tertiary, #94a3b8);
-}
-
-.hfl-ops-stat-card--orange .hfl-ops-stat-card__icon {
-  background: var(--color-warning-light);
-  color: var(--color-warning);
-}
-
-.hfl-ops-stat-card--indigo .hfl-ops-stat-card__icon {
-  background: #eef2ff;
-  color: #4f46e5;
-}
-
-.hfl-ops-stat-card--blue .hfl-ops-stat-card__icon {
-  background: var(--color-info-light);
-  color: var(--color-info);
-}
-
-.hfl-ops-stat-card--green .hfl-ops-stat-card__icon {
-  background: var(--color-success-light);
-  color: var(--color-success);
-}
-
-.hfl-ops-stat-card--yellow .hfl-ops-stat-card__icon {
-  background: #fefce8;
-  color: #ca8a04;
-}
-
-.hfl-ops-stat-card--red .hfl-ops-stat-card__icon {
-  background: var(--color-error-light);
-  color: var(--color-error);
-}
-
-.hfl-ops-stat-card--pink .hfl-ops-stat-card__icon {
-  background: #fdf2f8;
-  color: #db2777;
-}
-
-.hfl-ops-stat-card--gray .hfl-ops-stat-card__icon {
-  background: #f8fafc;
-  color: #64748b;
+  background: var(--hfl-ops-stat-accent-soft);
+  color: var(--hfl-ops-stat-accent);
 }
 
 .hfl-ops-stat-card__value-row {
@@ -232,13 +199,13 @@
   font-size: 1.5rem;
   font-weight: 700;
   line-height: 1.2;
-  color: rgb(15 23 42);
+  color: var(--hfl-ops-stat-value);
 }
 
 .hfl-ops-stat-card__sub {
   min-width: 0;
   overflow: hidden;
-  color: var(--color-text-tertiary, #94a3b8);
+  color: var(--color-text-tertiary);
   font-size: 11px;
   line-height: 1.4;
   text-overflow: ellipsis;
@@ -279,7 +246,7 @@
   width: 8px;
   height: 8px;
   border-radius: 999px;
-  background: #d97706;
+  background: var(--hfl-ops-stat-accent);
 }
 
 .hfl-ops-stat-card__pulse::before {
@@ -356,13 +323,13 @@
 }
 
 .hfl-ops-cell-stack__title {
-  color: rgb(15 23 42);
+  color: var(--color-text-title);
 }
 
 .hfl-ops-cell-stack__meta {
   margin-top: 2px;
   font-size: 11px;
-  color: var(--color-text-tertiary, #94a3b8);
+  color: var(--color-text-tertiary);
 }
 
 .hfl-ops-response-chip {
@@ -381,7 +348,7 @@
   font-size: 11px;
   line-height: 1.45;
   text-align: left;
-  color: rgb(71 85 105);
+  color: var(--color-text-primary);
   cursor: pointer;
 }
 
@@ -396,7 +363,7 @@
 
 .hfl-ops-response-chip:hover,
 .hfl-ops-response-chip:focus-visible {
-  color: var(--color-primary, #6d5dfc);
+  color: var(--color-primary);
   outline: none;
   text-decoration: underline;
   text-underline-offset: 3px;
@@ -425,11 +392,11 @@
 }
 
 .hfl-ops-result-chip--success {
-  color: #16a34a;
+  color: var(--color-success-text);
 }
 
 .hfl-ops-result-chip--danger {
-  color: #dc2626;
+  color: var(--color-error-text);
 }
 
 .hfl-ops-result-tag {
@@ -465,9 +432,9 @@
   display: inline-flex;
   padding: 2px 8px;
   border-radius: 6px;
-  background: #f1f5f9;
+  background: var(--color-grey-2);
   font-size: 10px;
-  color: rgb(71 85 105);
+  color: var(--color-text-primary);
 }
 
 /* ============================================
@@ -487,7 +454,7 @@
   height: 6px;
   overflow: hidden;
   border-radius: 999px;
-  background-color: rgb(226 232 240);
+  background-color: var(--color-border);
 }
 
 .hfl-task-list-progress__fill {
@@ -509,7 +476,7 @@
 
 .hfl-task-list-progress__fill--pending,
 .hfl-task-list-progress__fill--cancelled {
-  background-color: rgb(100 116 139);
+  background-color: var(--color-text-secondary);
 }
 
 .hfl-task-list-progress__text {

--- a/src/frontend/src/styles/opsStatCardColorSemantics.test.ts
+++ b/src/frontend/src/styles/opsStatCardColorSemantics.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8')
+
+const tokenValue = (content: string, name: string) => {
+  const match = content.match(new RegExp(`--${name}:\\s*([^;]+);`))
+  return match?.[1].trim()
+}
+
+const opsPageSources = () => readdirSync(resolve(process.cwd(), 'src/pages/ops'))
+  .filter((name) => name.endsWith('.vue'))
+  .map((name) => [`src/pages/ops/${name}`, source(`src/pages/ops/${name}`)] as const)
+
+const operationsCardConsumers = [
+  'src/pages/ops/AlertIncidents.vue',
+  'src/pages/ops/AlertPolicies.vue',
+  'src/pages/ops/Audit.vue',
+  'src/pages/ops/NotificationChannels.vue',
+  'src/pages/ops/NotificationRecords.vue',
+  'src/pages/ops/Tasks.vue',
+  'src/components/monitor/SystemMonitorDashboard.vue',
+]
+
+describe('Operations statistics card color semantics', () => {
+  it('uses only shared semantic tones in every Operations consumer', () => {
+    for (const path of operationsCardConsumers) {
+      const content = source(path)
+      expect(content, path).not.toMatch(/(?:^|\s):?accent=/)
+      expect(content, path).not.toMatch(/(?:^|\s)value-class=/)
+    }
+
+    const component = source('src/components/ops/OpsStatCard.vue')
+    expect(component).toContain("tone?: 'primary' | 'success' | 'warning' | 'danger' | 'info' | 'firing' | 'neutral'")
+    expect(component).not.toContain('accent?:')
+    expect(component).not.toContain('valueClass?:')
+  })
+
+  it('keeps alert severity and lifecycle tones distinct', () => {
+    const incidents = source('src/pages/ops/AlertIncidents.vue')
+    const policies = source('src/pages/ops/AlertPolicies.vue')
+
+    expect(incidents).toContain('tone="danger"')
+    expect(incidents).toContain('tone="warning"')
+    expect(incidents).toContain('tone="firing"')
+    expect(incidents).toContain('tone="info"')
+    expect(policies).toContain('tone="primary"')
+    expect(policies).toContain('tone="success"')
+    expect(policies).toContain('tone="danger"')
+  })
+
+  it('keeps task waiting and cancelled states semantically distinct', () => {
+    const tasks = source('src/pages/ops/Tasks.vue')
+
+    expect(tasks).toMatch(/status\.pending[\s\S]*?tone="warning"/)
+    expect(tasks).toMatch(/status\.cancelled[\s\S]*?tone="neutral"/)
+  })
+
+  it('uses success semantics for positive rates', () => {
+    const records = source('src/pages/ops/NotificationRecords.vue')
+    const channels = source('src/pages/ops/NotificationChannels.vue')
+
+    expect(records).toMatch(/notification\.successRate[\s\S]*?tone="success"/)
+    expect(channels).toMatch(/notification\.enabledRate[\s\S]*?tone="success"/)
+  })
+
+  it('resolves card and firing tag colors through global tokens', () => {
+    const tokens = source('src/index.css')
+    const tagStyles = source('src/styles/element-plus-tag.css')
+    const cardStyles = source('src/styles/ops-list-ui.css')
+
+    expect(tokens).toContain('--color-firing:')
+    expect(tokens).toContain('--color-firing-light:')
+    expect(tokens).toContain('--color-firing-border:')
+    expect(tokens).toContain('--color-text-inverse:')
+    expect(tokens).toContain('--color-primary-border:')
+    expect(tokenValue(tokens, 'color-info')).not.toBe(tokenValue(tokens, 'color-primary'))
+    expect(tokenValue(tokens, 'color-info-light')).not.toBe(tokenValue(tokens, 'color-primary-light'))
+    expect(tokenValue(tokens, 'color-firing')).not.toBe(tokenValue(tokens, 'color-warning'))
+    expect(tokens).toMatch(/html\[data-theme='dark'\][\s\S]*--color-success-light:/)
+    expect(tokens).toMatch(/html\[data-theme='dark'\][\s\S]*--color-warning-light:/)
+    expect(tokens).toMatch(/html\[data-theme='dark'\][\s\S]*--color-firing-light:/)
+    expect(tokens).toMatch(/html\[data-theme='dark'\][\s\S]*--color-error-light:/)
+    expect(tokens).toMatch(/html\[data-theme='dark'\][\s\S]*--color-info-light:/)
+    expect(tagStyles).toContain('.el-tag.hfl-tag--firing')
+    expect(tagStyles).toContain('--el-tag-text-color: var(--color-primary)')
+    expect(tagStyles).toContain('--el-tag-text-color: var(--color-info-text)')
+    expect(cardStyles).toContain('--hfl-ops-stat-accent:')
+    expect(cardStyles).toContain('.hfl-ops-stat-card--tone-firing')
+    expect(cardStyles).not.toMatch(/\.hfl-ops-stat-card--(?:red|yellow|green|blue|indigo|orange|pink|gray)/)
+  })
+
+  it('keeps Operations page and shared Operations styles theme-token based', () => {
+    const rawThemeColor = /#[0-9a-f]{3,8}\b|rgba?\([^)]*\)|\b(?:text|bg|border)-(?:slate|gray|red|green|yellow|orange|blue|indigo|pink|emerald|amber)-[0-9]{2,3}\b/i
+
+    for (const [path, content] of opsPageSources()) {
+      expect(content, path).not.toMatch(rawThemeColor)
+    }
+
+    expect(source('src/styles/ops-list-ui.css')).not.toMatch(rawThemeColor)
+  })
+})


### PR DESCRIPTION
## Summary

- Map Operations statistic cards and status tags to shared semantic tones
- Separate primary, info, warning, firing, success, danger, and neutral colors across Operations pages
- Apply theme tokens to Operations detail drawers, task timelines, progress states, and JSON panels
- Add dark-theme semantic variants and regression coverage for status mappings

Closes #969

## Testing

- Targeted Vitest tests passed: 67 tests
- Vue TypeScript check and production build passed
- ESLint passed for changed files
- `git diff --check` passed

Build output retains existing Vite chunk-size and dynamic-import warnings.