### PR TITLE
fix(frontend): show restore progress summary

### DIFF
--- a/src/frontend/src/pages/protection/components/TaskProgressCell.test.ts
+++ b/src/frontend/src/pages/protection/components/TaskProgressCell.test.ts
@@ -141,7 +141,9 @@ describe('TaskProgressCell', () => {
     expect(wrapper.get('.task-progress-cell__label-text').text()).toBe('Restoring')
     expect(wrapper.get('.task-progress-cell__percent').text()).toBe('10.20%')
     expect(wrapper.get('.el-progress-stub').attributes('data-percentage')).toBe('10.2')
-    expect(wrapper.find('.task-progress-cell__metrics').exists()).toBe(false)
+    expect(wrapper.get('.task-progress-cell__metric-line').text()).toBe(
+      'Data restored: 858 MB / 300 GB · 5.47 MB/s',
+    )
     expect(wrapper.get('.task-progress-cell__label-text').attributes('data-table-overflow-title')).toBe([
       'Restoring · 72592/333000 items restored',
       'Data restored: 858 MB / 300 GB',

--- a/src/frontend/src/pages/protection/components/TaskProgressCell.vue
+++ b/src/frontend/src/pages/protection/components/TaskProgressCell.vue
@@ -4,10 +4,12 @@ import { useI18n } from 'vue-i18n'
 import {
   formatTaskProgressBarPercent,
   formatTaskProgressPercent,
+  formatSpeedBps,
   parseTaskProgressValue,
   resolveStep3DisplayPercent,
   shouldShowStep3Percent,
   shouldShowTransferMetrics,
+  transferCapacityText,
   transferProgressLabel,
   transferMetricParts,
   type TransferProgress,
@@ -78,6 +80,12 @@ const metricParts = computed(() => {
   return transferMetricParts(t, props.transferProgress)
 })
 const metricLine = computed(() => metricParts.value.join(' · '))
+const restoreMetricLine = computed(() => {
+  if (!isRestore.value || props.compact) return ''
+  const capacity = transferCapacityText(t, props.transferProgress)
+  const speed = formatSpeedBps(props.transferProgress?.upload_speed_bps)
+  return [capacity, speed].filter(Boolean).join(' · ')
+})
 const overflowTitle = computed(() => {
   if (!metricParts.value.length) return ''
   const metrics = transferMetricParts(t, props.transferProgress, { labelProcessingSpeed: true, labelRestoreMetrics: isRestore.value })
@@ -125,16 +133,15 @@ const overflowTitle = computed(() => {
       :show-text="false"
     />
     <p
-      v-if="!isRestore"
       class="task-progress-cell__metrics"
-      :class="{ 'is-empty': !metricParts.length }"
+      :class="{ 'is-empty': !(isRestore ? restoreMetricLine : metricLine) }"
     >
       <span
-        v-if="metricLine"
+        v-if="isRestore ? restoreMetricLine : metricLine"
         class="task-progress-cell__metric-line"
-        :data-table-overflow-title="overflowTitle || undefined"
+        :data-table-overflow-title="isRestore ? undefined : overflowTitle || undefined"
         data-table-overflow-title-always
-      >{{ metricLine }}</span>
+      >{{ isRestore ? restoreMetricLine : metricLine }}</span>
     </p>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- show restored capacity and throughput below running restore progress bars
- preserve the existing restore hover details
- add regression coverage for the compact summary

## Validation
- `npm test -- --run src/pages/protection/components/TaskProgressCell.test.ts src/lib/kopiaProgress.test.ts`
- targeted ESLint
- `git diff --check`
- `python3 tools/quality/check-english-source.py`
- Community backend suite skipped by request

Fixes #951