### PR TITLE
fix(node): preserve upgrade source version in progress

### DIFF
--- a/src/backend/apps/node/services/internal/node_lifecycle.py
+++ b/src/backend/apps/node/services/internal/node_lifecycle.py
@@ -158,6 +158,12 @@ def _target_version_from_task(task: NodeTask) -> str:
     return str(result.get("target_version") or "").strip()
 
 
+def _source_version_from_task(task: NodeTask) -> str:
+    """Return the immutable Agent version recorded when an upgrade started."""
+    payload = task.payload if isinstance(task.payload, dict) else {}
+    return str(payload.get("source_version") or "").strip()
+
+
 def _target_commit_from_task(task: NodeTask) -> str:
     payload = task.payload if isinstance(task.payload, dict) else {}
     target = str(payload.get("target_commit") or "").strip().lower()
@@ -974,6 +980,7 @@ def _upgrade_lifecycle_payload(
     base: dict[str, Any] = {
         "kind": LIFECYCLE_KIND_UPGRADE,
         "task_id": str(task.id),
+        "source_version": _source_version_from_task(task) or current_version,
         "target_version": target_version,
         "target_commit": _target_commit_from_task(task) or None,
         "current_version": current_version,
@@ -1349,9 +1356,12 @@ def start_node_upgrade(
     # must never be inferred from a later reconnect event.
     persisted_payload = {
         **payload,
+        "source_version": current_version,
         "pre_upgrade_session_id": redis_store.get_agent_session(agent_id=node.id)
         or "",
     }
+    if current_commit:
+        persisted_payload["source_commit"] = current_commit
     handle = run_agent_task_async(
         org=org,
         node_id=node.id,

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -14,8 +14,10 @@ from apps.node.exceptions import NodeLifecycleError
 from apps.node.models import Node, NodeTask
 from apps.node.models.base import NodeRole
 from apps.node.services.internal.node_lifecycle import (
+    _source_version_from_task,
     _target_commit_from_task,
     _target_version_from_task,
+    _upgrade_lifecycle_payload,
     _upgrade_timeout_failure,
     _version_matches_target,
     advance_node_lifecycle,
@@ -493,6 +495,8 @@ class NodeLifecycleTests(TestCase):
     @patch("apps.node.services.internal.node_lifecycle.run_agent_task_async")
     @patch("apps.node.services.internal.node_lifecycle.agent_ws_routable", return_value=True)
     def test_start_upgrade_dispatches_task(self, _routable, mock_dispatch, _validate):
+        self.node.metadata = {"inventory": {"agent_commit": "A" * 40}}
+        self.node.save(update_fields=["metadata", "updated_at"])
         task = NodeTask.objects.create(
             organization=self.org,
             node=self.node,
@@ -510,6 +514,61 @@ class NodeLifecycleTests(TestCase):
         result = start_node_upgrade(org=self.org, node=self.node, user=self.user)
         self.assertEqual(result["state"], "upgrading")
         self.assertEqual(result["target_version"], "1.2.0")
+        persisted_payload = mock_dispatch.call_args.kwargs["persisted_payload"]
+        self.assertEqual(persisted_payload["source_version"], "1.0.0")
+        self.assertEqual(persisted_payload["source_commit"], "a" * 40)
+        self.assertNotIn("source_version", mock_dispatch.call_args.kwargs["payload"])
+
+    def test_upgrade_lifecycle_keeps_source_version_after_node_updates(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.FAILED,
+            payload={
+                "source_version": "0.2.10",
+                "source_commit": "a" * 40,
+                "target_version": "0.2.11",
+                "target_commit": "b" * 40,
+            },
+            last_error="Post-upgrade build identity was missing.",
+            result={"failure_code": "POST_UPGRADE_BUILD_IDENTITY_MISSING"},
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+        self.node.version = "0.2.11"
+        self.node.save(update_fields=["version", "updated_at"])
+
+        lifecycle = _upgrade_lifecycle_payload(
+            org=self.org,
+            node=self.node,
+            task=task,
+        )
+
+        self.assertEqual(lifecycle["source_version"], "0.2.10")
+        self.assertEqual(lifecycle["current_version"], "0.2.11")
+        self.assertEqual(lifecycle["target_version"], "0.2.11")
+
+    def test_source_version_falls_back_for_legacy_task(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.FAILED,
+            payload={"target_version": "1.2.0"},
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        self.assertEqual(_source_version_from_task(task), "")
+        lifecycle = _upgrade_lifecycle_payload(
+            org=self.org,
+            node=self.node,
+            task=task,
+        )
+        self.assertEqual(lifecycle["source_version"], "1.0.0")
 
     @patch(
         "apps.node.services.internal.node_lifecycle.agent_release_commit",

--- a/src/frontend/src/components/node-lifecycle/NodeUpgradeProgress.test.ts
+++ b/src/frontend/src/components/node-lifecycle/NodeUpgradeProgress.test.ts
@@ -34,10 +34,14 @@ const i18n = createI18n({
   },
 })
 
-function lifecycle(download: NodeLifecycleInfo['download']): NodeLifecycleInfo {
+function lifecycle(
+  download: NodeLifecycleInfo['download'],
+  sourceVersion?: string,
+): NodeLifecycleInfo {
   return {
     kind: 'upgrade',
     state: 'upgrading',
+    source_version: sourceVersion,
     current_version: '0.2.11',
     target_version: '0.2.12',
     timeline: [
@@ -52,14 +56,22 @@ function lifecycle(download: NodeLifecycleInfo['download']): NodeLifecycleInfo {
   }
 }
 
-function mountProgress(download: NodeLifecycleInfo['download']) {
+function mountProgress(download: NodeLifecycleInfo['download'], sourceVersion?: string) {
   return mount(NodeUpgradeProgress, {
-    props: { lifecycle: lifecycle(download) },
+    props: { lifecycle: lifecycle(download, sourceVersion) },
     global: { plugins: [i18n] },
   })
 }
 
 describe('NodeUpgradeProgress download details', () => {
+  it('uses the immutable source version for the upgrade path', () => {
+    const wrapper = mountProgress(null, '0.2.10')
+
+    const versions = wrapper.findAll('.node-upgrade-progress__version')
+    expect(versions[0].text()).toBe('0.2.10')
+    expect(versions[1].text()).toBe('0.2.12')
+  })
+
   it('shows compact transfer metrics in the existing upgrade step', () => {
     const wrapper = mountProgress({
       state: 'downloading',

--- a/src/frontend/src/components/node-lifecycle/NodeUpgradeProgress.vue
+++ b/src/frontend/src/components/node-lifecycle/NodeUpgradeProgress.vue
@@ -103,7 +103,7 @@ function formatPhaseTime(at: string | null) {
         {{ t('nodeUpgradeProgress.title') }}
       </div>
       <div class="node-upgrade-progress__version-row">
-        <span class="node-upgrade-progress__version">{{ lifecycle?.current_version || '—' }}</span>
+        <span class="node-upgrade-progress__version">{{ lifecycle?.source_version || lifecycle?.current_version || '—' }}</span>
         <ArrowRight
           :size="14"
           class="node-upgrade-progress__arrow"

--- a/src/frontend/src/types/nodeLifecycle.ts
+++ b/src/frontend/src/types/nodeLifecycle.ts
@@ -53,6 +53,7 @@ export type NodeLifecycleInfo = {
   state: NodeLifecycleState
   phase?: NodeLifecyclePhase | null
   task_id?: string | null
+  source_version?: string | null
   target_version?: string | null
   current_version?: string | null
   started_at?: string | null


### PR DESCRIPTION
## Summary

- persist the Agent version and commit observed when an upgrade starts
- expose the immutable source version in lifecycle responses
- keep the existing upgrade progress layout while displaying source-to-target versions
- preserve a current-version fallback for historical lifecycle tasks
- add backend and frontend regression coverage

## Validation

- Backend node lifecycle tests: 64 passed
- Frontend NodeUpgradeProgress tests: 3 passed
- Frontend production build
- Ruff
- ESLint: no errors
- git diff --check

Closes #867