### PR TITLE
Fix account dropdown corner clipping

### DIFF
--- a/src/frontend/src/styles/elementPlusPopperArrow.test.ts
+++ b/src/frontend/src/styles/elementPlusPopperArrow.test.ts
@@ -30,7 +30,9 @@ describe('Element Plus popper arrows', () => {
     expect(sharedStyles).toMatch(
       /\.el-dropdown-menu,[\s\S]*?\.el-table-filter__content\s*{[^}]*overflow:\s*hidden;/,
     )
-    expect(navigationStyles).toMatch(/\.nav-dropdown-panel\s*{[^}]*overflow:\s*hidden;/s)
+    expect(navigationStyles).toMatch(
+      /\.nav-dropdown-panel\s*{[^}]*border-radius:\s*inherit;[^}]*overflow:\s*hidden;/s,
+    )
   })
 
   it('clips the bordered arrow to its exposed triangular half', () => {

--- a/src/frontend/src/styles/nav-dropdown-panel.css
+++ b/src/frontend/src/styles/nav-dropdown-panel.css
@@ -9,6 +9,7 @@
 }
 
 .nav-dropdown-panel {
+  border-radius: inherit;
   overflow: hidden;
   background: #fff;
 }


### PR DESCRIPTION
## Summary

- Inherit the account dropdown popover radius on its inner panel
- Keep clipping on the inner panel so the shared Popper arrow remains visible
- Extend the existing Popper regression test to cover the rounded inner panel

## Testing

- `npm test -- --run src/styles/elementPlusPopperArrow.test.ts src/components/NavNotificationPopover.test.ts src/components/MobileHeaderUtilities.test.ts`
- `npm run build`

Closes #988
