### PR TITLE
Unify Gateway Agent and LensNode runtime layout

### DIFF
--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -3,8 +3,19 @@
 # Invoked by hfl-enroll gateway-install after agent registration.
 set -euo pipefail
 
-ENV_FILE="${HFL_LENS_ENV_FILE:-/etc/hyperfilelens/lensnode.env}"
-COMPOSE_DIR="/etc/hyperfilelens/lensnode"
+ENV_FILE="${HFL_LENS_ENV_FILE:-/opt/hyperfilelens-agent/config/lensnode.env}"
+COMPOSE_DIR="${HFL_GATEWAY_COMPOSE_DIR:-/opt/hyperfilelens-agent/runtime/lensnode}"
+LEGACY_ENV_FILE="/etc/hyperfilelens/lensnode.env"
+LEGACY_COMPOSE_DIR="/etc/hyperfilelens/lensnode"
+LEGACY_ADOPTION_MARKER="${COMPOSE_DIR}/.hfl-legacy-layout-adopted"
+LEGACY_MIGRATION_ENABLED=0
+legacy_migration_allowed_for_paths() {
+	[[ "${ENV_FILE}" == "/opt/hyperfilelens-agent/config/lensnode.env" \
+		&& "${COMPOSE_DIR}" == "/opt/hyperfilelens-agent/runtime/lensnode" ]]
+}
+if legacy_migration_allowed_for_paths; then
+	LEGACY_MIGRATION_ENABLED=1
+fi
 COMPOSE_PROJECT="hyperfilelens-gateway"
 DEFAULT_LENSNODE_IMAGE="${LENSNODE_IMAGE:-hyperfilelens-sourcelens-lensnode:latest}"
 SENTRY_PRIVACY_FILE="${COMPOSE_DIR}/hfl-sentry-sitecustomize.py"
@@ -27,6 +38,70 @@ hfl_warn() {
 hfl_fail() {
 	printf '  [FAIL] %s\n' "$1" >&2
 	exit "${2:-1}"
+}
+
+migrate_legacy_layout() {
+	local adopted=0
+	[[ "${LEGACY_MIGRATION_ENABLED}" == "1" ]] || return 0
+	[[ "${ENV_FILE}" == "${LEGACY_ENV_FILE}" ]] && return 0
+	if [[ -f "${LEGACY_ENV_FILE}" ]]; then
+		if [[ -e "${ENV_FILE}" ]]; then
+			if [[ "${HFL_LEGACY_LAYOUT_ADOPTED:-0}" == "1" ]]; then
+				adopted=1
+			elif [[ -f "${LEGACY_ADOPTION_MARKER}" ]]; then
+				adopted=1
+			elif cmp -s "${LEGACY_ENV_FILE}" "${ENV_FILE}"; then
+				adopted=1
+			else
+				hfl_fail "Legacy LensNode configuration conflicts with ${ENV_FILE}; resolve it before upgrading." 2
+			fi
+		else
+			mkdir -p "$(dirname "${ENV_FILE}")"
+			install -m 0600 "${LEGACY_ENV_FILE}" "${ENV_FILE}"
+			hfl_step "Adopted legacy LensNode configuration into the Agent Root."
+			adopted=1
+		fi
+	fi
+	if [[ "${COMPOSE_DIR}" != "${LEGACY_COMPOSE_DIR}" && -d "${LEGACY_COMPOSE_DIR}" ]]; then
+		if [[ -e "${COMPOSE_DIR}" ]]; then
+			if [[ "${HFL_LEGACY_LAYOUT_ADOPTED:-0}" == "1" || -f "${LEGACY_ADOPTION_MARKER}" ]]; then
+				adopted=1
+			elif [[ ! -e "${COMPOSE_DIR}/docker-compose.yml" ]]; then
+				cp -a "${LEGACY_COMPOSE_DIR}/." "${COMPOSE_DIR}/"
+				hfl_step "Adopted legacy LensNode Compose files into the Agent Root."
+				adopted=1
+			elif [[ -f "${LEGACY_COMPOSE_DIR}/docker-compose.yml" && -f "${COMPOSE_DIR}/docker-compose.yml" ]]; then
+				cmp -s "${LEGACY_COMPOSE_DIR}/docker-compose.yml" "${COMPOSE_DIR}/docker-compose.yml" \
+					|| hfl_fail "Legacy LensNode Compose configuration conflicts with ${COMPOSE_DIR}; resolve it before upgrading." 2
+				adopted=1
+			fi
+		else
+			mkdir -p "${COMPOSE_DIR}"
+			cp -a "${LEGACY_COMPOSE_DIR}/." "${COMPOSE_DIR}/"
+			chmod 0700 "${COMPOSE_DIR}"
+			hfl_step "Adopted legacy LensNode Compose files into the Agent Root."
+			adopted=1
+		fi
+	fi
+	if [[ "${adopted}" == "1" ]]; then
+		mkdir -p "${COMPOSE_DIR}"
+		chmod 0700 "${COMPOSE_DIR}"
+		: >"${LEGACY_ADOPTION_MARKER}"
+		chmod 0600 "${LEGACY_ADOPTION_MARKER}"
+	fi
+}
+
+cleanup_legacy_layout() {
+	[[ "${LEGACY_MIGRATION_ENABLED}" == "1" ]] || return 0
+	[[ "${ENV_FILE}" == "${LEGACY_ENV_FILE}" ]] || rm -f "${LEGACY_ENV_FILE}" \
+		|| hfl_warn "Could not remove legacy LensNode configuration; it will be retried later."
+	if [[ "${COMPOSE_DIR}" != "${LEGACY_COMPOSE_DIR}" && -d "${LEGACY_COMPOSE_DIR}" ]]; then
+		rm -rf "${LEGACY_COMPOSE_DIR}" \
+			|| hfl_warn "Could not remove legacy LensNode Compose directory; it will be retried later."
+	fi
+	if [[ ! -e "${LEGACY_ENV_FILE}" && ! -e "${LEGACY_COMPOSE_DIR}" ]]; then
+		rm -f "${LEGACY_ADOPTION_MARKER}"
+	fi
 }
 
 # The sidecar script is downloaded and executed on its own, so keep this
@@ -90,6 +165,8 @@ if [[ "$(id -u)" -ne 0 ]]; then
 fi
 
 acquire_sidecar_lock
+
+migrate_legacy_layout
 
 if [[ ! -f "${ENV_FILE}" ]]; then
 	hfl_fail "Missing ${ENV_FILE} (run hfl-enroll gateway-install first)." 2
@@ -213,7 +290,7 @@ resolve_lensnode_image() {
 }
 
 remove_owned_legacy_gateway_containers() {
-	local id project service working_dir config_files
+	local id project service working_dir config_files current_owned legacy_owned
 	local removed=0
 	while IFS= read -r id; do
 		[[ -n "${id}" ]] || continue
@@ -222,10 +299,18 @@ remove_owned_legacy_gateway_containers() {
 		working_dir="$(docker inspect --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' "${id}" 2>/dev/null || true)"
 		config_files="$(docker inspect --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}' "${id}" 2>/dev/null || true)"
 		[[ "${project}" == "sourcelens" && "${service}" == "lensnode" ]] || continue
-		if [[ "${working_dir}" != "${COMPOSE_DIR}" \
-			&& ",${config_files}," != *",${COMPOSE_DIR}/docker-compose.yml,"* ]]; then
-			continue
+		current_owned=0
+		if [[ "${working_dir}" == "${COMPOSE_DIR}" \
+			|| ",${config_files}," == *",${COMPOSE_DIR}/docker-compose.yml,"* ]]; then
+			current_owned=1
 		fi
+		legacy_owned=0
+		if [[ "${LEGACY_MIGRATION_ENABLED}" == "1" \
+			&& ("${working_dir}" == "${LEGACY_COMPOSE_DIR}" \
+				|| ",${config_files}," == *",${LEGACY_COMPOSE_DIR}/docker-compose.yml,"*) ]]; then
+			legacy_owned=1
+		fi
+		[[ "${current_owned}" == "1" || "${legacy_owned}" == "1" ]] || continue
 		hfl_step "Migrating owned legacy Gateway container ${id:0:12} from project sourcelens."
 		docker rm -f "${id}" >/dev/null
 		removed=1
@@ -241,6 +326,9 @@ install_docker_sidecar() {
 	local sentry_volume_block=""
 	local compose_file="${COMPOSE_DIR}/docker-compose.yml"
 	local compose_temporary="${COMPOSE_DIR}/.docker-compose.yml.tmp.$$"
+	local previous_compose="${COMPOSE_DIR}/.docker-compose.yml.previous.$$"
+	local recovery_detail="the new Compose configuration was removed"
+	local current_container="" previous_image_id="" desired_image_id=""
 	if [[ -z "${ssl_verify}" ]]; then
 		if [[ "${HFL_INSECURE_TLS}" == "1" ]]; then
 			ssl_verify="false"
@@ -312,28 +400,79 @@ ${sentry_volume_block}
 EOF
 	)
 	chmod 0600 "${compose_temporary}"
-	mv -f "${compose_temporary}" "${compose_file}"
-	chmod 0600 "${compose_file}"
-	if resolve_compose; then
-		remove_owned_legacy_gateway_containers
-		(
-			cd "${COMPOSE_DIR}"
-			current_container="$("${COMPOSE[@]}" -p "${COMPOSE_PROJECT}" ps -q lensnode 2>/dev/null || true)"
-			current_image_id=""
-			desired_image_id="$(docker image inspect --format '{{.Id}}' "${image}")"
-			if [[ -n "${current_container}" ]]; then
-				current_image_id="$(docker inspect --format '{{.Image}}' "${current_container}" 2>/dev/null || true)"
-			fi
-			compose_args=(up -d --pull never)
-			if [[ -n "${current_container}" && "${current_image_id}" != "${desired_image_id}" ]]; then
-				hfl_step "Recreating the AI engine because its loaded image ID changed."
-				compose_args+=(--force-recreate)
-			fi
-			"${COMPOSE[@]}" -p "${COMPOSE_PROJECT}" "${compose_args[@]}"
-		)
-	else
+	if ! resolve_compose; then
+		rm -f "${compose_temporary}"
 		hfl_fail "Docker Compose v2 >= ${MIN_COMPOSE_VERSION} is required when using the AI engine container image." 3
 	fi
+	if ! (
+		cd "${COMPOSE_DIR}"
+		"${COMPOSE[@]}" -p "${COMPOSE_PROJECT}" -f "${compose_temporary}" config --quiet
+	); then
+		rm -f "${compose_temporary}"
+		hfl_fail "Generated AI engine Compose configuration is invalid." 3
+	fi
+	if [[ -f "${compose_file}" ]]; then
+		cp -p "${compose_file}" "${previous_compose}"
+	fi
+	desired_image_id="$(docker image inspect --format '{{.Id}}' "${image}")"
+	current_container="$(
+		cd "${COMPOSE_DIR}"
+		"${COMPOSE[@]}" -p "${COMPOSE_PROJECT}" ps -q lensnode 2>/dev/null || true
+	)"
+	if [[ -n "${current_container}" ]]; then
+		previous_image_id="$(docker inspect --format '{{.Image}}' "${current_container}" 2>/dev/null || true)"
+	fi
+	mv -f "${compose_temporary}" "${compose_file}"
+	chmod 0600 "${compose_file}"
+	if ! (
+		cd "${COMPOSE_DIR}"
+		compose_args=(up -d --pull never)
+		if [[ -n "${current_container}" && "${previous_image_id}" != "${desired_image_id}" ]]; then
+			hfl_step "Recreating the AI engine because its loaded image ID changed."
+			compose_args+=(--force-recreate)
+		fi
+		"${COMPOSE[@]}" -p "${COMPOSE_PROJECT}" "${compose_args[@]}"
+		started_container="$("${COMPOSE[@]}" -p "${COMPOSE_PROJECT}" ps -q lensnode 2>/dev/null || true)"
+		[[ -n "${started_container}" ]] || exit 1
+		[[ "$(docker inspect --format '{{.State.Running}}' "${started_container}" 2>/dev/null || true)" == "true" ]] \
+			|| exit 1
+		[[ "$(docker inspect --format '{{.Image}}' "${started_container}" 2>/dev/null || true)" == "${desired_image_id}" ]] \
+			|| exit 1
+	); then
+		if [[ -f "${previous_compose}" ]]; then
+			mv -f "${previous_compose}" "${compose_file}"
+			chmod 0600 "${compose_file}"
+			recovery_detail="the previous Compose configuration was restored"
+			if [[ -n "${previous_image_id}" && "${previous_image_id}" != "${desired_image_id}" ]]; then
+				if docker image tag "${previous_image_id}" "${image}"; then
+					recovery_detail="the previous Compose configuration and image reference were restored"
+				else
+					hfl_warn "The previous AI engine image reference could not be restored automatically."
+				fi
+			fi
+			if ! (
+				cd "${COMPOSE_DIR}"
+				"${COMPOSE[@]}" -p "${COMPOSE_PROJECT}" up -d --pull never
+			); then
+				hfl_warn "The previous AI engine Compose configuration was restored, but its container could not be restarted automatically."
+			fi
+		else
+			# There is no previous installation to restore. Remove any partially
+			# created first-install project before returning the failure.
+			if ! (
+				cd "${COMPOSE_DIR}"
+				"${COMPOSE[@]}" -p "${COMPOSE_PROJECT}" down --remove-orphans
+			); then
+				hfl_warn "The failed first-install AI engine project could not be cleaned up automatically."
+			fi
+			rm -f "${compose_file}"
+		fi
+		hfl_fail "AI engine container startup failed; ${recovery_detail}." 3
+	fi
+	rm -f "${previous_compose}"
+	# A legacy sourcelens-project container can coexist with the new project.
+	# Remove it only after the replacement is confirmed started.
+	remove_owned_legacy_gateway_containers
 	hfl_ok "AI engine container started."
 }
 
@@ -346,3 +485,4 @@ install_docker_sidecar "${RESOLVED_IMAGE}"
 SIDECAR_MODE="docker"
 
 hfl_ok "AI engine installation completed (${SIDECAR_MODE})."
+cleanup_legacy_layout

--- a/deploy/bootstrap/gateway-lifecycle.sh
+++ b/deploy/bootstrap/gateway-lifecycle.sh
@@ -3,9 +3,26 @@
 # Published under /media/gateway-bootstrap/; invoked by hfl-enroll or detached agent scripts.
 set -euo pipefail
 
-ENV_FILE="${HFL_AGENT_ENV_FILE:-/opt/hyperfilelens-agent/config/agent.env}"
-LENS_ENV_FILE="${HFL_LENS_ENV_FILE:-/etc/hyperfilelens/lensnode.env}"
-COMPOSE_DIR="${HFL_GATEWAY_COMPOSE_DIR:-/etc/hyperfilelens/lensnode}"
+AGENT_ROOT="${HFL_AGENT_ROOT:-/opt/hyperfilelens-agent}"
+ENV_FILE="${HFL_AGENT_ENV_FILE:-${AGENT_ROOT}/config/agent.env}"
+LENS_ENV_FILE="${HFL_LENS_ENV_FILE:-${AGENT_ROOT}/config/lensnode.env}"
+COMPOSE_DIR="${HFL_GATEWAY_COMPOSE_DIR:-${AGENT_ROOT}/runtime/lensnode}"
+LEGACY_LENS_ENV_FILE="/etc/hyperfilelens/lensnode.env"
+LEGACY_COMPOSE_DIR="/etc/hyperfilelens/lensnode"
+LEGACY_ADOPTION_MARKER="${COMPOSE_DIR}/.hfl-legacy-layout-adopted"
+LEGACY_MIGRATION_ENABLED=0
+legacy_migration_allowed_for_agent() {
+	[[ "${AGENT_ROOT}" == "/opt/hyperfilelens-agent" \
+		&& ("${ENV_FILE}" == "/opt/hyperfilelens-agent/config/agent.env" \
+			|| "${ENV_FILE}" == "/var/lib/hyperfilelens-agent/agent.env") ]]
+}
+if legacy_migration_allowed_for_agent; then
+	LEGACY_MIGRATION_ENABLED=1
+fi
+if [[ "${LENS_ENV_FILE}" != "${AGENT_ROOT}/config/lensnode.env" \
+	|| "${COMPOSE_DIR}" != "${AGENT_ROOT}/runtime/lensnode" ]]; then
+	LEGACY_MIGRATION_ENABLED=0
+fi
 GATEWAY_BOOTSTRAP_BASE=""
 HFL_API_BASE=""
 HFL_ORG_KEY=""
@@ -88,6 +105,17 @@ hfl_fail() {
 	HFL_LAST_ERROR=$1
 	printf '  [FAIL] %s\n' "$1" >&2
 	exit "${2:-1}"
+}
+
+validate_lifecycle_paths() {
+	[[ "${AGENT_ROOT}" == /* && "${AGENT_ROOT}" != "/" ]] \
+		|| hfl_fail "HFL_AGENT_ROOT must be an absolute non-root path" 2
+	[[ "${ENV_FILE}" == /* && "${ENV_FILE}" != "/" ]] \
+		|| hfl_fail "HFL_AGENT_ENV_FILE must be an absolute file path" 2
+	[[ "${LENS_ENV_FILE}" == /* && "${LENS_ENV_FILE}" != "/" ]] \
+		|| hfl_fail "HFL_LENS_ENV_FILE must be an absolute file path" 2
+	[[ "${COMPOSE_DIR}" == /* && "${COMPOSE_DIR}" != "/" ]] \
+		|| hfl_fail "HFL_GATEWAY_COMPOSE_DIR must be an absolute non-root path" 2
 }
 
 compose_version_ge() {
@@ -174,15 +202,91 @@ load_agent_credentials() {
 }
 
 load_agent_credentials_optional() {
+	local persisted_agent_root=""
 	[[ -f "${ENV_FILE}" ]] || return 1
+	# Recompute legacy authority from the persisted installation identity. A
+	# custom Agent Root must never inherit permission to mutate the global old
+	# layout merely because this process initially used the default path.
+	LEGACY_MIGRATION_ENABLED=0
 	HFL_API_BASE="$(read_env_value "${ENV_FILE}" HFL_API_BASE)"
 	HFL_ORG_KEY="$(read_env_value "${ENV_FILE}" HFL_ORG_KEY)"
-	HFL_NODE_TOKEN="$(read_env_value "${ENV_FILE}" HFL_NODE_TOKEN)"
+	HFL_NODE_TOKEN="$(read_env_value "${ENV_FILE}" HFL_NODE_CREDENTIAL)"
+	[[ -n "${HFL_NODE_TOKEN}" ]] \
+		|| HFL_NODE_TOKEN="$(read_env_value "${ENV_FILE}" HFL_NODE_TOKEN)"
 	HFL_NODE_ID="$(read_env_value "${ENV_FILE}" HFL_NODE_ID)"
+	persisted_agent_root="$(read_env_value "${ENV_FILE}" HFL_AGENT_ROOT)"
+	if [[ -n "${persisted_agent_root}" ]]; then
+		[[ "${persisted_agent_root}" == /* ]] \
+			|| hfl_fail "invalid relative HFL_AGENT_ROOT in ${ENV_FILE}" 2
+		AGENT_ROOT="$(readlink -m -- "${persisted_agent_root}")" || return 1
+		[[ "${AGENT_ROOT}" != "/" ]] \
+			|| hfl_fail "invalid root HFL_AGENT_ROOT in ${ENV_FILE}" 2
+	elif [[ "${ENV_FILE}" == */config/agent.env ]]; then
+		AGENT_ROOT="$(cd -P -- "$(dirname -- "${ENV_FILE}")/.." 2>/dev/null && pwd -P || true)"
+	fi
+	[[ -n "${AGENT_ROOT}" ]] || AGENT_ROOT="/opt/hyperfilelens-agent"
+	[[ "${AGENT_ROOT}" == /* && "${AGENT_ROOT}" != "/" ]] || return 1
+	if legacy_migration_allowed_for_agent; then
+		LEGACY_MIGRATION_ENABLED=1
+	fi
+	LENS_ENV_FILE="${HFL_LENS_ENV_FILE:-${AGENT_ROOT}/config/lensnode.env}"
+	COMPOSE_DIR="${HFL_GATEWAY_COMPOSE_DIR:-${AGENT_ROOT}/runtime/lensnode}"
+	LEGACY_ADOPTION_MARKER="${COMPOSE_DIR}/.hfl-legacy-layout-adopted"
+	if [[ "${LENS_ENV_FILE}" != "${AGENT_ROOT}/config/lensnode.env" \
+		|| "${COMPOSE_DIR}" != "${AGENT_ROOT}/runtime/lensnode" ]]; then
+		LEGACY_MIGRATION_ENABLED=0
+	fi
 	[[ -n "${HFL_API_BASE}" && -n "${HFL_ORG_KEY}" && -n "${HFL_NODE_TOKEN}" && -n "${HFL_NODE_ID}" ]] \
 		|| return 1
 	GATEWAY_BOOTSTRAP_BASE="${HFL_API_BASE%/}/media/gateway-bootstrap"
 	return 0
+}
+
+migrate_legacy_layout() {
+	local adopted=0
+	[[ "${LEGACY_MIGRATION_ENABLED}" == "1" ]] || return 0
+	[[ "${LENS_ENV_FILE}" == "${LEGACY_LENS_ENV_FILE}" ]] && return 0
+	if [[ -f "${LEGACY_LENS_ENV_FILE}" ]]; then
+		if [[ -e "${LENS_ENV_FILE}" ]]; then
+			if [[ -f "${LEGACY_ADOPTION_MARKER}" ]] || cmp -s "${LEGACY_LENS_ENV_FILE}" "${LENS_ENV_FILE}"; then
+				adopted=1
+			else
+				hfl_fail "Legacy LensNode configuration conflicts with ${LENS_ENV_FILE}; resolve it before continuing" 2
+			fi
+		else
+			mkdir -p "$(dirname "${LENS_ENV_FILE}")"
+			install -m 0600 "${LEGACY_LENS_ENV_FILE}" "${LENS_ENV_FILE}"
+			hfl_log "adopted legacy LensNode configuration into ${LENS_ENV_FILE}"
+			adopted=1
+		fi
+	fi
+	if [[ "${COMPOSE_DIR}" != "${LEGACY_COMPOSE_DIR}" && -d "${LEGACY_COMPOSE_DIR}" ]]; then
+		if [[ -e "${COMPOSE_DIR}" ]]; then
+			if [[ -f "${LEGACY_ADOPTION_MARKER}" ]]; then
+				adopted=1
+			elif [[ ! -e "${COMPOSE_DIR}/docker-compose.yml" ]]; then
+				cp -a "${LEGACY_COMPOSE_DIR}/." "${COMPOSE_DIR}/"
+				hfl_log "adopted legacy LensNode Compose files into ${COMPOSE_DIR}"
+				adopted=1
+			elif [[ -f "${LEGACY_COMPOSE_DIR}/docker-compose.yml" && -f "${COMPOSE_DIR}/docker-compose.yml" ]]; then
+				cmp -s "${LEGACY_COMPOSE_DIR}/docker-compose.yml" "${COMPOSE_DIR}/docker-compose.yml" \
+					|| hfl_fail "Legacy LensNode Compose configuration conflicts with ${COMPOSE_DIR}; resolve it before continuing" 2
+				adopted=1
+			fi
+		else
+			mkdir -p "${COMPOSE_DIR}"
+			cp -a "${LEGACY_COMPOSE_DIR}/." "${COMPOSE_DIR}/"
+			chmod 0700 "${COMPOSE_DIR}"
+			hfl_log "adopted legacy LensNode Compose files into ${COMPOSE_DIR}"
+			adopted=1
+		fi
+	fi
+	if [[ "${adopted}" == "1" ]]; then
+		mkdir -p "${COMPOSE_DIR}"
+		chmod 0700 "${COMPOSE_DIR}"
+		: >"${LEGACY_ADOPTION_MARKER}"
+		chmod 0600 "${LEGACY_ADOPTION_MARKER}"
+	fi
 }
 
 report_lifecycle_status() {
@@ -219,7 +323,7 @@ remember_owned_lensnode_image() {
 }
 
 remove_owned_legacy_gateway_containers() {
-	local id project service working_dir config_files
+	local id project service working_dir config_files current_owned legacy_owned
 	while IFS= read -r id; do
 		[[ -n "${id}" ]] || continue
 		project="$(docker inspect --format '{{index .Config.Labels "com.docker.compose.project"}}' "${id}" 2>/dev/null || true)"
@@ -227,10 +331,18 @@ remove_owned_legacy_gateway_containers() {
 		working_dir="$(docker inspect --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' "${id}" 2>/dev/null || true)"
 		config_files="$(docker inspect --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}' "${id}" 2>/dev/null || true)"
 		[[ "${project}" == "sourcelens" && "${service}" == "lensnode" ]] || continue
-		if [[ "${working_dir}" != "${COMPOSE_DIR}" \
-			&& ",${config_files}," != *",${COMPOSE_DIR}/docker-compose.yml,"* ]]; then
-			continue
+		current_owned=0
+		if [[ "${working_dir}" == "${COMPOSE_DIR}" \
+			|| ",${config_files}," == *",${COMPOSE_DIR}/docker-compose.yml,"* ]]; then
+			current_owned=1
 		fi
+		legacy_owned=0
+		if [[ "${LEGACY_MIGRATION_ENABLED}" == "1" \
+			&& ("${working_dir}" == "${LEGACY_COMPOSE_DIR}" \
+				|| ",${config_files}," == *",${LEGACY_COMPOSE_DIR}/docker-compose.yml,"*) ]]; then
+			legacy_owned=1
+		fi
+		[[ "${current_owned}" == "1" || "${legacy_owned}" == "1" ]] || continue
 		remember_owned_lensnode_image "$(docker inspect --format '{{.Config.Image}}' "${id}" 2>/dev/null || true)"
 		hfl_log "Removing owned legacy Gateway container ${id:0:12} from project sourcelens."
 		docker rm -f "${id}" >/dev/null
@@ -388,6 +500,8 @@ run_sidecar_install_script() {
 	[[ -n "${script}" && -f "${script}" ]] || hfl_fail "sidecar install script missing" 3
 	[[ -f "${LENS_ENV_FILE}" ]] || hfl_fail "missing ${LENS_ENV_FILE}" 2
 	HFL_LENS_ENV_FILE="${LENS_ENV_FILE}" \
+	HFL_GATEWAY_COMPOSE_DIR="${COMPOSE_DIR}" \
+	HFL_AGENT_ROOT="${AGENT_ROOT}" \
 		HFL_INSECURE_TLS="${HFL_INSECURE_TLS}" \
 		LENSNODE_IMAGE="${DEFAULT_LENSNODE_IMAGE}" \
 		bash "${script}"
@@ -395,16 +509,22 @@ run_sidecar_install_script() {
 
 cmd_upgrade_sidecar() {
 	local tmp="" script
+	validate_lifecycle_paths
 	acquire_sidecar_lock
 	load_agent_credentials
+	validate_lifecycle_paths
 	report_lifecycle_status "sidecar_upgrade" "running"
 	trap 'gateway_upgrade_exit "$?" "${tmp}"' EXIT
 	tmp="$(mktemp -d)"
 	ensure_docker_ready
+	migrate_legacy_layout
 	script="${tmp}/${SIDECAR_INSTALL_SCRIPT}"
 	download_bootstrap_file "${SIDECAR_INSTALL_SCRIPT}" "${script}"
 	load_lensnode_image "${tmp}"
-	compose_down_sidecar
+	# Keep the existing container available while the downloaded installer
+	# validates and starts its replacement. The installer removes an owned
+	# legacy container only after the replacement is confirmed running and
+	# restores the previous Compose configuration when startup fails.
 	run_sidecar_install_script "${script}"
 	rm -rf "${tmp}"
 	report_lifecycle_status "sidecar_upgrade" "success"
@@ -441,13 +561,71 @@ remove_lensnode_images() {
 }
 
 validate_gateway_workspace_path() {
-	local candidate=${1:-} canonical normalized
+	local candidate=${1:-} canonical normalized root_prefix
 	[[ -n "${candidate}" ]] || return 1
 	canonical="$(readlink -m -- "${candidate}")" || return 1
 	normalized="${candidate%/}"
 	[[ "${normalized}" == "${canonical}" ]] || return 1
-	[[ "${canonical}" =~ ^/workspace/org-[1-9][0-9]*/data$ ]] || return 1
+	if [[ "${canonical}" =~ ^/workspace/org-[1-9][0-9]*/data$ ]]; then
+		printf '%s\n' "${canonical}"
+		return 0
+	fi
+	root_prefix="$(readlink -m -- "${AGENT_ROOT}/workspace")" || return 1
+	if [[ "${canonical}" == "${root_prefix}"/* ]]; then
+		local relative="${canonical#"${root_prefix}"/}"
+		[[ "${relative}" =~ ^org-[1-9][0-9]*/data$ ]] || return 1
+	else
+		return 1
+	fi
 	printf '%s\n' "${canonical}"
+}
+
+collect_mount_targets() {
+	local targets
+	if command -v findmnt >/dev/null 2>&1; then
+		if targets="$(LC_ALL=C findmnt -rn -o TARGET 2>/dev/null)" && [[ -n "${targets}" ]]; then
+			printf '%s\n' "${targets}"
+			return 0
+		fi
+	fi
+	if [[ -r /proc/mounts ]]; then
+		awk '{ print $2 }' /proc/mounts
+		return 0
+	fi
+	return 1
+}
+
+gateway_workspace_mounts() {
+	local workspace=${1:-} managed_root target canonical_target canonical_root protected_root targets
+	managed_root="$(readlink -m -- "${AGENT_ROOT}/workspace")" || return 1
+	targets="$(collect_mount_targets)" || return 1
+	while IFS= read -r target; do
+		[[ -n "${target}" ]] || continue
+		canonical_target="$(readlink -m -- "${target}")" || continue
+		if [[ "${canonical_target}" == "${managed_root}" || "${canonical_target}" == "${managed_root}"/* ]]; then
+			printf '%s\n' "${canonical_target}"
+			continue
+		fi
+		[[ -n "${workspace}" ]] || continue
+		canonical_root="$(readlink -m -- "${workspace}")" || continue
+		# The Agent keeps LensNode state beside data/ under the same org
+		# directory. Protect both data and .hyperfilelens for legacy
+		# /workspace layouts; the unified managed_root check already covers
+		# the equivalent Agent Root tree.
+		protected_root="$(dirname -- "${canonical_root}")"
+		if [[ "${canonical_target}" == "${protected_root}" || "${canonical_target}" == "${protected_root}"/* ]]; then
+			printf '%s\n' "${canonical_target}"
+		fi
+	done <<<"${targets}"
+}
+
+assert_gateway_workspace_not_mounted() {
+	local workspace=${1:-} mounts
+	mounts="$(gateway_workspace_mounts "${workspace}")" \
+		|| hfl_fail "could not verify Gateway workspace mounts; refusing purge-all" 6
+	mounts="$(printf '%s\n' "${mounts}" | sort -u)"
+	[[ -z "${mounts}" ]] || hfl_fail \
+		"refusing to purge mounted Gateway workspace data (${mounts//$'\n'/, }); unmount it manually and retry" 6
 }
 
 purge_sidecar_artifacts() {
@@ -459,10 +637,17 @@ purge_sidecar_artifacts() {
 		workspace="$(validate_gateway_workspace_path "${workspace}")" \
 			|| hfl_fail "refusing to purge unsafe Gateway workspace path from ${LENS_ENV_FILE}" 6
 	fi
+	# This check must precede container, image, configuration, and Compose
+	# removal. A mounted workspace is user-owned storage, even for --purge-all.
+	assert_gateway_workspace_not_mounted "${workspace}"
 	compose_down_sidecar
 	remove_lensnode_images
 	rm -f "${LENS_ENV_FILE}"
 	rm -rf "${COMPOSE_DIR}"
+	if [[ "${LEGACY_MIGRATION_ENABLED}" == "1" ]]; then
+		[[ "${LENS_ENV_FILE}" == "${LEGACY_LENS_ENV_FILE}" ]] || rm -f "${LEGACY_LENS_ENV_FILE}"
+		[[ "${COMPOSE_DIR}" == "${LEGACY_COMPOSE_DIR}" ]] || rm -rf "${LEGACY_COMPOSE_DIR}"
+	fi
 	if [[ -n "${workspace}" ]]; then
 		hfl_log "Removing gateway workspace ${workspace}."
 		rm -rf "${workspace}"
@@ -473,11 +658,24 @@ purge_sidecar_artifacts() {
 }
 
 cmd_uninstall_sidecar() {
+	validate_lifecycle_paths
 	acquire_sidecar_lock
 	if ! load_agent_credentials_optional; then
 		hfl_log "Agent credentials are unavailable; continuing local AI engine cleanup without status reporting."
+		# Local uninstall must still remove the known legacy LensNode layout
+		# when a standard Agent credential file is unavailable. Explicit custom
+		# lifecycle paths remain isolated from the system legacy directories.
+		if legacy_migration_allowed_for_agent; then
+			LEGACY_MIGRATION_ENABLED=1
+		fi
 	fi
+	if [[ "${LENS_ENV_FILE}" != "${AGENT_ROOT}/config/lensnode.env" \
+		|| "${COMPOSE_DIR}" != "${AGENT_ROOT}/runtime/lensnode" ]]; then
+		LEGACY_MIGRATION_ENABLED=0
+	fi
+	validate_lifecycle_paths
 	ensure_docker_ready
+	migrate_legacy_layout
 	report_lifecycle_status "sidecar_uninstall" "running"
 	if [[ "${PURGE_ALL}" -eq 1 ]]; then
 		purge_sidecar_artifacts

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -62,7 +62,10 @@ LOCAL_PLATFORM_AGENT_INSTALL_DIR="/opt/hyperfilelens-agent/bin"
 LOCAL_PLATFORM_AGENT_DATA_DIR="/opt/hyperfilelens-agent"
 LOCAL_PLATFORM_AGENT_LEGACY_INSTALL_DIR="/opt/hyperfilelens-agent"
 LOCAL_PLATFORM_AGENT_LEGACY_DATA_DIR="/var/lib/hyperfilelens-agent"
-LOCAL_PLATFORM_LENSNODE_ENV_FILE="/etc/hyperfilelens/lensnode.env"
+LOCAL_PLATFORM_LENSNODE_ENV_FILE="${LOCAL_PLATFORM_AGENT_DATA_DIR}/config/lensnode.env"
+LOCAL_PLATFORM_LEGACY_LENSNODE_ENV_FILE="/etc/hyperfilelens/lensnode.env"
+LOCAL_PLATFORM_LENSNODE_COMPOSE_DIR="${LOCAL_PLATFORM_AGENT_DATA_DIR}/runtime/lensnode"
+LOCAL_PLATFORM_LEGACY_LENSNODE_COMPOSE_DIR="/etc/hyperfilelens/lensnode"
 LOCAL_PLATFORM_LENSNODE_IMAGE="hyperfilelens-sourcelens-lensnode:latest"
 LOCAL_PLATFORM_GATEWAY_VERIFIED=0
 
@@ -4566,7 +4569,7 @@ verify_local_platform_gateway_agent() {
 }
 
 converge_local_platform_gateway_lensnode() {
-	local desired_id current_id container_id running script
+	local desired_id current_id container_id running script layout_migration=0 legacy_layout_adopted=0
 	desired_id="$(docker image inspect --format '{{.Id}}' \
 		"${LOCAL_PLATFORM_LENSNODE_IMAGE}" 2>/dev/null || true)"
 	[[ -n "${desired_id}" ]] \
@@ -4576,18 +4579,54 @@ converge_local_platform_gateway_lensnode() {
 		--filter 'label=com.hyperfilelens.component=gateway-lensnode' \
 		--filter 'label=com.docker.compose.project=hyperfilelens-gateway' \
 		--filter 'label=com.docker.compose.service=lensnode' | head -1)"
+	# Pre-unification Gateway containers used the SourceLens Compose project
+	# name. Find only containers tied to the known legacy LensNode directory;
+	# unrelated SourceLens LensNode projects must remain untouched.
+	if [[ -z "${container_id}" ]]; then
+		local candidate working_dir config_files
+		while IFS= read -r candidate; do
+			[[ -n "${candidate}" ]] || continue
+			working_dir="$(docker inspect --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' "${candidate}" 2>/dev/null || true)"
+			config_files="$(docker inspect --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}' "${candidate}" 2>/dev/null || true)"
+			if [[ "${working_dir}" == "${LOCAL_PLATFORM_LEGACY_LENSNODE_COMPOSE_DIR}" \
+				|| ",${config_files}," == *",${LOCAL_PLATFORM_LEGACY_LENSNODE_COMPOSE_DIR}/docker-compose.yml,"* ]]; then
+				container_id="${candidate}"
+				break
+			fi
+		done < <(docker ps -aq --no-trunc \
+			--filter 'label=com.docker.compose.project=sourcelens' \
+			--filter 'label=com.docker.compose.service=lensnode')
+	fi
 	[[ -n "${container_id}" ]] \
 		|| die "installer-managed Platform Data Gateway AI engine container is missing"
 	current_id="$(docker inspect --format '{{.Image}}' "${container_id}" 2>/dev/null || true)"
-	if [[ "${current_id}" == "${desired_id}" ]]; then
+	if [[ -e "${LOCAL_PLATFORM_LEGACY_LENSNODE_ENV_FILE}" ]] \
+		|| [[ -d "${LOCAL_PLATFORM_LEGACY_LENSNODE_COMPOSE_DIR}" ]]; then
+		layout_migration=1
+		# Only authorize the sidecar's legacy adoption shortcut when the
+		# canonical env file is absent. If both layouts already exist, the
+		# sidecar must compare them and reject conflicting credentials.
+		if [[ ! -e "${LOCAL_PLATFORM_LENSNODE_ENV_FILE}" \
+			&& ! -e "${LOCAL_PLATFORM_LENSNODE_COMPOSE_DIR}/docker-compose.yml" ]]; then
+			legacy_layout_adopted=1
+		fi
+	fi
+	if [[ "${current_id}" == "${desired_id}" && "${layout_migration}" -eq 0 ]]; then
 		skip "Platform Data Gateway AI engine already uses the desired image"
 	else
 		script="${ROOT}/data/media/gateway-bootstrap/gateway-install-lensnode-sidecar.sh"
 		[[ -f "${script}" && ! -L "${script}" ]] \
 			|| die "Platform Data Gateway AI engine installer is missing: ${script}"
-		step "Recreating the Platform Data Gateway AI engine for a changed image"
+		if [[ "${layout_migration}" -eq 1 && "${current_id}" == "${desired_id}" ]]; then
+			step "Migrating the Platform Data Gateway AI engine into the unified Agent Root"
+		else
+			step "Recreating the Platform Data Gateway AI engine for a changed image"
+		fi
 		run_as_root env \
 			HFL_LENS_ENV_FILE="${LOCAL_PLATFORM_LENSNODE_ENV_FILE}" \
+			HFL_GATEWAY_COMPOSE_DIR="${LOCAL_PLATFORM_LENSNODE_COMPOSE_DIR}" \
+			HFL_AGENT_ROOT="${LOCAL_PLATFORM_AGENT_DATA_DIR}" \
+			HFL_LEGACY_LAYOUT_ADOPTED="${legacy_layout_adopted}" \
 			HFL_INSECURE_TLS=1 \
 			LENSNODE_IMAGE="${LOCAL_PLATFORM_LENSNODE_IMAGE}" \
 			/bin/bash "${script}"

--- a/src/agent/internal/enroll/config.go
+++ b/src/agent/internal/enroll/config.go
@@ -24,6 +24,10 @@ type Config struct {
 	APIBase          string
 	WSSURL           string
 	InsecureTLS      bool
+	// AgentRoot is the installer-owned root used for Gateway sidecar state.
+	// It is persisted in agent.env so lifecycle commands can use the same
+	// paths as the running Agent instead of relying on a global /etc location.
+	AgentRoot string
 }
 
 // LoadConfigFromEnv reads enrollment settings injected by bootstrap stubs.
@@ -76,6 +80,10 @@ func LoadConfigFromEnv() (Config, error) {
 		APIBase:          strings.TrimRight(strings.TrimSpace(os.Getenv("HFL_API_BASE")), "/"),
 		WSSURL:           strings.TrimSpace(os.Getenv("HFL_WSS_URL")),
 		InsecureTLS:      os.Getenv("HFL_INSECURE_TLS") != "0",
+		AgentRoot:        strings.TrimSpace(os.Getenv("HFL_AGENT_ROOT")),
+	}
+	if cfg.AgentRoot != "" && (!filepath.IsAbs(cfg.AgentRoot) || filepath.Clean(cfg.AgentRoot) == string(filepath.Separator)) {
+		return Config{}, fmt.Errorf("HFL_AGENT_ROOT must be an absolute non-root path")
 	}
 	if cfg.OrgKey == "" || cfg.NodeToken == "" || cfg.APIBase == "" {
 		return Config{}, fmt.Errorf("HFL_ORG_KEY, HFL_NODE_TOKEN, and HFL_API_BASE are required")
@@ -134,7 +142,7 @@ func (c Config) AgentConfig() *model.AgentConfig {
 		NodeToken:        c.NodeToken,
 		InstallationID:   c.InstallationID,
 		InstallationMode: c.InstallationMode,
-		AgentRoot:        strings.TrimSpace(os.Getenv("HFL_AGENT_ROOT")),
+		AgentRoot:        c.AgentRoot,
 		RunAsUser:        c.RunAsUser,
 		RunAsHome:        c.RunAsHome,
 		NodeID:           ReadNodeID(envPath),

--- a/src/agent/internal/enroll/config_test.go
+++ b/src/agent/internal/enroll/config_test.go
@@ -28,6 +28,40 @@ func TestLoadConfigDefaultsToSystemInstallation(t *testing.T) {
 	}
 }
 
+func TestLoadConfigAcceptsAbsoluteAgentRoot(t *testing.T) {
+	setRequiredEnrollmentEnv(t)
+	t.Setenv("HFL_NODE_ROLE", "gateway")
+	t.Setenv("HFL_AGENT_ROOT", "/opt/hyperfilelens-agent")
+
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AgentRoot != "/opt/hyperfilelens-agent" {
+		t.Fatalf("AgentRoot = %q", cfg.AgentRoot)
+	}
+}
+
+func TestLoadConfigRejectsRelativeAgentRoot(t *testing.T) {
+	setRequiredEnrollmentEnv(t)
+	t.Setenv("HFL_NODE_ROLE", "gateway")
+	t.Setenv("HFL_AGENT_ROOT", "relative/agent-root")
+
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected relative HFL_AGENT_ROOT to be rejected")
+	}
+}
+
+func TestLoadConfigRejectsFilesystemRootAsAgentRoot(t *testing.T) {
+	setRequiredEnrollmentEnv(t)
+	t.Setenv("HFL_NODE_ROLE", "gateway")
+	t.Setenv("HFL_AGENT_ROOT", "/")
+
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected filesystem root HFL_AGENT_ROOT to be rejected")
+	}
+}
+
 func TestLoadConfigAcceptsUserLevelSourceAgent(t *testing.T) {
 	setRequiredEnrollmentEnv(t)
 	t.Setenv("HFL_NODE_ROLE", "agent")

--- a/src/agent/internal/enroll/envfile.go
+++ b/src/agent/internal/enroll/envfile.go
@@ -194,7 +194,10 @@ func WriteEnrollmentEnv(cfg Config) error {
 	envPath := EnvFilePath()
 	dataDir := dataDirForAgent()
 	kopiaPath := bundledKopiaPath()
-	agentRoot := strings.TrimSpace(os.Getenv("HFL_AGENT_ROOT"))
+	agentRoot := strings.TrimSpace(cfg.AgentRoot)
+	if agentRoot == "" {
+		agentRoot = strings.TrimSpace(os.Getenv("HFL_AGENT_ROOT"))
+	}
 	if agentRoot == "" {
 		agentRoot = vfs.AgentRootForMode(cfg.InstallationMode)
 	}
@@ -240,7 +243,10 @@ func syncEnrollmentConsoleSettings(cfg Config) error {
 func syncEnrollmentConsoleSettingsAt(envPath string, cfg Config) error {
 	dataDir := dataDirForAgent()
 	kopiaPath := bundledKopiaPath()
-	agentRoot := strings.TrimSpace(os.Getenv("HFL_AGENT_ROOT"))
+	agentRoot := strings.TrimSpace(cfg.AgentRoot)
+	if agentRoot == "" {
+		agentRoot = strings.TrimSpace(os.Getenv("HFL_AGENT_ROOT"))
+	}
 	if agentRoot == "" {
 		agentRoot = vfs.AgentRootForMode(cfg.InstallationMode)
 	}

--- a/src/agent/internal/enroll/sidecar_install_unix.go
+++ b/src/agent/internal/enroll/sidecar_install_unix.go
@@ -20,11 +20,11 @@ import (
 
 	"hyperfilelens/agent/internal/platform/install"
 	"hyperfilelens/agent/internal/platform/tlsclient"
+	"hyperfilelens/agent/internal/platform/vfs"
 )
 
 const (
-	lensEnvFilePath            = "/etc/hyperfilelens/lensnode.env"
-	lensAppliedFingerprintPath = "/etc/hyperfilelens/lensnode/.hfl-applied-config.sha256"
+	legacyLensEnvFilePath      = "/etc/hyperfilelens/lensnode.env"
 	lensSidecarLockPath        = "/run/lock/hyperfilelens-gateway-sidecar.lock"
 	lensSidecarLockHeldEnv     = "HFL_GATEWAY_SIDECAR_LOCK_HELD"
 	lensSidecarScript          = "gateway-install-lensnode-sidecar.sh"
@@ -34,6 +34,29 @@ const (
 	gatewayMinDockerEngine     = "24.0.0"
 	gatewayMinDockerCompose    = "2.20.0"
 )
+
+func gatewayAgentRoot(agentRoot string) string {
+	root := strings.TrimSpace(agentRoot)
+	if root == "" {
+		root = "/opt/hyperfilelens-agent"
+	}
+	return filepath.Clean(root)
+}
+
+func gatewayLensPaths(agentRoot string) (string, string, string) {
+	root := gatewayAgentRoot(agentRoot)
+	runtimeDir := vfs.AgentLensnodeRuntimeDir(root)
+	return filepath.Join(vfs.AgentConfigDir(root), "lensnode.env"),
+		filepath.Join(runtimeDir, ".hfl-applied-config.sha256"),
+		runtimeDir
+}
+
+func gatewayLegacyLensEnvPath(agentRoot string) string {
+	if gatewayAgentRoot(agentRoot) == "/opt/hyperfilelens-agent" {
+		return legacyLensEnvFilePath
+	}
+	return ""
+}
 
 var (
 	sourceLensHealthOK     = regexp.MustCompile(`"health"\s*:\s*"OK"`)
@@ -72,10 +95,11 @@ func checkSourceLensHealthViaConsole(ctx context.Context, cfg Config) error {
 type lensSidecarRuntime struct {
 	envPath        string
 	appliedPath    string
+	legacyEnvPath  string
 	lockPath       string
 	healthy        func() bool
 	ensureImage    func(context.Context, Config) error
-	installSidecar func(context.Context, Config) error
+	installSidecar func(context.Context, Config, bool) error
 }
 
 func checkGatewayRuntimePreflight(ctx context.Context, cfg Config) gatewayRuntimePreflightResult {
@@ -199,9 +223,12 @@ func gatewayDockerArchiveName() string {
 }
 
 func defaultLensSidecarRuntime() lensSidecarRuntime {
+	agentRoot := os.Getenv("HFL_AGENT_ROOT")
+	envPath, appliedPath, _ := gatewayLensPaths(agentRoot)
 	return lensSidecarRuntime{
-		envPath:        lensEnvFilePath,
-		appliedPath:    lensAppliedFingerprintPath,
+		envPath:        envPath,
+		appliedPath:    appliedPath,
+		legacyEnvPath:  gatewayLegacyLensEnvPath(agentRoot),
 		lockPath:       lensSidecarLockPath,
 		healthy:        lensSidecarHealthy,
 		ensureImage:    ensureLensnodeImage,
@@ -211,7 +238,10 @@ func defaultLensSidecarRuntime() lensSidecarRuntime {
 
 // InstallLensSidecar writes LensNode credentials and runs the bundled sidecar install script.
 func InstallLensSidecar(ctx context.Context, cfg Config, lens LensSidecarConfig) error {
-	return defaultLensSidecarRuntime().install(ctx, cfg, lens)
+	runtime := defaultLensSidecarRuntime()
+	runtime.envPath, runtime.appliedPath, _ = gatewayLensPaths(cfg.AgentRoot)
+	runtime.legacyEnvPath = gatewayLegacyLensEnvPath(cfg.AgentRoot)
+	return runtime.install(ctx, cfg, lens)
 }
 
 func (runtime lensSidecarRuntime) install(
@@ -220,12 +250,20 @@ func (runtime lensSidecarRuntime) install(
 	lens LensSidecarConfig,
 ) error {
 	return withFileLock(ctx, runtime.lockPath, func() error {
+		legacyLayoutPresent := legacyLensLayoutPresentAt(runtime.legacyEnvPath)
+		legacyLayoutAdopted := legacyLensLayoutPendingAt(runtime.envPath, runtime.legacyEnvPath)
+		if legacyLayoutAdopted {
+			if err := markLegacyLensLayoutAdopted(runtime.appliedPath); err != nil {
+				return err
+			}
+		}
 		_, fingerprint, err := writeLensEnvFileAt(runtime.envPath, lens)
 		if err != nil {
 			return err
 		}
 
 		if runtime.healthy() &&
+			!legacyLayoutPresent &&
 			os.Getenv("HFL_FORCE_SIDECAR_INSTALL") != "1" &&
 			lensConfigurationApplied(runtime.appliedPath, fingerprint) {
 			logStep("AI engine is already running.")
@@ -235,11 +273,56 @@ func (runtime lensSidecarRuntime) install(
 		if err := runtime.ensureImage(ctx, cfg); err != nil {
 			return err
 		}
-		if err := runtime.installSidecar(ctx, cfg); err != nil {
+		if err := runtime.installSidecar(ctx, cfg, legacyLayoutAdopted); err != nil {
 			return err
 		}
 		return markLensConfigurationApplied(runtime.appliedPath, fingerprint)
 	})
+}
+
+// legacyLensLayoutPending is intentionally narrow: only an Agent-managed
+// install may use it to tell the downloaded installer that the newly written
+// control-plane configuration supersedes the pre-unified file. Direct script
+// invocations retain strict conflict checks.
+func legacyLensLayoutPendingAt(envPath, legacyPath string) bool {
+	if legacyPath == "" || envPath == legacyPath {
+		return false
+	}
+	if !legacyLensLayoutPresentAt(legacyPath) {
+		return false
+	}
+	// Only authorize the migration marker before the canonical env file has
+	// been created. If both files already exist, the downloaded sidecar script
+	// must compare them and reject conflicting credentials instead of having a
+	// pre-existing file silently marked as adopted.
+	_, err := os.Stat(envPath)
+	return os.IsNotExist(err)
+}
+
+func legacyLensLayoutPresentAt(legacyPath string) bool {
+	if legacyPath == "" {
+		return false
+	}
+	if _, err := os.Stat(legacyPath); err == nil {
+		return true
+	}
+	// The old layout kept the Compose project beside lensnode.env. Either
+	// artifact can survive a partially completed cleanup and must trigger one
+	// more convergence attempt so the sidecar script can remove the remainder.
+	legacyComposeDir := filepath.Join(filepath.Dir(legacyPath), "lensnode")
+	_, err := os.Stat(legacyComposeDir)
+	return err == nil
+}
+
+func markLegacyLensLayoutAdopted(appliedPath string) error {
+	marker := filepath.Join(filepath.Dir(appliedPath), ".hfl-legacy-layout-adopted")
+	if err := os.MkdirAll(filepath.Dir(marker), 0o700); err != nil {
+		return fmt.Errorf("create legacy LensNode migration state directory: %w", err)
+	}
+	if err := writePrivateEnvAtomically(marker, []byte("managed-by=hfl-enroll\n")); err != nil {
+		return fmt.Errorf("record legacy LensNode migration state: %w", err)
+	}
+	return nil
 }
 
 func ensureGatewayDocker(ctx context.Context, cfg Config) error {
@@ -362,7 +445,7 @@ func lensSidecarHealthy() bool {
 
 func writeLensEnvFileAt(path string, lens LensSidecarConfig) (bool, string, error) {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return false, "", fmt.Errorf("create %s: %w", dir, err)
 	}
 
@@ -410,7 +493,10 @@ func ConvergeGatewayLensObservability(
 	cfg Config,
 	lens LensSidecarConfig,
 ) (bool, error) {
-	return defaultLensSidecarRuntime().convergeObservability(ctx, cfg, lens)
+	runtime := defaultLensSidecarRuntime()
+	runtime.envPath, runtime.appliedPath, _ = gatewayLensPaths(cfg.AgentRoot)
+	runtime.legacyEnvPath = gatewayLegacyLensEnvPath(cfg.AgentRoot)
+	return runtime.convergeObservability(ctx, cfg, lens)
 }
 
 func (runtime lensSidecarRuntime) convergeObservability(
@@ -420,17 +506,24 @@ func (runtime lensSidecarRuntime) convergeObservability(
 ) (bool, error) {
 	changed := false
 	err := withFileLock(ctx, runtime.lockPath, func() error {
+		legacyLayoutPresent := legacyLensLayoutPresentAt(runtime.legacyEnvPath)
+		legacyLayoutAdopted := legacyLensLayoutPendingAt(runtime.envPath, runtime.legacyEnvPath)
+		if legacyLayoutAdopted {
+			if err := markLegacyLensLayoutAdopted(runtime.appliedPath); err != nil {
+				return err
+			}
+		}
 		var fingerprint string
 		var err error
 		changed, fingerprint, err = writeLensEnvFileAt(runtime.envPath, lens)
 		if err != nil {
 			return err
 		}
-		if lensConfigurationApplied(runtime.appliedPath, fingerprint) ||
+		if (lensConfigurationApplied(runtime.appliedPath, fingerprint) && !legacyLayoutPresent) ||
 			!runtime.healthy() {
 			return nil
 		}
-		if err := runtime.installSidecar(ctx, cfg); err != nil {
+		if err := runtime.installSidecar(ctx, cfg, legacyLayoutAdopted); err != nil {
 			return fmt.Errorf("refresh AI engine observability: %w", err)
 		}
 		if err := markLensConfigurationApplied(runtime.appliedPath, fingerprint); err != nil {
@@ -487,19 +580,25 @@ func withFileLock(ctx context.Context, path string, action func() error) error {
 	return action()
 }
 
-func runLensSidecarInstaller(ctx context.Context, cfg Config) error {
+func runLensSidecarInstaller(ctx context.Context, cfg Config, legacyLayoutAdopted bool) error {
 	scriptPath, cleanup, err := downloadSidecarInstallScript(ctx, cfg)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 	cmd := exec.CommandContext(ctx, "/bin/bash", scriptPath)
+	envPath, _, composeDir := gatewayLensPaths(cfg.AgentRoot)
 	cmd.Env = append(os.Environ(),
-		"HFL_LENS_ENV_FILE="+lensEnvFilePath,
+		"HFL_AGENT_ROOT="+gatewayAgentRoot(cfg.AgentRoot),
+		"HFL_LENS_ENV_FILE="+envPath,
+		"HFL_GATEWAY_COMPOSE_DIR="+composeDir,
 		"HFL_INSECURE_TLS="+insecureTLSEnv(),
 		"LENSNODE_IMAGE="+defaultLensnodeImage,
 		lensSidecarLockHeldEnv+"=1",
 	)
+	if legacyLayoutAdopted {
+		cmd.Env = append(cmd.Env, "HFL_LEGACY_LAYOUT_ADOPTED=1")
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/src/agent/internal/enroll/sidecar_observability_unix_test.go
+++ b/src/agent/internal/enroll/sidecar_observability_unix_test.go
@@ -95,7 +95,7 @@ func TestLensObservabilityRetriesFailedApply(t *testing.T) {
 		lockPath:    filepath.Join(root, "sidecar.lock"),
 		healthy:     func() bool { return true },
 		ensureImage: func(context.Context, Config) error { return nil },
-		installSidecar: func(context.Context, Config) error {
+		installSidecar: func(context.Context, Config, bool) error {
 			attempts++
 			if attempts == 1 {
 				return errors.New("simulated compose failure")
@@ -142,7 +142,7 @@ func TestHealthyLensSidecarAppliesChangedConfiguration(t *testing.T) {
 		lockPath:    filepath.Join(root, "sidecar.lock"),
 		healthy:     func() bool { return true },
 		ensureImage: func(context.Context, Config) error { return nil },
-		installSidecar: func(context.Context, Config) error {
+		installSidecar: func(context.Context, Config, bool) error {
 			runs++
 			return nil
 		},
@@ -174,6 +174,136 @@ func TestHealthyLensSidecarAppliesChangedConfiguration(t *testing.T) {
 	}
 	if runs != 1 {
 		t.Fatalf("unchanged configuration installer runs = %d, want 1", runs)
+	}
+}
+
+func TestLegacyLensLayoutAuthorizationOnlyBeforeCanonicalEnv(t *testing.T) {
+	root := t.TempDir()
+	legacy := filepath.Join(root, "legacy", "lensnode.env")
+	current := filepath.Join(root, "agent", "config", "lensnode.env")
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacy, []byte("old-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(current), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(current, []byte("new-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if legacyLensLayoutPendingAt(current, legacy) {
+		t.Fatal("existing canonical env must not be auto-authorized for legacy adoption")
+	}
+	if err := os.Remove(current); err != nil {
+		t.Fatal(err)
+	}
+	if !legacyLensLayoutPendingAt(current, legacy) {
+		t.Fatal("missing canonical env should authorize the first legacy adoption")
+	}
+	if err := os.Remove(legacy); err != nil {
+		t.Fatal(err)
+	}
+	if legacyLensLayoutPendingAt(current, legacy) {
+		t.Fatal("legacy layout should no longer be pending after successful cleanup")
+	}
+	legacyCompose := filepath.Join(filepath.Dir(legacy), "lensnode")
+	if err := os.MkdirAll(legacyCompose, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if !legacyLensLayoutPresentAt(legacy) {
+		t.Fatal("leftover legacy Compose directory should remain visible to migration")
+	}
+	if !legacyLensLayoutPendingAt(current, legacy) {
+		t.Fatal("leftover legacy Compose directory should trigger convergence when canonical env is absent")
+	}
+	if err := os.RemoveAll(legacyCompose); err != nil {
+		t.Fatal(err)
+	}
+	if legacyLensLayoutPresentAt(legacy) {
+		t.Fatal("legacy layout should be absent after Compose cleanup")
+	}
+}
+
+func TestCustomAgentRootDoesNotObserveGlobalLegacyLensLayout(t *testing.T) {
+	if got := gatewayLegacyLensEnvPath("/srv/custom-hfl-agent"); got != "" {
+		t.Fatalf("custom Agent Root legacy env = %q, want empty", got)
+	}
+	if got := gatewayLegacyLensEnvPath("/opt/hyperfilelens-agent"); got != legacyLensEnvFilePath {
+		t.Fatalf("standard Agent Root legacy env = %q, want %q", got, legacyLensEnvFilePath)
+	}
+}
+
+func TestMarkLegacyLensLayoutAdoptedUsesPrivateRuntimeState(t *testing.T) {
+	root := t.TempDir()
+	appliedPath := filepath.Join(root, "runtime", "lensnode", ".hfl-applied-config.sha256")
+	if err := markLegacyLensLayoutAdopted(appliedPath); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(filepath.Dir(appliedPath), ".hfl-legacy-layout-adopted")
+	info, err := os.Stat(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("migration marker mode = %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestAppliedConfigurationDoesNotSkipPendingLegacyCleanup(t *testing.T) {
+	root := t.TempDir()
+	legacy := filepath.Join(root, "legacy", "lensnode.env")
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacy, []byte("legacy\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runs := 0
+	runtime := lensSidecarRuntime{
+		envPath:       filepath.Join(root, "agent", "config", "lensnode.env"),
+		appliedPath:   filepath.Join(root, "agent", "runtime", "lensnode", ".hfl-applied-config.sha256"),
+		legacyEnvPath: legacy,
+		lockPath:      filepath.Join(root, "sidecar.lock"),
+		healthy:       func() bool { return true },
+		ensureImage:   func(context.Context, Config) error { return nil },
+		installSidecar: func(_ context.Context, _ Config, adopted bool) error {
+			if adopted {
+				t.Fatal("existing canonical env must not be marked as an authorized adoption")
+			}
+			runs++
+			return os.Remove(legacy)
+		},
+	}
+	lens := LensSidecarConfig{
+		LensBaseURL:   "https://lens.example.com",
+		LensnodeUUID:  "26d1822b-3ccc-48f8-80f1-f4c0ae99e61e",
+		LensnodeToken: "lens-token",
+		WorkspaceRoot: "/workspace",
+	}
+	_, fingerprint, err := writeLensEnvFileAt(runtime.envPath, lens)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markLensConfigurationApplied(runtime.appliedPath, fingerprint); err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.install(context.Background(), Config{}, lens); err != nil {
+		t.Fatal(err)
+	}
+	if runs != 1 {
+		t.Fatalf("installer runs = %d, want 1", runs)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(runtime.appliedPath), ".hfl-legacy-layout-adopted")); !os.IsNotExist(err) {
+		t.Fatalf("conflicting pre-existing layout was unexpectedly marked adopted: %v", err)
+	}
+	if err := runtime.install(context.Background(), Config{}, lens); err != nil {
+		t.Fatal(err)
+	}
+	if runs != 1 {
+		t.Fatalf("cleanup reran after legacy state was removed: runs=%d", runs)
 	}
 }
 

--- a/src/agent/internal/platform/install/gateway_hooks_unix.go
+++ b/src/agent/internal/platform/install/gateway_hooks_unix.go
@@ -53,21 +53,21 @@ run_gateway_sidecar_uninstall_if_needed() {
   local api_base org token node_id insecure bootstrap script tmp curl_tls purge_args
   [[ -f "$env_file" ]] || return 0
   grep -q '^HFL_NODE_ROLE=gateway' "$env_file" || return 0
-  api_base="$(grep -E '^HFL_API_BASE=' "$env_file" | head -1 | cut -d= -f2- | tr -d '\r' | sed 's/^["'\'' ]//; s/["'\'' ]$//')"
-  org="$(grep -E '^HFL_ORG_KEY=' "$env_file" | head -1 | cut -d= -f2- | tr -d '\r' | sed 's/^["'\'' ]//; s/["'\'' ]$//')"
-  token="$(grep -E '^HFL_NODE_CREDENTIAL=' "$env_file" | head -1 | cut -d= -f2- | tr -d '\r' | sed 's/^["'\'' ]//; s/["'\'' ]$//')"
-  [[ -n "$token" ]] || token="$(grep -E '^HFL_NODE_TOKEN=' "$env_file" | head -1 | cut -d= -f2- | tr -d '\r' | sed 's/^["'\'' ]//; s/["'\'' ]$//')"
-  node_id="$(grep -E '^HFL_NODE_ID=' "$env_file" | head -1 | cut -d= -f2- | tr -d '\r' | sed 's/^["'\'' ]//; s/["'\'' ]$//')"
+  api_base="$(grep -E '^HFL_API_BASE=' "$env_file" | head -1 | cut -d= -f2- | tr -d '\r' | sed 's/^["'\'' ]//; s/["'\'' ]$//')" || api_base=""
+  org="$(grep -E '^HFL_ORG_KEY=' "$env_file" | head -1 | cut -d= -f2- | tr -d '\r' | sed 's/^["'\'' ]//; s/["'\'' ]$//')" || org=""
+  token="$(grep -E '^HFL_NODE_CREDENTIAL=' "$env_file" | head -1 | cut -d= -f2- | tr -d '\r' | sed 's/^["'\'' ]//; s/["'\'' ]$//')" || token=""
+  [[ -n "$token" ]] || token="$(grep -E '^HFL_NODE_TOKEN=' "$env_file" | head -1 | cut -d= -f2- | tr -d '\r' | sed 's/^["'\'' ]//; s/["'\'' ]$//')" || token=""
+  node_id="$(grep -E '^HFL_NODE_ID=' "$env_file" | head -1 | cut -d= -f2- | tr -d '\r' | sed 's/^["'\'' ]//; s/["'\'' ]$//')" || node_id=""
   insecure="$(grep -E '^HFL_INSECURE_TLS=' "$env_file" | head -1 | cut -d= -f2- | tr -d '\r' || true)"
-  [[ -n "$api_base" && -n "$org" && -n "$token" && -n "$node_id" ]] || {
-    log "WARN " "Gateway sidecar uninstall skipped (incomplete agent.env credentials)."
-    return 0
-  }
   curl_tls=()
   [[ "$insecure" != "0" ]] && curl_tls=(-k)
   script="$INSTALL_DIR/libexec/gateway-lifecycle.sh"
   tmp=""
   if [[ ! -x "$script" ]]; then
+    [[ -n "$api_base" && -n "$org" && -n "$token" && -n "$node_id" ]] || {
+      log "FAIL " "Gateway sidecar uninstall cannot continue because the local lifecycle script and download credentials are unavailable."
+      return 1
+    }
     bootstrap="${api_base%/}/media/gateway-bootstrap"
     tmp="$(mktemp -d)"
     script="${tmp}/gateway-lifecycle.sh"

--- a/src/agent/internal/platform/install/local_uninstall_unix.go
+++ b/src/agent/internal/platform/install/local_uninstall_unix.go
@@ -410,6 +410,21 @@ verify_uninstall_artifacts() {
 
 log "detached uninstall script started install_dir=$INSTALL_DIR data_dir=$DATA_DIR keep_data=$KEEP_DATA log_file=$LOG_FILE"
 sleep "$SLEEP_SECONDS"
+if [[ "$KEEP_DATA" == "0" ]]; then
+	if ! gateway_workspace_mounts="$(collect_gateway_workspace_mount_points "$DATA_DIR")"; then
+		log "could not verify Gateway workspace mounts; refusing purge"
+		CLEANUP_FAILED=1
+		AGENT_ARTIFACTS_FAILED=1
+		exit 1
+	fi
+	gateway_workspace_mounts="$(printf '%%s\n' "$gateway_workspace_mounts" | sort -u)"
+  if [[ -n "$gateway_workspace_mounts" ]]; then
+    log "refusing purge while Gateway workspace storage is mounted: ${gateway_workspace_mounts//$'\n'/, }"
+    CLEANUP_FAILED=1
+    AGENT_ARTIFACTS_FAILED=1
+    exit 1
+  fi
+fi
 log "delay elapsed; running gateway sidecar uninstall when applicable"
 %s
 if ! run_gateway_sidecar_uninstall_if_needed; then

--- a/src/agent/internal/platform/install/local_uninstall_unix_test.go
+++ b/src/agent/internal/platform/install/local_uninstall_unix_test.go
@@ -54,6 +54,10 @@ func TestWriteUnixUninstallScriptIncludesLogFile(t *testing.T) {
 	if !strings.Contains(body, `script="$INSTALL_DIR/libexec/gateway-lifecycle.sh"`) {
 		t.Fatalf("script should prefer the Agent-owned Gateway lifecycle helper:\n%s", body)
 	}
+	if strings.Contains(body, `Gateway sidecar uninstall skipped (incomplete agent.env credentials)`) ||
+		!strings.Contains(body, `local lifecycle script and download credentials are unavailable`) {
+		t.Fatalf("script should use the local lifecycle helper when reporting credentials are incomplete:\n%s", body)
+	}
 	if !strings.Contains(body, `local env_file="$DATA_DIR/config/agent.env"`) {
 		t.Fatalf("script should read Gateway credentials from the resolved data directory:\n%s", body)
 	}
@@ -99,6 +103,10 @@ func TestWriteUnixUninstallScriptIncludesLogFile(t *testing.T) {
 	if !strings.Contains(body, `Agent-managed NAS mount cleanup failed; preserving Agent files and data for manual retry`) {
 		t.Fatalf("script must stop removal when managed mounts remain:\n%s", body)
 	}
+	if !strings.Contains(body, `collect_gateway_workspace_mount_points "$DATA_DIR"`) ||
+		!strings.Contains(body, `refusing purge while Gateway workspace storage is mounted`) {
+		t.Fatalf("script must preserve mounted Gateway workspace storage during purge:\n%s", body)
+	}
 	if !strings.Contains(body, `config retire-installation --data-dir "$DATA_DIR"`) {
 		t.Fatalf("script must retire installation identity when data is preserved:\n%s", body)
 	}
@@ -109,12 +117,15 @@ func TestWriteUnixUninstallScriptIncludesLogFile(t *testing.T) {
 		t.Fatalf("script must not require local uninstall to change the console record:\n%s", body)
 	}
 	unmountAt := strings.Index(body, `unmount_agent_mounts "$DATA_DIR"`)
+	workspaceMountAt := strings.Index(body, `gateway_workspace_mounts="$(collect_gateway_workspace_mount_points "$DATA_DIR"`)
+	gatewayAt := strings.Index(body, `run_gateway_sidecar_uninstall_if_needed`)
 	stopAt := strings.Index(body, `hfl_systemctl stop "$SERVICE_NAME"`)
 	retireAt := strings.Index(body, `config retire-installation --data-dir "$DATA_DIR"`)
 	removeAt := strings.Index(body, `for target in "$INSTALL_DIR/hfl-agent"`)
-	if unmountAt < 0 || stopAt < 0 || retireAt < 0 || removeAt < 0 ||
+	if workspaceMountAt < 0 || gatewayAt < 0 || workspaceMountAt > gatewayAt ||
+		unmountAt < 0 || stopAt < 0 || retireAt < 0 || removeAt < 0 ||
 		unmountAt > stopAt || stopAt > retireAt || retireAt > removeAt {
-		t.Fatalf("script must unmount managed shares before stopping and removing the Agent:\n%s", body)
+		t.Fatalf("script must protect Gateway workspace mounts, then unmount managed shares before removal:\n%s", body)
 	}
 	if !strings.Contains(body, `report_uninstall_completion "$rc"`) {
 		t.Fatalf("script must report the signed completion result:\n%s", body)

--- a/src/agent/internal/platform/install/managed_mounts_unix.go
+++ b/src/agent/internal/platform/install/managed_mounts_unix.go
@@ -3,9 +3,30 @@
 package install
 
 // unixManagedMountCleanupScript is embedded in the detached Unix uninstaller.
-// It only touches mounts below DATA_DIR/mounts and verifies that every mount has
-// disappeared before the uninstaller removes Agent files or persistent data.
+// It only unmounts Agent-managed mounts below DATA_DIR/mounts. Gateway workspace
+// mounts are detected separately and block purge rather than being unmounted.
 const unixManagedMountCleanupScript = `
+collect_gateway_workspace_mount_points() {
+  local data_dir="$1" workspace_root="${1%/}/workspace" targets=""
+
+  [[ -n "$data_dir" ]] || return 0
+  if command -v findmnt >/dev/null 2>&1; then
+    targets="$(LC_ALL=C findmnt -rn -o TARGET 2>/dev/null)" || targets=""
+  fi
+  if [[ -z "$targets" && -r /proc/mounts ]]; then
+    targets="$(awk '{ print $2 }' /proc/mounts)"
+  elif [[ -z "$targets" ]]; then
+    return 1
+  fi
+  printf '%s\n' "$targets" | awk -v root="$workspace_root" '
+    BEGIN { len = length(root) }
+    length($0) >= len && substr($0, 1, len) == root &&
+      (length($0) == len || substr($0, len + 1, 1) == "/") {
+      print $0
+    }
+  '
+}
+
 collect_agent_mount_points() {
   local mounts_root="$1" targets=""
 

--- a/src/agent/internal/platform/vfs/layout.go
+++ b/src/agent/internal/platform/vfs/layout.go
@@ -7,9 +7,21 @@ func AgentBackupDir(dataRoot string) string {
 	return filepath.Join(dataRoot, "backup")
 }
 
-// AgentRuntimeDir is AgentRoot/runtime (download + workspace).
+// AgentRuntimeDir is AgentRoot/runtime (transient lifecycle state).
 func AgentRuntimeDir(dataRoot string) string {
 	return filepath.Join(dataRoot, "runtime")
+}
+
+// AgentLensnodeRuntimeDir is the private Compose project directory for the
+// Gateway LensNode sidecar. It is separate from AgentRuntimeDir's transient
+// download/session files so upgrades can replace Compose metadata atomically.
+func AgentLensnodeRuntimeDir(dataRoot string) string {
+	return filepath.Join(dataRoot, "runtime", "lensnode")
+}
+
+// AgentWorkspaceDir is the root for managed Gateway workspaces.
+func AgentWorkspaceDir(dataRoot string) string {
+	return filepath.Join(dataRoot, "workspace")
 }
 
 // AgentLifecycleDir is AgentRoot/lifecycle (detached upgrade/uninstall).

--- a/src/agent/internal/platform/vfs/vfs_test.go
+++ b/src/agent/internal/platform/vfs/vfs_test.go
@@ -24,6 +24,16 @@ func TestDefaultAgentDataDir(t *testing.T) {
 	}
 }
 
+func TestGatewayLensnodeLayout(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "hyperfilelens-agent")
+	if got, want := AgentLensnodeRuntimeDir(root), filepath.Join(root, "runtime", "lensnode"); got != want {
+		t.Fatalf("AgentLensnodeRuntimeDir() = %q, want %q", got, want)
+	}
+	if got, want := AgentWorkspaceDir(root), filepath.Join(root, "workspace"); got != want {
+		t.Fatalf("AgentWorkspaceDir() = %q, want %q", got, want)
+	}
+}
+
 func TestUserLevelLinuxLayout(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Linux layout assertion")

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -3024,6 +3024,35 @@ uninstall_gateway_sidecar_if_needed() {
 	log_ok "Data Gateway AI engine removal completed."
 }
 
+gateway_workspace_mounts_in_agent_root() {
+	local agent_root="${1%/}" workspace_root target canonical_target targets=""
+	workspace_root="$(readlink -m -- "${agent_root}/workspace")" || return 1
+	if command -v findmnt >/dev/null 2>&1; then
+		targets="$(LC_ALL=C findmnt -rn -o TARGET 2>/dev/null)" || targets=""
+	fi
+	if [[ -z "${targets}" && -r /proc/mounts ]]; then
+		targets="$(awk '{ print $2 }' /proc/mounts)" || return 1
+	elif [[ -z "${targets}" ]]; then
+		return 1
+	fi
+	while IFS= read -r target; do
+		[[ -n "${target}" ]] || continue
+		canonical_target="$(readlink -m -- "${target}")" || continue
+		if [[ "${canonical_target}" == "${workspace_root}" || "${canonical_target}" == "${workspace_root}"/* ]]; then
+			printf '%s\n' "${canonical_target}"
+		fi
+	done <<<"${targets}"
+}
+
+assert_gateway_workspace_purge_safe() {
+	local agent_root="$1" mounts
+	mounts="$(gateway_workspace_mounts_in_agent_root "${agent_root}")" \
+		|| log_fail "Could not verify Gateway workspace mounts; refusing purge-all." 2
+	mounts="$(printf '%s\n' "${mounts}" | sort -u)"
+	[[ -z "${mounts}" ]] || log_fail \
+		"Refusing purge-all while Gateway workspace storage is mounted (${mounts//$'\n'/, }); unmount it manually and retry." 2
+}
+
 cmd_uninstall() {
 	parse_uninstall_flags "$@"
 	require_root
@@ -3048,6 +3077,9 @@ cmd_uninstall() {
 	[[ -f "${INSTALLED_VERSION_FILE}" ]] && installed_version="$(tr -d ' \t\r\n' <"${INSTALLED_VERSION_FILE}")"
 	data_policy="preserve"
 	[[ "${PURGE_ALL}" -eq 0 ]] || data_policy="remove"
+	if [[ "${PURGE_ALL}" -eq 1 && "$(uname -s)" == "Linux" ]]; then
+		assert_gateway_workspace_purge_safe "${resolved_data}"
+	fi
 	hfl_print_banner "$(hfl_role_display_name "${installed_role}" "${gateway_scope}")" "Uninstaller"
 	hfl_print_section "Target"
 	hfl_print_value "Role" "$(hfl_role_display_name "${installed_role}" "${gateway_scope}")"

--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -1077,7 +1077,11 @@ def _resolve_gateway_link_identity(
                 organization=org,
                 gateway=gateway,
                 defaults={
-                    "workspace_root": f"/workspace/org-{org.id}/data",
+                    # Gateway Agent and LensNode share the same host/container
+                    # path under the unified Agent Root. Existing links retain
+                    # their persisted legacy /workspace path through
+                    # resolved_workspace_root().
+                    "workspace_root": f"/opt/hyperfilelens-agent/workspace/org-{org.id}/data",
                     "owner_user": None if is_platform else owner_user,
                     "scope": desired_scope,
                     "origin": desired_origin,

--- a/src/backend/apps/lens_bridge/tests/test_gateway_lensnode_provisioning.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_lensnode_provisioning.py
@@ -223,3 +223,7 @@ class DurableGatewayLensNodeProvisioningTests(TestCase):
         self.assertEqual(result.capacity_bytes, -1)
         self.assertEqual(result.scope, LensGatewayLink.GatewayScope.PLATFORM)
         self.assertEqual(result.sl_lensnode_uuid, remote_uuid)
+        self.assertEqual(
+            result.workspace_root,
+            f"/opt/hyperfilelens-agent/workspace/org-{platform_org.id}/data",
+        )

--- a/src/frontend/src/lib/nodeInstallCommands.test.ts
+++ b/src/frontend/src/lib/nodeInstallCommands.test.ts
@@ -101,6 +101,9 @@ describe('manual node maintenance commands', () => {
     const command = buildLocalServiceCommand('linux', 'restart', 'gateway')
 
     expect(command).toContain('/opt/hyperfilelens-agent/bin/install.sh restart')
+    expect(command).toContain('/opt/hyperfilelens-agent/runtime/lensnode/docker-compose.yml')
+    expect(command).toContain('/etc/hyperfilelens/lensnode/docker-compose.yml')
+    expect(command).toContain('sudo test -f')
     expect(command).toContain('docker compose -p hyperfilelens-gateway')
     expect(command).toContain('up -d')
   })

--- a/src/frontend/src/lib/nodeInstallCommands.ts
+++ b/src/frontend/src/lib/nodeInstallCommands.ts
@@ -156,7 +156,13 @@ export function buildLocalServiceCommand(
 ) {
   if (role === 'gateway' && os === 'linux') {
     const agent = `sudo ${linuxInstallScriptPath()} ${action}`
-    const sidecar = 'sudo docker compose -p hyperfilelens-gateway -f /etc/hyperfilelens/lensnode/docker-compose.yml'
+    const sidecar = [
+      'if sudo test -f /opt/hyperfilelens-agent/runtime/lensnode/docker-compose.yml',
+      'then compose_file=/opt/hyperfilelens-agent/runtime/lensnode/docker-compose.yml',
+      'else compose_file=/etc/hyperfilelens/lensnode/docker-compose.yml',
+      'fi',
+      'sudo docker compose -p hyperfilelens-gateway -f "$compose_file"',
+    ].join('; ')
     if (action === 'status') return `${agent}\n${sidecar} ps`
     if (action === 'start') return `${agent}\n${sidecar} up -d`
     if (action === 'stop') return `${sidecar} stop\n${agent}`
@@ -261,7 +267,7 @@ export function installPathsSummary(
   }
   if (role === 'gateway') {
     return {
-      installDir: `${LINUX_INSTALL_DIR} · /etc/hyperfilelens/lensnode`,
+      installDir: `${LINUX_INSTALL_DIR} · /opt/hyperfilelens-agent/runtime/lensnode`,
       dataDir: `${LINUX_DATA_DIR} · Data Gateway workspace`,
       service: 'hyperfilelens-agent.service · LensNode container',
     }

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1663,5 +1663,11 @@ grep -F 'chmod 0700 "${COMPOSE_DIR}"' \
 	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
 grep -F 'chmod 0600 "${compose_file}"' \
 	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
+grep -F 'config/lensnode.env' \
+	"${ROOT}/deploy/bootstrap/gateway-lifecycle.sh" \
+	"${ROOT}/deploy/installer/install.sh" >/dev/null
+grep -F 'runtime/lensnode' \
+	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" \
+	"${ROOT}/deploy/bootstrap/gateway-lifecycle.sh" >/dev/null
 
 printf 'Release contract checks passed.\n'

--- a/tools/quality/test-agent-gateway-uninstall.sh
+++ b/tools/quality/test-agent-gateway-uninstall.sh
@@ -11,22 +11,24 @@ trap 'rm -rf "${tmp}"' EXIT
 # shellcheck disable=SC1090
 source <(sed '/^case "$CMD" in/,$d' "${installer}")
 
-INSTALL_DIR="${tmp}/opt/hyperfilelens-agent"
-DEFAULT_DATA="${tmp}/var/lib/hyperfilelens-agent"
+AGENT_ROOT="${tmp}/opt/hyperfilelens-agent"
+INSTALL_DIR="${AGENT_ROOT}/bin"
+DEFAULT_DATA="${AGENT_ROOT}"
 install_parent="$(dirname "${INSTALL_DIR}")"
 data_parent="$(dirname "${DEFAULT_DATA}")"
-INSTALLED_VERSION_FILE="${INSTALL_DIR}/INSTALLED_VERSION"
+INSTALLED_VERSION_FILE="${AGENT_ROOT}/INSTALLED_VERSION"
+MANIFEST_FILE="${AGENT_ROOT}/MANIFEST.json"
 GATEWAY_LIFECYCLE_SCRIPT="${INSTALL_DIR}/libexec/gateway-lifecycle.sh"
 UNIT_DST="${tmp}/hyperfilelens-agent.service"
 GATEWAY_RESOURCE_DROPIN="${tmp}/20-gateway-resources.conf"
 marker="${tmp}/sidecar-removed"
 stop_marker="${tmp}/agent-stopped"
 
-mkdir -p "${INSTALL_DIR}/libexec" "${DEFAULT_DATA}"
+mkdir -p "${INSTALL_DIR}/libexec" "${DEFAULT_DATA}/config"
 printf '%s\n' \
 	'HFL_NODE_ROLE=gateway' \
 	"HFL_DATA_DIR=${DEFAULT_DATA}" \
-	>"${DEFAULT_DATA}/agent.env"
+	>"${DEFAULT_DATA}/config/agent.env"
 printf agent >"${INSTALL_DIR}/hfl-agent"
 printf '%s\n' \
 	'#!/usr/bin/env bash' \
@@ -54,7 +56,7 @@ remove_service_unit() { :; }
 data_dir_allowed_for_removal() { [[ "$1" == "${DEFAULT_DATA}" || "$1" == "${INSTALL_DIR}" ]]; }
 unmount_agent_mounts() { :; }
 
-export TEST_AGENT_ENV="${DEFAULT_DATA}/agent.env"
+export TEST_AGENT_ENV="${DEFAULT_DATA}/config/agent.env"
 export TEST_SIDECAR_MARKER="${marker}"
 
 # Preserving data retires the installation identity. A missing Agent binary
@@ -71,13 +73,47 @@ grep -F 'Cannot retire the installation identity' "${tmp}/uninstall-preflight.lo
 [[ ! -e "${marker}" ]]
 [[ ! -e "${stop_marker}" ]]
 
+original_gateway_mount_detector="$(declare -f gateway_workspace_mounts_in_agent_root)"
+gateway_workspace_mounts_in_agent_root() {
+	printf '%s\n' "${DEFAULT_DATA}/workspace"
+}
+set +e
+(
+	exec 3>&1 4>&2
+	cmd_uninstall --purge-all
+) >"${tmp}/mounted-workspace-preflight.log" 2>&1
+mounted_preflight_status=$?
+set -e
+[[ "${mounted_preflight_status}" -eq 2 ]]
+grep -F 'Refusing purge-all while Gateway workspace storage is mounted' \
+	"${tmp}/mounted-workspace-preflight.log" >/dev/null
+[[ -f "${DEFAULT_DATA}/config/agent.env" ]]
+[[ ! -e "${marker}" ]]
+[[ ! -e "${stop_marker}" ]]
+
+gateway_workspace_mounts_in_agent_root() { return 1; }
+set +e
+(
+	exec 3>&1 4>&2
+	cmd_uninstall --purge-all
+) >"${tmp}/mount-scan-failure.log" 2>&1
+mount_scan_status=$?
+set -e
+[[ "${mount_scan_status}" -eq 2 ]]
+grep -F 'Could not verify Gateway workspace mounts; refusing purge-all' \
+	"${tmp}/mount-scan-failure.log" >/dev/null
+[[ -f "${DEFAULT_DATA}/config/agent.env" ]]
+[[ ! -e "${marker}" ]]
+[[ ! -e "${stop_marker}" ]]
+eval "${original_gateway_mount_detector}"
+
 cmd_uninstall --purge-all
 
 [[ -f "${marker}" ]]
 [[ -f "${stop_marker}" ]]
 [[ ! -e "${INSTALL_DIR}" ]]
 [[ ! -e "${DEFAULT_DATA}" ]]
-[[ -d "${install_parent}" ]]
+[[ ! -e "${install_parent}" ]]
 [[ -d "${data_parent}" ]]
 
 fake_bin="${tmp}/fake-bin"
@@ -89,7 +125,8 @@ cat >"${fake_bin}/docker" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
-  info|"compose version") exit 0 ;;
+  info) exit 0 ;;
+  "compose version --short"|"compose version") printf '%s\n' '2.39.0' ;;
   "ps -aq --no-trunc") exit 0 ;;
   "compose -p hyperfilelens-gateway config --images")
     printf '%s\n' 'example/hfl-lensnode:test'
@@ -136,6 +173,36 @@ PATH="${fake_bin}:${PATH}" \
 grep -Fx 'image rm hyperfilelens-sourcelens-lensnode:latest' "${docker_state}.images" >/dev/null
 grep -Fx 'image rm example/hfl-lensnode:test' "${docker_state}.images" >/dev/null
 
+mounted_root="${tmp}/mounted-agent"
+mounted_env="${mounted_root}/config/lensnode.env"
+mounted_compose="${mounted_root}/runtime/lensnode"
+mounted_workspace="${mounted_root}/workspace/org-42/data"
+mkdir -p "$(dirname "${mounted_env}")" "${mounted_compose}" "${mounted_workspace}"
+printf 'HFL_WORKSPACE_ROOT=%s\n' "${mounted_workspace}" >"${mounted_env}"
+printf 'services: {}\n' >"${mounted_compose}/docker-compose.yml"
+set +e
+(
+	# shellcheck disable=SC1090
+	source "${ROOT}/deploy/bootstrap/gateway-lifecycle.sh"
+	AGENT_ROOT="${mounted_root}"
+	LENS_ENV_FILE="${mounted_env}"
+	COMPOSE_DIR="${mounted_compose}"
+	LEGACY_MIGRATION_ENABLED=0
+	collect_mount_targets() { printf '%s\n' "${mounted_root}/workspace"; }
+	compose_down_sidecar() { printf down >"${mounted_root}/compose-down"; }
+	remove_lensnode_images() { printf images >"${mounted_root}/images-removed"; }
+	purge_sidecar_artifacts
+) >"${tmp}/mounted-sidecar-purge.log" 2>&1
+mounted_sidecar_status=$?
+set -e
+[[ "${mounted_sidecar_status}" -eq 6 ]]
+grep -F 'refusing to purge mounted Gateway workspace data' \
+	"${tmp}/mounted-sidecar-purge.log" >/dev/null
+[[ -f "${mounted_env}" ]]
+[[ -f "${mounted_compose}/docker-compose.yml" ]]
+[[ ! -e "${mounted_root}/compose-down" ]]
+[[ ! -e "${mounted_root}/images-removed" ]]
+
 validate_workspace() {
 	bash -c 'source "$1"; validate_gateway_workspace_path "$2"' \
 		_ "${ROOT}/deploy/bootstrap/gateway-lifecycle.sh" "$1"
@@ -143,6 +210,17 @@ validate_workspace() {
 
 [[ "$(validate_workspace /workspace/org-42/data)" == "/workspace/org-42/data" ]]
 [[ "$(validate_workspace /workspace/org-42/data/)" == "/workspace/org-42/data" ]]
+[[ "$(validate_workspace /opt/hyperfilelens-agent/workspace/org-42/data)" == "/opt/hyperfilelens-agent/workspace/org-42/data" ]]
+
+legacy_state_mount="$(
+	# shellcheck disable=SC1090
+	source "${ROOT}/deploy/bootstrap/gateway-lifecycle.sh"
+	AGENT_ROOT=/opt/hyperfilelens-agent
+	collect_mount_targets() { printf '%s\n' /workspace/org-42/.hyperfilelens/sourcelens; }
+	gateway_workspace_mounts /workspace/org-42/data
+)"
+[[ "${legacy_state_mount}" == "/workspace/org-42/.hyperfilelens/sourcelens" ]]
+
 for unsafe_workspace in \
 	/workspace/org-0/data \
 	/workspace/org-alpha/data \

--- a/tools/quality/test-gateway-lifecycle-upgrade.sh
+++ b/tools/quality/test-gateway-lifecycle-upgrade.sh
@@ -4,6 +4,7 @@ umask 077
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 LIFECYCLE="${ROOT}/deploy/bootstrap/gateway-lifecycle.sh"
+SIDECAR_INSTALLER="${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh"
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
 export HFL_GATEWAY_SIDECAR_LOCK_FILE="${tmp}/sidecar.lock"
@@ -102,8 +103,379 @@ test_failed_staging_reports_and_preserves_sidecar() {
 	grep -Fx 'sidecar_upgrade:failed:simulated staging download failure' "${status_file}" >/dev/null
 }
 
+test_legacy_layout_adoption_is_retryable() (
+	# shellcheck disable=SC1090
+	source "${LIFECYCLE}"
+	local legacy_root="${tmp}/legacy" agent_root="${tmp}/agent"
+	LEGACY_LENS_ENV_FILE="${legacy_root}/lensnode.env"
+	LEGACY_COMPOSE_DIR="${legacy_root}/lensnode"
+	AGENT_ROOT="${agent_root}"
+	LENS_ENV_FILE="${agent_root}/config/lensnode.env"
+	COMPOSE_DIR="${agent_root}/runtime/lensnode"
+	LEGACY_ADOPTION_MARKER="${COMPOSE_DIR}/.hfl-legacy-layout-adopted"
+	LEGACY_MIGRATION_ENABLED=1
+	mkdir -p "${LEGACY_COMPOSE_DIR}"
+	printf '%s\n' 'LENSNODE_TOKEN=legacy' >"${LEGACY_LENS_ENV_FILE}"
+	printf '%s\n' 'services: {}' >"${LEGACY_COMPOSE_DIR}/docker-compose.yml"
+
+	migrate_legacy_layout
+	cmp -s "${LEGACY_LENS_ENV_FILE}" "${LENS_ENV_FILE}"
+	cmp -s "${LEGACY_COMPOSE_DIR}/docker-compose.yml" "${COMPOSE_DIR}/docker-compose.yml"
+	[[ -f "${LEGACY_ADOPTION_MARKER}" ]]
+
+	# A failed first sidecar start may leave the new control-plane config next
+	# to the old file. The durable adoption marker makes the retry deterministic.
+	printf '%s\n' 'LENSNODE_TOKEN=refreshed' >"${LENS_ENV_FILE}"
+	migrate_legacy_layout
+	grep -Fx 'LENSNODE_TOKEN=refreshed' "${LENS_ENV_FILE}" >/dev/null
+)
+
+test_sidecar_start_failure_restores_previous_compose() {
+	local root="${tmp}/sidecar-rollback" compose_dir="${tmp}/sidecar-rollback/runtime/lensnode"
+	local fake_compose="${tmp}/fake-compose" fake_docker="${tmp}/fake-docker"
+	local calls="${tmp}/compose-calls" docker_calls="${tmp}/docker-calls" old_compose="${tmp}/old-compose"
+	mkdir -p "${compose_dir}" "${root}/workspace/org-42/data"
+	printf '%s\n' 'services:' '  lensnode:' '    image: previous:test' >"${old_compose}"
+	cp "${old_compose}" "${compose_dir}/docker-compose.yml"
+	cat >"${fake_compose}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${TEST_COMPOSE_CALLS}"
+case "$*" in
+  *" config --quiet") exit 0 ;;
+  "-p hyperfilelens-gateway ps -q lensnode") printf '%s\n' current-lensnode ;;
+  "-p hyperfilelens-gateway up -d --pull never --force-recreate") exit 17 ;;
+  "-p hyperfilelens-gateway up -d --pull never") exit 0 ;;
+  *) printf 'unexpected compose invocation: %s\n' "$*" >&2; exit 90 ;;
+esac
+EOF
+	cat >"${fake_docker}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${TEST_DOCKER_CALLS}"
+case "$*" in
+  "image inspect desired:test") exit 0 ;;
+  "image inspect --format {{.Id}} desired:test") printf '%s\n' sha256:desired ;;
+  "inspect --format {{.Image}} current-lensnode") printf '%s\n' sha256:previous ;;
+  "image tag sha256:previous desired:test") exit 0 ;;
+  *) printf 'unexpected docker invocation: %s\n' "$*" >&2; exit 91 ;;
+esac
+EOF
+	chmod 755 "${fake_compose}" "${fake_docker}"
+
+	set +e
+	(
+		# Load only the function under test; the published installer normally
+		# executes immediately after download.
+		# shellcheck disable=SC1090
+		source <(sed -n '/^install_docker_sidecar() {/,/^}/p' "${SIDECAR_INSTALLER}")
+		COMPOSE_DIR="${compose_dir}"
+		COMPOSE_PROJECT=hyperfilelens-gateway
+		SENTRY_PRIVACY_FILE="${compose_dir}/hfl-sentry-sitecustomize.py"
+		HFL_WORKSPACE_ROOT="${root}/workspace/org-42/data"
+		HFL_SOURCELENS_MOUNTPOINT="${HFL_WORKSPACE_ROOT}/.sourcelens"
+		HFL_SOURCELENS_STATE_ROOT="${root}/workspace/org-42/.hyperfilelens/sourcelens"
+		HFL_GATEWAY_TRASH_ROOT="${HFL_WORKSPACE_ROOT}/.hyperfilelens-trash"
+		LENSNODE_TOKEN=test-token
+		LENSNODE_NAME=test-gateway
+		LENS_CONTAINER_URL=https://host.docker.internal/sourcelens
+		SENTRY_ENABLED=false
+		HFL_INSECURE_TLS=1
+		hfl_step() { :; }
+		hfl_ok() { :; }
+		hfl_warn() { printf '%s\n' "$*" >&2; }
+		hfl_fail() { printf '%s\n' "$1" >&2; exit "${2:-1}"; }
+		lens_url_needs_extra_hosts() { return 0; }
+		resolve_compose() { COMPOSE=("${fake_compose}"); }
+		docker() { "${fake_docker}" "$@"; }
+		remove_owned_legacy_gateway_containers() { printf removed >"${tmp}/legacy-removed-early"; }
+		export TEST_COMPOSE_CALLS="${calls}"
+		export TEST_DOCKER_CALLS="${docker_calls}"
+		install_docker_sidecar desired:test
+	) >"${tmp}/sidecar-rollback.log" 2>&1
+	local status=$?
+	set -e
+	[[ "${status}" -eq 3 ]]
+	cmp -s "${old_compose}" "${compose_dir}/docker-compose.yml"
+	grep -Fx -- '-p hyperfilelens-gateway up -d --pull never --force-recreate' "${calls}" >/dev/null
+	grep -Fx -- '-p hyperfilelens-gateway up -d --pull never' "${calls}" >/dev/null
+	grep -Fx -- 'image tag sha256:previous desired:test' "${docker_calls}" >/dev/null
+	[[ ! -e "${tmp}/legacy-removed-early" ]]
+}
+
+test_first_sidecar_start_failure_cleans_partial_project() {
+	local root="${tmp}/sidecar-first-failure" compose_dir="${tmp}/sidecar-first-failure/runtime/lensnode"
+	local fake_compose="${tmp}/fake-first-compose" fake_docker="${tmp}/fake-first-docker"
+	local calls="${tmp}/first-compose-calls"
+	mkdir -p "${compose_dir}" "${root}/workspace/org-42/data"
+	cat >"${fake_compose}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${TEST_COMPOSE_CALLS}"
+case "$*" in
+  *" config --quiet") exit 0 ;;
+  "-p hyperfilelens-gateway ps -q lensnode") printf '%s\n' partial-lensnode ;;
+  "-p hyperfilelens-gateway up -d --pull never") exit 17 ;;
+  "-p hyperfilelens-gateway down --remove-orphans") exit 0 ;;
+  *) exit 90 ;;
+esac
+EOF
+	cat >"${fake_docker}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "image inspect --format {{.Id}} desired:first") printf '%s\n' sha256:desired ;;
+  *) exit 0 ;;
+esac
+EOF
+	chmod 755 "${fake_compose}" "${fake_docker}"
+	set +e
+	(
+		# shellcheck disable=SC1090
+		source <(sed -n '/^install_docker_sidecar() {/,/^}/p' "${SIDECAR_INSTALLER}")
+		COMPOSE_DIR="${compose_dir}"
+		COMPOSE_PROJECT=hyperfilelens-gateway
+		SENTRY_PRIVACY_FILE="${compose_dir}/hfl-sentry-sitecustomize.py"
+		HFL_WORKSPACE_ROOT="${root}/workspace/org-42/data"
+		HFL_SOURCELENS_MOUNTPOINT="${HFL_WORKSPACE_ROOT}/.sourcelens"
+		HFL_SOURCELENS_STATE_ROOT="${root}/workspace/org-42/.hyperfilelens/sourcelens"
+		HFL_GATEWAY_TRASH_ROOT="${HFL_WORKSPACE_ROOT}/.hyperfilelens-trash"
+		LENSNODE_TOKEN=test-token LENSNODE_NAME=test-gateway
+		LENS_CONTAINER_URL=https://host.docker.internal/sourcelens SENTRY_ENABLED=false HFL_INSECURE_TLS=1
+		hfl_step() { :; }
+		hfl_ok() { :; }
+		hfl_warn() { :; }
+		hfl_fail() { exit "${2:-1}"; }
+		lens_url_needs_extra_hosts() { return 0; }
+		resolve_compose() { COMPOSE=("${fake_compose}"); }
+		docker() { "${fake_docker}" "$@"; }
+		remove_owned_legacy_gateway_containers() { :; }
+		export TEST_COMPOSE_CALLS="${calls}"
+		install_docker_sidecar desired:first
+	) >/dev/null 2>&1
+	local status=$?
+	set -e
+	[[ "${status}" -eq 3 ]]
+	[[ ! -e "${compose_dir}/docker-compose.yml" ]]
+	grep -Fx -- '-p hyperfilelens-gateway down --remove-orphans' "${calls}" >/dev/null
+}
+
+test_upgrade_keeps_existing_sidecar_until_replacement_starts() {
+	local body
+	body="$(sed -n '/^cmd_upgrade_sidecar() {/,/^}/p' "${LIFECYCLE}")"
+	if grep -Eq '^[[:space:]]*compose_down_sidecar([[:space:]]|$)' <<<"${body}"; then
+		printf 'upgrade tears down the existing sidecar before replacement startup\n' >&2
+		return 1
+	fi
+	grep -Eq '^[[:space:]]*run_sidecar_install_script([[:space:]]|$)' <<<"${body}"
+}
+
+test_lifecycle_accepts_persisted_node_credential() (
+	# shellcheck disable=SC1090
+	source "${LIFECYCLE}"
+	ENV_FILE="${tmp}/credential-agent.env"
+	cat >"${ENV_FILE}" <<'EOF'
+HFL_API_BASE=https://console.example
+HFL_ORG_KEY=org-test
+HFL_NODE_CREDENTIAL=persisted-credential
+HFL_NODE_ID=42
+HFL_AGENT_ROOT=/opt/hyperfilelens-agent
+EOF
+	load_agent_credentials_optional
+	[[ "${HFL_NODE_TOKEN}" == "persisted-credential" ]]
+	[[ "${LENS_ENV_FILE}" == "/opt/hyperfilelens-agent/config/lensnode.env" ]]
+	[[ "${COMPOSE_DIR}" == "/opt/hyperfilelens-agent/runtime/lensnode" ]]
+)
+
+test_lifecycle_rejects_relative_persisted_agent_root() (
+	# shellcheck disable=SC1090
+	source "${LIFECYCLE}"
+	ENV_FILE="${tmp}/relative-root-agent.env"
+	cat >"${ENV_FILE}" <<'EOF'
+HFL_API_BASE=https://console.example
+HFL_ORG_KEY=org-test
+HFL_NODE_CREDENTIAL=persisted-credential
+HFL_NODE_ID=42
+HFL_AGENT_ROOT=relative/agent-root
+EOF
+	set +e
+	(load_agent_credentials_optional) >"${tmp}/relative-root.log" 2>&1
+	local status=$?
+	set -e
+	[[ "${status}" -eq 2 ]]
+	grep -F 'invalid relative HFL_AGENT_ROOT' "${tmp}/relative-root.log" >/dev/null
+)
+
+test_lifecycle_rejects_relative_agent_env_path() (
+	# shellcheck disable=SC1090
+	source "${LIFECYCLE}"
+	ENV_FILE="relative-agent.env"
+	set +e
+	(validate_lifecycle_paths) >"${tmp}/relative-env.log" 2>&1
+	local status=$?
+	set -e
+	[[ "${status}" -eq 2 ]]
+	grep -F 'HFL_AGENT_ENV_FILE must be an absolute file path' "${tmp}/relative-env.log" >/dev/null
+)
+
+test_legacy_agent_env_enables_layout_migration() {
+	local enabled
+	enabled="$(
+		HFL_AGENT_ENV_FILE=/var/lib/hyperfilelens-agent/agent.env \
+			bash -c 'source "$1"; printf "%s" "${LEGACY_MIGRATION_ENABLED}"' \
+			_ "${LIFECYCLE}"
+	)"
+	[[ "${enabled}" == "1" ]]
+}
+
+test_custom_agent_root_does_not_enable_global_legacy_migration() {
+	local enabled
+	enabled="$(
+		HFL_AGENT_ROOT=/srv/custom-hfl-agent \
+			HFL_AGENT_ENV_FILE=/srv/custom-hfl-agent/config/agent.env \
+			bash -c 'source "$1"; printf "%s" "${LEGACY_MIGRATION_ENABLED}"' \
+			_ "${LIFECYCLE}"
+	)"
+	[[ "${enabled}" == "0" ]]
+	enabled="$(
+		HFL_AGENT_ROOT=/srv/custom-hfl-agent \
+			HFL_AGENT_ENV_FILE=/opt/hyperfilelens-agent/config/agent.env \
+			bash -c 'source "$1"; printf "%s" "${LEGACY_MIGRATION_ENABLED}"' \
+			_ "${LIFECYCLE}"
+	)"
+	[[ "${enabled}" == "0" ]]
+	enabled="$(
+		HFL_AGENT_ENV_FILE=/opt/hyperfilelens-agent/config/agent.env \
+		HFL_LENS_ENV_FILE=/srv/custom-hfl/lensnode.env \
+		HFL_GATEWAY_COMPOSE_DIR=/srv/custom-hfl/lensnode \
+		HFL_LEGACY_LAYOUT_ADOPTED=1 \
+			bash -c 'source "$1"; printf "%s" "${LEGACY_MIGRATION_ENABLED}"' \
+			_ "${LIFECYCLE}"
+	)"
+	[[ "${enabled}" == "0" ]]
+}
+
+test_custom_lensnode_paths_do_not_enable_global_legacy_migration() {
+	local enabled
+	enabled="$(
+		HFL_AGENT_ENV_FILE=/opt/hyperfilelens-agent/config/agent.env \
+		HFL_LENS_ENV_FILE=/srv/custom-hfl/lensnode.env \
+		HFL_GATEWAY_COMPOSE_DIR=/srv/custom-hfl/lensnode \
+			bash -c 'source "$1"; printf "%s" "${LEGACY_MIGRATION_ENABLED}"' \
+			_ "${LIFECYCLE}"
+	)"
+	[[ "${enabled}" == "0" ]]
+}
+
+test_sidecar_custom_path_does_not_touch_global_legacy_layout() (
+	local sidecar="${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh"
+	local legacy_env="${tmp}/global-legacy/lensnode.env" legacy_compose="${tmp}/global-legacy/lensnode"
+	local current_env="${tmp}/custom-agent/config/lensnode.env" current_compose="${tmp}/custom-agent/runtime/lensnode"
+	mkdir -p "$(dirname "${legacy_env}")" "${legacy_compose}" "$(dirname "${current_env}")" "${current_compose}"
+	printf '%s\n' legacy >"${legacy_env}"
+	printf '%s\n' 'services: {}' >"${legacy_compose}/docker-compose.yml"
+	# shellcheck disable=SC1090
+	source <(sed -n '/^migrate_legacy_layout() {/,/^}/p' "${sidecar}")
+	# shellcheck disable=SC1090
+	source <(sed -n '/^cleanup_legacy_layout() {/,/^}/p' "${sidecar}")
+	ENV_FILE="${current_env}"
+	COMPOSE_DIR="${current_compose}"
+	LEGACY_ENV_FILE="${legacy_env}"
+	LEGACY_COMPOSE_DIR="${legacy_compose}"
+	LEGACY_ADOPTION_MARKER="${current_compose}/.hfl-legacy-layout-adopted"
+	LEGACY_MIGRATION_ENABLED=0
+	migrate_legacy_layout
+	cleanup_legacy_layout
+	[[ -f "${legacy_env}" && -f "${legacy_compose}/docker-compose.yml" ]]
+	[[ ! -e "${current_env}" && ! -e "${current_compose}/docker-compose.yml" ]]
+)
+
+test_sidecar_custom_marker_does_not_enable_global_legacy_migration() {
+	local enabled
+	enabled="$(
+		HFL_LENS_ENV_FILE=/srv/custom-hfl/lensnode.env \
+		HFL_GATEWAY_COMPOSE_DIR=/srv/custom-hfl/lensnode \
+		HFL_LEGACY_LAYOUT_ADOPTED=1 \
+			bash -c 'source <(sed -n "/^legacy_migration_allowed_for_paths() {/,/^}/p" "$1"); ENV_FILE="$HFL_LENS_ENV_FILE" COMPOSE_DIR="$HFL_GATEWAY_COMPOSE_DIR"; if legacy_migration_allowed_for_paths; then printf 1; else printf 0; fi' \
+			_ "${SIDECAR_INSTALLER}"
+	)"
+	[[ "${enabled}" == "0" ]]
+}
+
+test_custom_layout_does_not_remove_global_legacy_container() (
+	# shellcheck disable=SC1090
+	source "${LIFECYCLE}"
+	local removed="${tmp}/legacy-container-removed"
+	COMPOSE_DIR="${tmp}/custom-agent/runtime/lensnode"
+	LEGACY_COMPOSE_DIR="${tmp}/global-legacy/lensnode"
+	LEGACY_MIGRATION_ENABLED=0
+	remember_owned_lensnode_image() { :; }
+	docker() {
+		case "$*" in
+		"ps -aq --no-trunc") printf '%s\n' legacy-lensnode ;;
+		"inspect --format {{index .Config.Labels \"com.docker.compose.project\"}} legacy-lensnode") printf '%s\n' sourcelens ;;
+		"inspect --format {{index .Config.Labels \"com.docker.compose.service\"}} legacy-lensnode") printf '%s\n' lensnode ;;
+		"inspect --format {{index .Config.Labels \"com.docker.compose.project.working_dir\"}} legacy-lensnode") printf '%s\n' "${LEGACY_COMPOSE_DIR}" ;;
+		"inspect --format {{index .Config.Labels \"com.docker.compose.project.config_files\"}} legacy-lensnode") printf '%s\n' "${LEGACY_COMPOSE_DIR}/docker-compose.yml" ;;
+		"inspect --format {{.Config.Image}} legacy-lensnode") printf '%s\n' legacy:test ;;
+		"rm -f legacy-lensnode") printf removed >"${removed}" ;;
+		*) printf 'unexpected fake Docker invocation: %s\n' "$*" >&2; return 90 ;;
+		esac
+	}
+	remove_owned_legacy_gateway_containers
+	[[ ! -e "${removed}" ]]
+	LEGACY_MIGRATION_ENABLED=1
+	remove_owned_legacy_gateway_containers
+	[[ -f "${removed}" ]]
+)
+
+test_uninstall_without_credentials_purges_legacy_layout() (
+	# shellcheck disable=SC1090
+	source "${LIFECYCLE}"
+	local legacy_root="${tmp}/uninstall-legacy" agent_root="${tmp}/uninstall-agent"
+	ENV_FILE="${agent_root}/config/agent.env"
+	LEGACY_LENS_ENV_FILE="${legacy_root}/lensnode.env"
+	LEGACY_COMPOSE_DIR="${legacy_root}/lensnode"
+	AGENT_ROOT="${agent_root}"
+	LENS_ENV_FILE="${agent_root}/config/lensnode.env"
+	COMPOSE_DIR="${agent_root}/runtime/lensnode"
+	LEGACY_ADOPTION_MARKER="${COMPOSE_DIR}/.hfl-legacy-layout-adopted"
+	LEGACY_MIGRATION_ENABLED=1
+	PURGE_ALL=1
+	mkdir -p "${LEGACY_COMPOSE_DIR}"
+	printf '%s\n' "HFL_WORKSPACE_ROOT=${agent_root}/workspace/org-42/data" \
+		>"${LEGACY_LENS_ENV_FILE}"
+	printf '%s\n' 'services: {}' >"${LEGACY_COMPOSE_DIR}/docker-compose.yml"
+	ensure_docker_ready() { :; }
+	acquire_sidecar_lock() { :; }
+	collect_mount_targets() { :; }
+	compose_down_sidecar() { :; }
+	remove_lensnode_images() { :; }
+
+	cmd_uninstall_sidecar
+
+	[[ ! -e "${LENS_ENV_FILE}" ]]
+	[[ ! -e "${COMPOSE_DIR}" ]]
+	[[ ! -e "${LEGACY_LENS_ENV_FILE}" ]]
+	[[ ! -e "${LEGACY_COMPOSE_DIR}" ]]
+)
+
 test_resume_after_interruption
 test_retry_exhaustion_keeps_partial
 test_failed_staging_reports_and_preserves_sidecar
+test_legacy_layout_adoption_is_retryable
+test_sidecar_start_failure_restores_previous_compose
+test_first_sidecar_start_failure_cleans_partial_project
+test_upgrade_keeps_existing_sidecar_until_replacement_starts
+test_lifecycle_accepts_persisted_node_credential
+test_lifecycle_rejects_relative_persisted_agent_root
+test_lifecycle_rejects_relative_agent_env_path
+test_legacy_agent_env_enables_layout_migration
+test_custom_agent_root_does_not_enable_global_legacy_migration
+test_custom_lensnode_paths_do_not_enable_global_legacy_migration
+test_sidecar_custom_path_does_not_touch_global_legacy_layout
+test_sidecar_custom_marker_does_not_enable_global_legacy_migration
+test_custom_layout_does_not_remove_global_legacy_container
+test_uninstall_without_credentials_purges_legacy_layout
 
 printf 'Gateway sidecar resumable upgrade contracts passed.\n'

--- a/tools/quality/test-platform-gateway-auto-deploy.sh
+++ b/tools/quality/test-platform-gateway-auto-deploy.sh
@@ -19,6 +19,9 @@ LOCAL_PLATFORM_AGENT_DATA_DIR="${tmp}/agent-data"
 LOCAL_PLATFORM_AGENT_LEGACY_INSTALL_DIR="${tmp}/legacy-agent-install"
 LOCAL_PLATFORM_AGENT_LEGACY_DATA_DIR="${tmp}/legacy-agent-data"
 LOCAL_PLATFORM_LENSNODE_ENV_FILE="${tmp}/lensnode.env"
+LOCAL_PLATFORM_LEGACY_LENSNODE_ENV_FILE="${tmp}/legacy-lensnode.env"
+LOCAL_PLATFORM_LENSNODE_COMPOSE_DIR="${tmp}/lensnode-compose"
+LOCAL_PLATFORM_LEGACY_LENSNODE_COMPOSE_DIR="${tmp}/legacy-lensnode-compose"
 LOCAL_PLATFORM_LENSNODE_IMAGE="hyperfilelens-sourcelens-lensnode:latest"
 mkdir -p \
 	"${ROOT}/data/media/enroll-bootstrap" \


### PR DESCRIPTION
## Summary

- unify Data Gateway Agent configuration, LensNode Compose runtime, and workspace paths under the Agent Root
- preserve and safely migrate the legacy /etc/hyperfilelens and /workspace layouts
- make sidecar upgrades transactional with startup validation and rollback recovery
- protect mounted workspace data and isolate custom Agent Roots during uninstall
- keep Gateway lifecycle commands and platform auto-deploy compatible with both layouts

## Validation

- Gateway lifecycle upgrade, migration, rollback, uninstall, and mount-protection contracts
- Platform Gateway auto-deploy and Compose compatibility checks
- Go vet and targeted Agent tests
- Python compilation and Ruff checks
- frontend esbuild, ESLint, and Vitest (24 tests)
- Shell syntax and git diff checks