### PR TITLE
feat(protection): bound skipped backup item samples

### DIFF
--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -45,7 +45,7 @@ const (
 	repositoryAlreadyExistsMessage       = "A Kopia repository already exists at the selected location. Import is not supported in this version. Choose a different storage location."
 	nasRepositoryWriteDeniedCode         = "NAS_REPOSITORY_WRITE_DENIED"
 	nasRepositoryWriteDeniedMessage      = "The NAS share was mounted, but the Agent does not have permission to write repository data."
-	snapshotFailureSampleLimit           = 20
+	snapshotFailureSampleLimit           = 10
 	snapshotFailurePathLimit             = 1024
 	snapshotFailureErrorLimit            = 2048
 )

--- a/src/agent/internal/wire/result_bounds.go
+++ b/src/agent/internal/wire/result_bounds.go
@@ -10,8 +10,9 @@ import (
 const (
 	maxTaskResultFrameBytes = 256 * 1024
 	// Reserve space for the task.result envelope, task ID, status, and bounded error.
-	maxTaskResultBytes   = maxTaskResultFrameBytes - 16*1024
-	maxResultStringBytes = 8 * 1024
+	maxTaskResultBytes        = maxTaskResultFrameBytes - 16*1024
+	maxResultStringBytes      = 8 * 1024
+	maxSnapshotFailureSamples = 10
 )
 
 type resultBoundStats struct {
@@ -130,8 +131,8 @@ func compactSnapshotFailureSummary(value any) any {
 		}
 	}
 	items, _ := summary["items"].([]any)
-	boundedItems := make([]any, 0, min(len(items), 20))
-	for _, raw := range items[:min(len(items), 20)] {
+	boundedItems := make([]any, 0, min(len(items), maxSnapshotFailureSamples))
+	for _, raw := range items[:min(len(items), maxSnapshotFailureSamples)] {
 		item, ok := raw.(map[string]any)
 		if !ok {
 			continue
@@ -143,8 +144,46 @@ func compactSnapshotFailureSummary(value any) any {
 			"item_type": truncateUTF8(stringJSONScalar(item["item_type"]), 32),
 		})
 	}
+	out["reported_count"] = len(boundedItems)
+	if total, ok := compactInteger(summary["total_count"]); ok {
+		out["truncated"] = summary["truncated"] == true || total > int64(len(boundedItems))
+	}
 	out["items"] = boundedItems
 	return out
+}
+
+func compactInteger(value any) (int64, bool) {
+	switch number := value.(type) {
+	case int:
+		return int64(number), true
+	case int8:
+		return int64(number), true
+	case int16:
+		return int64(number), true
+	case int32:
+		return int64(number), true
+	case int64:
+		return number, true
+	case uint:
+		return int64(number), true
+	case uint8:
+		return int64(number), true
+	case uint16:
+		return int64(number), true
+	case uint32:
+		return int64(number), true
+	case uint64:
+		if number > uint64(^uint64(0)>>1) {
+			return 0, false
+		}
+		return int64(number), true
+	case float64:
+		return int64(number), number == float64(int64(number))
+	case float32:
+		return int64(number), number == float32(int64(number))
+	default:
+		return 0, false
+	}
 }
 
 func stringJSONScalar(value any) string {

--- a/src/agent/internal/wire/result_bounds_test.go
+++ b/src/agent/internal/wire/result_bounds_test.go
@@ -59,6 +59,32 @@ func TestBoundTaskResultKeepsCompactSnapshotFailureSummary(t *testing.T) {
 	}
 }
 
+func TestBoundTaskResultCapsSnapshotFailureSamplesAtTen(t *testing.T) {
+	items := make([]any, 0, 20)
+	for i := 0; i < 20; i++ {
+		items = append(items, map[string]any{
+			"path":  "Library/Caches/item-" + string(rune('a'+i)),
+			"error": "operation not permitted",
+		})
+	}
+	bounded, _ := boundTaskResult(map[string]any{
+		"snapshot_failure_summary": map[string]any{
+			"total_count":    int64(20),
+			"reported_count": int64(20),
+			"truncated":      false,
+			"items":          items,
+		},
+		"other": strings.Repeat("x", maxTaskResultBytes),
+	})
+	summary := bounded["snapshot_failure_summary"].(map[string]any)
+	if got := len(summary["items"].([]any)); got != maxSnapshotFailureSamples {
+		t.Fatalf("sample count=%d, want %d", got, maxSnapshotFailureSamples)
+	}
+	if summary["reported_count"] != maxSnapshotFailureSamples || summary["truncated"] != true {
+		t.Fatalf("summary bounds are inconsistent: %#v", summary)
+	}
+}
+
 func TestBoundTaskResultReservesFailureSummaryUnderExtremeEssentialData(t *testing.T) {
 	result := map[string]any{
 		"snapshot_failure_summary": map[string]any{

--- a/src/backend/apps/protection/services/backup_task.py
+++ b/src/backend/apps/protection/services/backup_task.py
@@ -103,6 +103,7 @@ _DIRECTORY_TERMINAL_STATUSES = {
     BackupSourceSnapshotDirectory.Status.FAILED,
     BackupSourceSnapshotDirectory.Status.DELETED,
 }
+_MAX_SKIPPED_EVENT_ITEMS = 10
 
 
 def _is_global_backup_admission_error(exc: Exception) -> bool:
@@ -1907,7 +1908,6 @@ def kopia_snapshot_skipped_metadata(
             reported_total,
             file_count + directory_count + special_count,
         )
-    max_event_items = 20
     return {
         "skipped_details": {
             "category": "source_items_skipped",
@@ -1915,9 +1915,9 @@ def kopia_snapshot_skipped_metadata(
             "file_count": file_count,
             "directory_count": directory_count,
             "special_count": special_count,
-            "items": items[:max_event_items],
-            "reported_count": min(len(items), max_event_items),
-            "truncated": total_count > min(len(items), max_event_items),
+            "items": items[:_MAX_SKIPPED_EVENT_ITEMS],
+            "reported_count": min(len(items), _MAX_SKIPPED_EVENT_ITEMS),
+            "truncated": total_count > min(len(items), _MAX_SKIPPED_EVENT_ITEMS),
         }
     }
 

--- a/src/backend/apps/protection/tests/test_kopia_progress.py
+++ b/src/backend/apps/protection/tests/test_kopia_progress.py
@@ -758,7 +758,7 @@ class KopiaFailureMessageTests(SimpleTestCase):
         self.assertEqual(details["items"][1]["path"], "private")
         self.assertEqual(details["items"][1]["error"], "readdir private: access denied")
 
-    def test_skipped_metadata_limits_event_details_to_twenty_items(self):
+    def test_skipped_metadata_limits_event_details_to_ten_items(self):
         from apps.protection.services.backup_task import (
             kopia_snapshot_skipped_metadata,
         )
@@ -774,8 +774,8 @@ class KopiaFailureMessageTests(SimpleTestCase):
         details = kopia_snapshot_skipped_metadata(result)["skipped_details"]
 
         self.assertEqual(details["count"], 25)
-        self.assertEqual(details["reported_count"], 20)
-        self.assertEqual(len(details["items"]), 20)
+        self.assertEqual(details["reported_count"], 10)
+        self.assertEqual(len(details["items"]), 10)
         self.assertTrue(details["truncated"])
 
     def test_skipped_metadata_uses_exact_summary_type_counts(self):

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
@@ -59,12 +59,13 @@ describe('FlowBackupSourceDetailDrawer task columns', () => {
   })
 })
 
-describe('FlowBackupSourceDetailDrawer structured failure layout', () => {
-  it('lets structured failure details use the unused event-time column', () => {
-    expect(drawer).toContain("'dp-task-detail__event-row--failure-details': hasEventFailureDetails(event)")
-    expect(drawer).toContain('.dp-task-detail__event-row--failure-details .dp-task-detail__event-content')
+describe('FlowBackupSourceDetailDrawer structured detail layout', () => {
+  it('lets failure and skipped-item details use the unused event-time column', () => {
+    expect(drawer).toContain("['failure_details', 'skipped_details']")
+    expect(drawer).toContain("'dp-task-detail__event-row--detail-panel': hasEventDetailPanel(event)")
+    expect(drawer).toContain('.dp-task-detail__event-row--detail-panel .dp-task-detail__event-content')
     expect(drawer).toContain('grid-template-columns: 16px minmax(0, 1fr);')
-    expect(drawer).toContain('.dp-task-detail__event-row--failure-details .dp-task-detail__event-time')
+    expect(drawer).toContain('.dp-task-detail__event-row--detail-panel .dp-task-detail__event-time')
   })
 })
 

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -1372,9 +1372,13 @@ function taskEventMetadataText(event: TaskEventRow, keys: string[]) {
   return ''
 }
 
-function hasEventFailureDetails(event: TaskEventRow) {
-  const details = taskEventMetadata(event).failure_details
-  return Boolean(details && typeof details === 'object' && !Array.isArray(details))
+function hasEventDetailPanel(event: TaskEventRow) {
+  const metadata = taskEventMetadata(event)
+  return ['failure_details', 'skipped_details'].some((key) => {
+    const details = metadata[key]
+    return Boolean(details && typeof details === 'object' && !Array.isArray(details))
+  }) || ['skipped_item_count', 'skipped_file_count', 'skipped_directory_count', 'skipped_special_count']
+    .some(key => Number(metadata[key]) > 0)
 }
 
 function taskEventMetadataList(event: TaskEventRow, key: string) {
@@ -5405,7 +5409,7 @@ function onClosed() {
                       v-for="event in step.events"
                       :key="event.id"
                       class="dp-task-detail__event-row"
-                      :class="{ 'dp-task-detail__event-row--failure-details': hasEventFailureDetails(event) }"
+                      :class="{ 'dp-task-detail__event-row--detail-panel': hasEventDetailPanel(event) }"
                     >
                       <span
                         class="dp-task-detail__event-dot"
@@ -5471,7 +5475,7 @@ function onClosed() {
                       v-for="event in unlinkedTaskEvents"
                       :key="event.id"
                       class="dp-task-detail__event-row"
-                      :class="{ 'dp-task-detail__event-row--failure-details': hasEventFailureDetails(event) }"
+                      :class="{ 'dp-task-detail__event-row--detail-panel': hasEventDetailPanel(event) }"
                     >
                       <span
                         class="dp-task-detail__event-dot"
@@ -5523,7 +5527,7 @@ function onClosed() {
                 v-for="event in taskDetailEvents"
                 :key="event.id"
                 class="dp-task-detail__event-row"
-                :class="{ 'dp-task-detail__event-row--failure-details': hasEventFailureDetails(event) }"
+                :class="{ 'dp-task-detail__event-row--detail-panel': hasEventDetailPanel(event) }"
               >
                 <span
                   class="dp-task-detail__event-dot"
@@ -7671,44 +7675,44 @@ function onClosed() {
   white-space: nowrap;
 }
 
-.dp-task-detail__event-row--failure-details {
+.dp-task-detail__event-row--detail-panel {
   position: relative;
   grid-template-columns: 16px minmax(0, 1fr);
 }
 
-.dp-task-detail__event-row--failure-details .dp-task-detail__event-content {
+.dp-task-detail__event-row--detail-panel .dp-task-detail__event-content {
   grid-column: 2;
   align-items: stretch;
 }
 
-.dp-task-detail__event-row--failure-details .dp-task-detail__event-msg {
+.dp-task-detail__event-row--detail-panel .dp-task-detail__event-msg {
   align-self: flex-start;
   max-width: calc(100% - 132px);
 }
 
-.dp-task-detail__event-row--failure-details .dp-task-detail__event-object,
-.dp-task-detail__event-row--failure-details .dp-task-detail__event-error {
+.dp-task-detail__event-row--detail-panel .dp-task-detail__event-object,
+.dp-task-detail__event-row--detail-panel .dp-task-detail__event-error {
   align-self: flex-start;
 }
 
-.dp-task-detail__event-row--failure-details .dp-task-detail__event-time {
+.dp-task-detail__event-row--detail-panel .dp-task-detail__event-time {
   position: absolute;
   top: 0;
   right: 0;
 }
 
 @media (max-width: 760px) {
-  .dp-task-detail__event-row--failure-details {
+  .dp-task-detail__event-row--detail-panel {
     grid-template-columns: 16px minmax(0, 1fr);
   }
 
-  .dp-task-detail__event-row--failure-details .dp-task-detail__event-time {
+  .dp-task-detail__event-row--detail-panel .dp-task-detail__event-time {
     position: static;
     grid-column: 2;
     justify-self: start;
   }
 
-  .dp-task-detail__event-row--failure-details .dp-task-detail__event-msg {
+  .dp-task-detail__event-row--detail-panel .dp-task-detail__event-msg {
     max-width: 100%;
   }
 }

--- a/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
@@ -331,9 +331,13 @@ function taskEventMetadata(event: TaskEventRow): Record<string, unknown> {
   return event.metadata && typeof event.metadata === 'object' ? event.metadata as Record<string, unknown> : {}
 }
 
-function hasEventFailureDetails(event: TaskEventRow) {
-  const details = taskEventMetadata(event).failure_details
-  return Boolean(details && typeof details === 'object' && !Array.isArray(details))
+function hasEventDetailPanel(event: TaskEventRow) {
+  const metadata = taskEventMetadata(event)
+  return ['failure_details', 'skipped_details'].some((key) => {
+    const details = metadata[key]
+    return Boolean(details && typeof details === 'object' && !Array.isArray(details))
+  }) || ['skipped_item_count', 'skipped_file_count', 'skipped_directory_count', 'skipped_special_count']
+    .some(key => Number(metadata[key]) > 0)
 }
 
 function taskEventMetadataText(event: TaskEventRow, keys: string[]) {
@@ -1043,7 +1047,7 @@ watch(
                       v-for="event in step.events"
                       :key="event.id"
                       class="hfl-task-drawer__event-row"
-                      :class="{ 'hfl-task-drawer__event-row--failure-details': hasEventFailureDetails(event) }"
+                      :class="{ 'hfl-task-drawer__event-row--detail-panel': hasEventDetailPanel(event) }"
                     >
                       <span
                         class="hfl-task-drawer__event-dot"
@@ -1094,7 +1098,7 @@ watch(
                   v-for="event in unlinkedEvents"
                   :key="event.id"
                   class="hfl-task-drawer__event-row"
-                  :class="{ 'hfl-task-drawer__event-row--failure-details': hasEventFailureDetails(event) }"
+                  :class="{ 'hfl-task-drawer__event-row--detail-panel': hasEventDetailPanel(event) }"
                 >
                   <span
                     class="hfl-task-drawer__event-dot"
@@ -2133,27 +2137,27 @@ watch(
   white-space: nowrap;
 }
 
-.hfl-task-drawer__event-row--failure-details {
+.hfl-task-drawer__event-row--detail-panel {
   position: relative;
   grid-template-columns: 16px minmax(0, 1fr);
 }
 
-.hfl-task-drawer__event-row--failure-details .hfl-task-drawer__event-content {
+.hfl-task-drawer__event-row--detail-panel .hfl-task-drawer__event-content {
   grid-column: 2;
   align-items: stretch;
 }
 
-.hfl-task-drawer__event-row--failure-details .hfl-task-drawer__event-msg {
+.hfl-task-drawer__event-row--detail-panel .hfl-task-drawer__event-msg {
   align-self: flex-start;
   max-width: calc(100% - 132px);
 }
 
-.hfl-task-drawer__event-row--failure-details .hfl-task-drawer__event-object,
-.hfl-task-drawer__event-row--failure-details .hfl-task-drawer__event-error {
+.hfl-task-drawer__event-row--detail-panel .hfl-task-drawer__event-object,
+.hfl-task-drawer__event-row--detail-panel .hfl-task-drawer__event-error {
   align-self: flex-start;
 }
 
-.hfl-task-drawer__event-row--failure-details .hfl-task-drawer__event-time {
+.hfl-task-drawer__event-row--detail-panel .hfl-task-drawer__event-time {
   position: absolute;
   top: 0;
   right: 0;
@@ -2179,17 +2183,17 @@ watch(
     max-width: 100%;
   }
 
-  .hfl-task-drawer__event-row--failure-details {
+  .hfl-task-drawer__event-row--detail-panel {
     grid-template-columns: 16px minmax(0, 1fr);
   }
 
-  .hfl-task-drawer__event-row--failure-details .hfl-task-drawer__event-time {
+  .hfl-task-drawer__event-row--detail-panel .hfl-task-drawer__event-time {
     position: static;
     grid-column: 2;
     justify-self: start;
   }
 
-  .hfl-task-drawer__event-row--failure-details .hfl-task-drawer__event-msg {
+  .hfl-task-drawer__event-row--detail-panel .hfl-task-drawer__event-msg {
     max-width: 100%;
   }
 }

--- a/src/frontend/src/pages/protection/components/TaskDetailDrawerNasWriteDenied.test.ts
+++ b/src/frontend/src/pages/protection/components/TaskDetailDrawerNasWriteDenied.test.ts
@@ -16,11 +16,12 @@ describe('TaskDetailDrawer NAS repository write denial', () => {
   })
 })
 
-describe('TaskDetailDrawer structured failure layout', () => {
-  it('lets structured failure details use the unused event-time column', () => {
-    expect(source).toContain("'hfl-task-drawer__event-row--failure-details': hasEventFailureDetails(event)")
-    expect(source).toContain('.hfl-task-drawer__event-row--failure-details .hfl-task-drawer__event-content')
+describe('TaskDetailDrawer structured detail layout', () => {
+  it('lets failure and skipped-item details use the unused event-time column', () => {
+    expect(source).toContain("['failure_details', 'skipped_details']")
+    expect(source).toContain("'hfl-task-drawer__event-row--detail-panel': hasEventDetailPanel(event)")
+    expect(source).toContain('.hfl-task-drawer__event-row--detail-panel .hfl-task-drawer__event-content')
     expect(source).toContain('grid-template-columns: 16px minmax(0, 1fr);')
-    expect(source).toContain('.hfl-task-drawer__event-row--failure-details .hfl-task-drawer__event-time')
+    expect(source).toContain('.hfl-task-drawer__event-row--detail-panel .hfl-task-drawer__event-time')
   })
 })

--- a/src/frontend/src/pages/protection/components/TaskEventFailureDetails.test.ts
+++ b/src/frontend/src/pages/protection/components/TaskEventFailureDetails.test.ts
@@ -145,4 +145,31 @@ describe('TaskEventFailureDetails', () => {
     expect(wrapper.text()).toContain('6 source items were skipped (files: 4; directories: 1; special entries: 1).')
     expect(wrapper.find('details').exists()).toBe(false)
   })
+
+  it('caps legacy skipped-item payloads at ten visible items', () => {
+    const wrapper = mount(TaskEventFailureDetails, {
+      props: {
+        metadata: {
+          skipped_details: {
+            count: 20,
+            reported_count: 20,
+            truncated: false,
+            items: Array.from({ length: 20 }, (_, index) => ({
+              path: `cache/item-${index}.tmp`,
+              error: 'sharing violation',
+            })),
+          },
+        },
+      },
+      global: {
+        plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })],
+      },
+    })
+
+    expect(wrapper.text()).toContain('View 10 skipped items')
+    expect(wrapper.text()).toContain('Showing the first 10 of 20 skipped items.')
+    expect(wrapper.findAll('.task-event-failure__files li')).toHaveLength(10)
+    expect(wrapper.text()).toContain('cache/item-9.tmp')
+    expect(wrapper.text()).not.toContain('cache/item-10.tmp')
+  })
 })

--- a/src/frontend/src/pages/protection/components/TaskEventFailureDetails.vue
+++ b/src/frontend/src/pages/protection/components/TaskEventFailureDetails.vue
@@ -16,6 +16,8 @@ const props = defineProps<{
   metadata?: unknown
 }>()
 
+const MAX_SKIPPED_ITEMS = 10
+
 const { t } = useI18n()
 
 const metadataRecord = computed<Record<string, unknown>>(() => {
@@ -120,7 +122,11 @@ const skippedItems = computed<SkippedItem[]>(() => {
     const path = String(record.path || '').trim()
     const error = String(record.error || '').trim()
     return path || error ? [{ path, error }] : []
-  })
+  }).slice(0, MAX_SKIPPED_ITEMS)
+})
+const skippedItemPayloadCount = computed(() => {
+  const value = skippedDetails.value.items
+  return Array.isArray(value) ? value.length : 0
 })
 
 function positiveCount(value: unknown) {
@@ -143,9 +149,16 @@ const skippedCount = computed(() => (
   || skippedItems.value.length
 ))
 const skippedReportedCount = computed(() => (
-  positiveCount(skippedDetails.value.reported_count) || skippedItems.value.length
+  Math.min(
+    MAX_SKIPPED_ITEMS,
+    positiveCount(skippedDetails.value.reported_count) || skippedItems.value.length,
+  )
 ))
-const skippedTruncated = computed(() => Boolean(skippedDetails.value.truncated))
+const skippedTruncated = computed(() => (
+  Boolean(skippedDetails.value.truncated)
+  || skippedCount.value > skippedItems.value.length
+  || skippedItemPayloadCount.value > MAX_SKIPPED_ITEMS
+))
 const hasSkippedDetails = computed(() => skippedCount.value > 0)
 const hasDetails = computed(() => (
   items.value.length > 0


### PR DESCRIPTION
## Problem and root cause

Successful backup task results retained and displayed up to 20 skipped-source
samples independently in the Agent, wire compaction, and backend task-event
metadata. Long paths and error messages made these previews unnecessarily
large even though aggregate counters already preserved the complete result.

The two skipped-item warning panels also remained constrained to the middle
event column after their timestamps moved above the panel, leaving usable
space empty and causing avoidable wrapping.

## Solution

- Bound skipped-source previews to 10 items in Agent summaries, wire
  compaction, and backend task-event persistence.
- Recalculate wire `reported_count` and `truncated` metadata after compaction
  while preserving exact total, item-type, and cause counters.
- Cap historical task payloads at 10 visible samples in the frontend without
  requiring a data migration.
- Apply the shared full-width detail-panel layout to both skipped-item warning
  variants in both task-detail drawers, preserving timestamp placement and
  responsive narrow-screen behavior.

## Validation

- Agent wire and focused snapshot-summary engine tests passed.
- Community Backend suite passed: 2,257 tests, with 2 skipped.
- Community Frontend suite passed on Node.js 22.23.2: 262 files and 1,435
  tests.
- Backend Ruff, changed-file ESLint, the type-checked production build, Go
  formatting, the English-source boundary, and `git diff --check` passed.
- Complete Agent testing on macOS was baseline-equivalent to clean
  `origin/main` at `49f0ddb8c5294340e20ec95e544a48a767671211`: the candidate's 25
  environment-specific failing test identities were a strict subset of the
  baseline failures, with no new failure identity.
- Manual testing: passed.
- Post-sync product tests were not repeated because the commit was already
  based directly on the latest `origin/main`; synchronization was
  conflict-free and did not change the tested tree.

## Risks and compatibility

No database schema or public API field changes are required. Existing task
records that contain 20 samples remain readable and are capped only at display
time. Aggregate totals and classifications remain authoritative and exact;
only the representative sample array is reduced.

Fixes #996
