### PR TITLE
Fix sign-out dialog focus

### DIFF
--- a/src/frontend/src/lib/logout.test.ts
+++ b/src/frontend/src/lib/logout.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  confirm: vi.fn(),
+}))
+
+vi.mock('element-plus', () => ({
+  ElMessageBox: {
+    close: mocks.close,
+    confirm: mocks.confirm,
+  },
+}))
+
+import { confirmSignOut } from './logout'
+
+describe('confirmSignOut', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.confirm.mockResolvedValue('confirm')
+  })
+
+  it('opens without auto-focusing the confirm action', async () => {
+    const t = (key: string) => key
+
+    await expect(confirmSignOut(t)).resolves.toBe(true)
+
+    expect(mocks.confirm).toHaveBeenCalledWith(
+      'account.logoutConfirmBody',
+      'account.logoutConfirmTitle',
+      expect.objectContaining({
+        autofocus: false,
+        customClass: 'hfl-message-box--sign-out',
+      }),
+    )
+  })
+})

--- a/src/frontend/src/lib/logout.ts
+++ b/src/frontend/src/lib/logout.ts
@@ -19,6 +19,10 @@ export async function confirmSignOut(t: (key: string) => string): Promise<boolea
       customClass: 'hfl-message-box--sign-out',
       appendTo: document.body,
       closeOnClickModal: false,
+      // Keep the confirm action in its neutral state when the dialog opens.
+      // Auto-focusing it also makes an immediate Enter keypress sign the user
+      // out without an explicit confirmation.
+      autofocus: false,
     })
     return true
   } catch {


### PR DESCRIPTION
## Summary

- disable confirm-button autofocus in the Sign out message box
- keep unrelated confirmation dialogs on their existing focus behavior
- add regression coverage for the Sign out dialog option

Closes #991

## Testing

- `npx vitest run src/lib/logout.test.ts`
- `npx eslint src/lib/logout.ts src/lib/logout.test.ts`
- `npx vue-tsc --noEmit`
- `npm run build`