### PR TITLE
fix(frontend): handle Turnstile config load failures

### DIFF
--- a/src/frontend/src/components/auth/AuthTurnstileField.test.ts
+++ b/src/frontend/src/components/auth/AuthTurnstileField.test.ts
@@ -11,11 +11,13 @@ const baseProps = {
   pending: false,
   ready: false,
   blocked: false,
+  configError: false,
   verified: false,
   siteKey: 'test-site-key',
   action: 'login',
   loadingMessage: 'Loading Cloudflare human verification...',
   blockedMessage: 'Cloudflare verification unavailable.',
+  configErrorMessage: 'Something went wrong. Please try again.',
   retryLabel: 'Retry',
   manualRetryLabel: 'Verification taking longer than expected? Reload',
   errorCodeLabel: '',
@@ -103,6 +105,17 @@ describe('AuthTurnstileField display states', () => {
 
     await wrapper.get('.auth-turnstile-field__retry').trigger('click')
     expect(wrapper.emitted('retry')).toHaveLength(1)
+  })
+
+  it('shows a configuration error only once and exposes retry', () => {
+    const wrapper = mountField({
+      configError: true,
+      errorMessage: baseProps.configErrorMessage,
+    })
+
+    expect(wrapper.find('.auth-turnstile-field__blocked').exists()).toBe(true)
+    expect(wrapper.find('.auth-turnstile-field__error').exists()).toBe(false)
+    expect(wrapper.text().match(/Something went wrong\. Please try again\./g)).toHaveLength(1)
   })
 
   it('assigns exactly one frame owner to every visual state', () => {

--- a/src/frontend/src/components/auth/AuthTurnstileField.vue
+++ b/src/frontend/src/components/auth/AuthTurnstileField.vue
@@ -8,11 +8,13 @@ defineProps<{
   pending: boolean
   ready: boolean
   blocked: boolean
+  configError?: boolean
   verified: boolean
   siteKey: string
   action: string
   loadingMessage: string
   blockedMessage: string
+  configErrorMessage?: string
   retryLabel: string
   manualRetryLabel: string
   errorCodeLabel?: string
@@ -74,7 +76,7 @@ defineExpose({ reset })
 
 <template>
   <div
-    v-if="pending || ready || blocked"
+    v-if="pending || ready || blocked || configError"
     class="auth-turnstile-field"
   >
     <div
@@ -126,7 +128,7 @@ defineExpose({ reset })
     </button>
 
     <div
-      v-if="blocked"
+      v-if="blocked || configError"
       class="auth-turnstile-field__control auth-turnstile-field__blocked"
       role="alert"
     >
@@ -135,7 +137,7 @@ defineExpose({ reset })
         aria-hidden="true"
       />
       <span class="auth-turnstile-field__blocked-text">
-        <span>{{ blockedMessage }}</span>
+        <span>{{ configError ? (configErrorMessage || blockedMessage) : blockedMessage }}</span>
         <span
           v-if="errorCodeLabel"
           class="auth-turnstile-field__reference-code"
@@ -153,7 +155,7 @@ defineExpose({ reset })
     </div>
 
     <p
-      v-if="errorMessage && !blocked"
+      v-if="errorMessage && !blocked && !configError"
       class="auth-turnstile-field__error"
       role="alert"
     >

--- a/src/frontend/src/components/auth/ResetPasswordCard.vue
+++ b/src/frontend/src/components/auth/ResetPasswordCard.vue
@@ -30,6 +30,7 @@ const {
   isTurnstilePending,
   isTurnstileReady,
   isTurnstileBlocked,
+  isTurnstileConfigError,
   loadTurnstileConfig,
   retryTurnstileConfig,
   buildTurnstilePayload,
@@ -86,7 +87,7 @@ const maskedEmail = computed(() => maskEmail(savedEmail.value))
 const canSendResetCode = computed(() => {
   if (submitLoading.value) return false
   if (isTurnstilePending.value) return false
-  if (isTurnstileBlocked.value) return false
+  if (isTurnstileBlocked.value || isTurnstileConfigError.value) return false
   if (isTurnstileReady.value) return Boolean(turnstileToken.value)
   return true
 })
@@ -244,8 +245,10 @@ function validateRequestForm() {
   if (isTurnstilePending.value) {
     turnstileError.value = t('login.captchaLoading')
     hasError = true
-  } else if (isTurnstileBlocked.value) {
-    turnstileError.value = t('login.captchaUnavailable')
+  } else if (isTurnstileBlocked.value || isTurnstileConfigError.value) {
+    turnstileError.value = isTurnstileConfigError.value
+      ? t('errors.generic.requestFailed')
+      : t('login.captchaUnavailable')
     hasError = true
   } else if (isTurnstileReady.value) {
     if (!turnstileToken.value) {
@@ -495,11 +498,13 @@ onUnmounted(() => {
           :pending="isTurnstilePending"
           :ready="isTurnstileReady"
           :blocked="isTurnstileBlocked"
+          :config-error="isTurnstileConfigError"
           :verified="Boolean(turnstileToken)"
           :site-key="turnstileSiteKey"
           action="forgot_password"
           :loading-message="t('login.captchaLoading')"
           :blocked-message="t('login.captchaUnavailable')"
+          :config-error-message="t('errors.generic.requestFailed')"
           :retry-label="t('login.captchaRetry')"
           :manual-retry-label="t('login.captchaManualRetry')"
           :error-code-label="turnstileErrorCode ? t('login.captchaReferenceCode', { code: turnstileErrorCode }) : ''"

--- a/src/frontend/src/composables/useTurnstileConfig.test.ts
+++ b/src/frontend/src/composables/useTurnstileConfig.test.ts
@@ -4,11 +4,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   api: vi.fn(),
+  isAbortError: vi.fn(() => false),
   preloadTurnstileScript: vi.fn(),
   resetTurnstileScriptLoad: vi.fn(),
 }))
 
-vi.mock('../lib/api', () => ({ api: mocks.api }))
+vi.mock('../lib/api', () => ({
+  api: mocks.api,
+  isAbortError: mocks.isAbortError,
+}))
 vi.mock('../lib/turnstileLoader', () => ({
   preloadTurnstileScript: mocks.preloadTurnstileScript,
   resetTurnstileScriptLoad: mocks.resetTurnstileScriptLoad,
@@ -18,10 +22,11 @@ describe('Turnstile configuration retry', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    mocks.isAbortError.mockReturnValue(false)
     mocks.preloadTurnstileScript.mockResolvedValue(undefined)
   })
 
-  it('clears the shared loader and recovers after a configuration failure', async () => {
+  it('recovers after one transient configuration failure', async () => {
     mocks.api
       .mockRejectedValueOnce(new Error('network unavailable'))
       .mockResolvedValueOnce({
@@ -37,16 +42,8 @@ describe('Turnstile configuration retry', () => {
     const turnstile = useTurnstileConfig()
 
     await turnstile.loadTurnstileConfig()
-    expect(turnstile.isTurnstileBlocked.value).toBe(true)
-
-    await Promise.all([
-      turnstile.retryTurnstileConfig(),
-      turnstile.retryTurnstileConfig(),
-    ])
-
-    expect(mocks.resetTurnstileScriptLoad).toHaveBeenCalledTimes(1)
-    expect(turnstile.authTurnstileMountGeneration.value).toBe(1)
     expect(turnstile.isTurnstileReady.value).toBe(true)
+    expect(mocks.api).toHaveBeenCalledTimes(2)
     expect(turnstile.turnstileSiteKey.value).toBe('test-site-key')
     expect(mocks.preloadTurnstileScript).toHaveBeenCalledTimes(1)
   })
@@ -58,10 +55,67 @@ describe('Turnstile configuration retry', () => {
     const turnstile = useTurnstileConfig()
 
     await turnstile.loadTurnstileConfig()
+
+    expect(mocks.api).toHaveBeenCalledTimes(2)
+    expect(turnstile.isTurnstileConfigError.value).toBe(true)
+    expect(turnstile.turnstileSiteKey.value).toBe('')
+  })
+
+  it('does not surface an error when the request is aborted', async () => {
+    const aborted = new Error('route changed')
+    aborted.name = 'AbortError'
+    mocks.api.mockRejectedValue(aborted)
+    mocks.isAbortError.mockReturnValue(true)
+
+    const { useTurnstileConfig } = await import('./useTurnstileConfig')
+    const turnstile = useTurnstileConfig()
+
+    await turnstile.loadTurnstileConfig()
+
+    expect(turnstile.isTurnstileConfigError.value).toBe(false)
+    expect(turnstile.isTurnstilePending.value).toBe(true)
+    expect(mocks.api).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not load the Cloudflare script when Turnstile is disabled', async () => {
+    mocks.api.mockResolvedValue({
+      code: '0000',
+      data: { enabled: false, configured: false },
+    })
+
+    const { useTurnstileConfig } = await import('./useTurnstileConfig')
+    const turnstile = useTurnstileConfig()
+
+    await turnstile.loadTurnstileConfig()
+
+    expect(turnstile.isTurnstileDisabled.value).toBe(true)
+    expect(mocks.preloadTurnstileScript).not.toHaveBeenCalled()
+  })
+
+  it('reloads configuration after a forced retry is aborted', async () => {
+    mocks.api.mockResolvedValueOnce({
+      code: '0000',
+      data: { enabled: true, configured: true, site_key: 'test-site-key' },
+    })
+
+    const { useTurnstileConfig } = await import('./useTurnstileConfig')
+    const turnstile = useTurnstileConfig()
+    await turnstile.loadTurnstileConfig()
+
+    const aborted = new Error('route changed')
+    aborted.name = 'AbortError'
+    mocks.api.mockRejectedValueOnce(aborted)
+    mocks.isAbortError.mockReturnValue(true)
     await turnstile.retryTurnstileConfig()
 
-    expect(mocks.resetTurnstileScriptLoad).toHaveBeenCalledTimes(1)
-    expect(turnstile.isTurnstileBlocked.value).toBe(true)
-    expect(turnstile.turnstileSiteKey.value).toBe('')
+    mocks.isAbortError.mockReturnValue(false)
+    mocks.api.mockResolvedValueOnce({
+      code: '0000',
+      data: { enabled: false, configured: false },
+    })
+    await turnstile.loadTurnstileConfig()
+
+    expect(turnstile.isTurnstileDisabled.value).toBe(true)
+    expect(mocks.api).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/frontend/src/composables/useTurnstileConfig.ts
+++ b/src/frontend/src/composables/useTurnstileConfig.ts
@@ -1,11 +1,11 @@
 import { computed, nextTick, ref } from 'vue'
-import { api } from '../lib/api'
+import { api, isAbortError } from '../lib/api'
 import {
   preloadTurnstileScript,
   resetTurnstileScriptLoad,
 } from '../lib/turnstileLoader'
 
-export type TurnstileState = 'pending' | 'disabled' | 'ready' | 'blocked'
+export type TurnstileState = 'pending' | 'disabled' | 'ready' | 'blocked' | 'config-error'
 
 interface TurnstileConfigResponse {
   code: string
@@ -22,28 +22,45 @@ const configLoaded = ref(false)
 let configLoadPromise: Promise<void> | null = null
 let configRetryPromise: Promise<void> | null = null
 const authTurnstileMountGeneration = ref(0)
+const MAX_CONFIG_ATTEMPTS = 2
+
+async function fetchTurnstileConfig(): Promise<TurnstileConfigResponse> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < MAX_CONFIG_ATTEMPTS; attempt += 1) {
+    try {
+      const res = await api<TurnstileConfigResponse>('/api/v1/auth/turnstile/config')
+      if (res.code !== '0000' || !res.data) {
+        throw new Error('Invalid Turnstile configuration response')
+      }
+      return res
+    } catch (error) {
+      if (isAbortError(error)) throw error
+      lastError = error
+    }
+  }
+  throw lastError ?? new Error('Unable to load Turnstile configuration')
+}
 
 async function loadTurnstileConfig(force = false): Promise<void> {
   if (configLoadPromise) return configLoadPromise
   if (configLoaded.value && !force) return
 
+  const previousState = state.value
+  const previousConfigLoaded = configLoaded.value
   state.value = 'pending'
   configLoadPromise = (async () => {
     try {
-      const res = await api<TurnstileConfigResponse>('/api/v1/auth/turnstile/config')
-      if (res.code !== '0000' || !res.data) {
-        state.value = 'blocked'
-        siteKey.value = ''
-        return
-      }
+      const res = await fetchTurnstileConfig()
       if (!res.data.enabled) {
         state.value = 'disabled'
         siteKey.value = ''
+        configLoaded.value = true
         return
       }
       if (!res.data.configured || !res.data.site_key) {
         state.value = 'blocked'
         siteKey.value = ''
+        configLoaded.value = true
         return
       }
 
@@ -53,11 +70,17 @@ async function loadTurnstileConfig(force = false): Promise<void> {
       // failures are intentionally swallowed here to avoid an unhandled
       // rejection before the lazy authentication page finishes mounting.
       void preloadTurnstileScript().catch(() => undefined)
-    } catch {
-      state.value = 'blocked'
-      siteKey.value = ''
-    } finally {
       configLoaded.value = true
+    } catch (error) {
+      if (isAbortError(error)) {
+        state.value = previousState
+        configLoaded.value = previousConfigLoaded
+        return
+      }
+      state.value = 'config-error'
+      siteKey.value = ''
+      configLoaded.value = false
+    } finally {
       configLoadPromise = null
     }
   })()
@@ -72,6 +95,7 @@ async function retryTurnstileConfig(): Promise<void> {
     // Leave the ready state first so any mounted widget is removed before the
     // shared Turnstile API and script tag are discarded.
     state.value = 'pending'
+    configLoaded.value = false
     await nextTick()
     resetTurnstileScriptLoad()
     authTurnstileMountGeneration.value += 1
@@ -100,6 +124,7 @@ export function useTurnstileConfig() {
   const isTurnstileDisabled = computed(() => state.value === 'disabled')
   const isTurnstileReady = computed(() => state.value === 'ready')
   const isTurnstileBlocked = computed(() => state.value === 'blocked')
+  const isTurnstileConfigError = computed(() => state.value === 'config-error')
 
   function blockTurnstile(): void {
     if (state.value !== 'disabled') state.value = 'blocked'
@@ -117,6 +142,7 @@ export function useTurnstileConfig() {
     isTurnstileDisabled,
     isTurnstileReady,
     isTurnstileBlocked,
+    isTurnstileConfigError,
     loadTurnstileConfig,
     retryTurnstileConfig,
     buildTurnstilePayload,

--- a/src/frontend/src/pages/auth/AuthTurnstileRetryFlows.test.ts
+++ b/src/frontend/src/pages/auth/AuthTurnstileRetryFlows.test.ts
@@ -43,6 +43,7 @@ vi.mock('../../composables/useTurnstileConfig', () => ({
     isTurnstilePending: ref(false),
     isTurnstileReady: ref(true),
     isTurnstileBlocked: ref(false),
+    isTurnstileConfigError: ref(false),
     authTurnstileMountGeneration: ref(0),
     loadTurnstileConfig: mocks.loadTurnstileConfig,
     retryTurnstileConfig: mocks.retryTurnstileConfig,

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -50,6 +50,7 @@ const {
   isTurnstilePending,
   isTurnstileReady,
   isTurnstileBlocked,
+  isTurnstileConfigError,
   authTurnstileMountGeneration,
   loadTurnstileConfig,
   retryTurnstileConfig,
@@ -304,8 +305,10 @@ function validateForm() {
   if (isTurnstilePending.value) {
     turnstileError.value = t('login.captchaLoading')
     hasError = true
-  } else if (isTurnstileBlocked.value) {
-    turnstileError.value = t('login.captchaUnavailable')
+  } else if (isTurnstileBlocked.value || isTurnstileConfigError.value) {
+    turnstileError.value = isTurnstileConfigError.value
+      ? t('errors.generic.requestFailed')
+      : t('login.captchaUnavailable')
     hasError = true
   } else if (isTurnstileReady.value) {
     if (!turnstileToken.value) {
@@ -669,7 +672,7 @@ const canSubmitLogin = computed(() => {
   if (submitLoading.value) return false
   if (!credentialsPresent.value) return false
   if (isTurnstilePending.value) return false
-  if (isTurnstileBlocked.value) return false
+  if (isTurnstileBlocked.value || isTurnstileConfigError.value) return false
   if (isTurnstileReady.value) return Boolean(turnstileToken.value)
   return true
 })
@@ -942,11 +945,13 @@ onMounted(async () => {
               :pending="isTurnstilePending"
               :ready="isTurnstileReady"
               :blocked="isTurnstileBlocked"
+              :config-error="isTurnstileConfigError"
               :verified="Boolean(turnstileToken)"
               :site-key="turnstileSiteKey"
               action="login"
               :loading-message="t('login.captchaLoading')"
               :blocked-message="t('login.captchaUnavailable')"
+              :config-error-message="t('errors.generic.requestFailed')"
               :retry-label="t('login.captchaRetry')"
               :manual-retry-label="t('login.captchaManualRetry')"
               :error-code-label="turnstileErrorCode ? t('login.captchaReferenceCode', { code: turnstileErrorCode }) : ''"

--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -53,6 +53,7 @@ vi.mock('../../composables/useTurnstileConfig', () => ({
     isTurnstilePending: ref(false),
     isTurnstileReady: ref(true),
     isTurnstileBlocked: ref(mocks.turnstileBlocked),
+    isTurnstileConfigError: ref(false),
     authTurnstileMountGeneration: ref(0),
     loadTurnstileConfig: mocks.loadTurnstileConfig,
     retryTurnstileConfig: mocks.retryTurnstileConfig,

--- a/src/frontend/src/pages/auth/Register.vue
+++ b/src/frontend/src/pages/auth/Register.vue
@@ -25,6 +25,7 @@ const {
   isTurnstilePending,
   isTurnstileReady,
   isTurnstileBlocked,
+  isTurnstileConfigError,
   authTurnstileMountGeneration,
   loadTurnstileConfig,
   retryTurnstileConfig,
@@ -278,8 +279,10 @@ function validateSendCodeForm() {
   if (isTurnstilePending.value) {
     turnstileError.value = t('login.captchaLoading')
     hasError = true
-  } else if (isTurnstileBlocked.value) {
-    turnstileError.value = t('login.captchaUnavailable')
+  } else if (isTurnstileBlocked.value || isTurnstileConfigError.value) {
+    turnstileError.value = isTurnstileConfigError.value
+      ? t('errors.generic.requestFailed')
+      : t('login.captchaUnavailable')
     hasError = true
   } else if (isTurnstileReady.value) {
     if (!turnstileToken.value) {
@@ -479,11 +482,13 @@ onUnmounted(() => {
           :pending="isTurnstilePending"
           :ready="isTurnstileReady"
           :blocked="isTurnstileBlocked"
+          :config-error="isTurnstileConfigError"
           :verified="Boolean(turnstileToken)"
           :site-key="turnstileSiteKey"
           action="register_send_code"
           :loading-message="t('login.captchaLoading')"
           :blocked-message="t('login.captchaUnavailable')"
+          :config-error-message="t('errors.generic.requestFailed')"
           :retry-label="t('login.captchaRetry')"
           :manual-retry-label="t('login.captchaManualRetry')"
           :error-code-label="turnstileErrorCode ? t('login.captchaReferenceCode', { code: turnstileErrorCode }) : ''"


### PR DESCRIPTION
## Summary

- distinguish disabled, unavailable, and configuration-request failure states
- avoid loading the Cloudflare script when Turnstile is disabled
- retry transient configuration failures and recover safely after aborted requests
- prevent authentication submission while configuration state is unresolved
- keep Turnstile error presentation to one visible message

## Validation

- 49 Turnstile and authentication lifecycle tests passed
- ESLint passed for changed files
- vue-tsc --noEmit passed
- production frontend build passed
- git diff --check passed