### PR TITLE
Extend primary navigation active indicator

### DIFF
--- a/src/frontend/src/app/layout/TopNav.vue
+++ b/src/frontend/src/app/layout/TopNav.vue
@@ -256,8 +256,8 @@ function handleNavClick(event: MouseEvent, to: string) {
 .nav-item.active::after {
   content: '';
   position: absolute;
-  left: 32px;
-  right: 32px;
+  left: 16px;
+  right: 16px;
   bottom: 6px;
   width: auto;
   height: 2px;


### PR DESCRIPTION
## Summary

- extend the primary navigation active indicator by reducing its horizontal inset from 32px to 16px
- preserve the existing color, position, thickness, glow, and active background

## Validation

- `git diff --check`