### PR TITLE
fix(protection): paginate snapshot directory browsing

### DIFF
--- a/language-packs/packs/es/frontend/messages.json
+++ b/language-packs/packs/es/frontend/messages.json
@@ -1669,6 +1669,8 @@
       "snapshotBrowserDownloadNotReady": "El archivo de descarga todavía no está listo",
       "snapshotBrowserDownloadFailed": "La descarga ha fallado",
       "snapshotBrowserDownloadTimeout": "La descarga ha agotado el tiempo de espera",
+      "snapshotBrowserPartialCount": "Se han cargado {n} elementos. Hay más elementos disponibles.",
+      "snapshotBrowserLoadMore": "Cargar más",
       "snapshotRecoverAction": "Restaurar",
       "snapshotRecoverTodo": "Aún no se ha aplicado la restauración",
       "snapshotBrowserEmpty": "Este directorio está vacío",

--- a/language-packs/packs/es/frontend/source-lock.json
+++ b/language-packs/packs/es/frontend/source-lock.json
@@ -1605,6 +1605,8 @@
   "protection.backupsPage.snapshotBrowserDownloadNotReady": "4f77f4cb6d9d3be1d6234838a95ca32a441c9b21626f1b33fcde0552fce8081b",
   "protection.backupsPage.snapshotBrowserDownloadFailed": "1fd304f48b074c502565c8d1b50372edefd0196aa880f3b7c0745e3591450426",
   "protection.backupsPage.snapshotBrowserDownloadTimeout": "a38396cc11ace0d557dae9065c0ecf7c5156952dad4367d4307134e7e8c60389",
+  "protection.backupsPage.snapshotBrowserPartialCount": "0625fbe6be1203180b11c5cbfecdc83fbb9302ced465e2014f9c6602a516be33",
+  "protection.backupsPage.snapshotBrowserLoadMore": "7a9c3041ba5bccca921ad676189b671e8200c15dc8af562676a93b98e5462344",
   "protection.backupsPage.snapshotRecoverAction": "9fb92d5ac48a197b0499952ff25f2e8a84937831504f23569b5b8ad549a4334d",
   "protection.backupsPage.snapshotRecoverTodo": "0b141badafcf15d5d1367dae0bf502247c9c38896388469002bea673d096c9e2",
   "protection.backupsPage.snapshotBrowserEmpty": "a72fd4e7bd6e675f69bdebc5e85a5d1862b717db22ade61b315615e1a5f295d9",

--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -1385,6 +1385,8 @@
       "snapshotBrowserDownloadNotReady": "下载文件尚未准备完成",
       "snapshotBrowserDownloadFailed": "下载任务失败",
       "snapshotBrowserDownloadTimeout": "下载任务超时",
+      "snapshotBrowserPartialCount": "已加载 {n} 项，还有更多内容。",
+      "snapshotBrowserLoadMore": "加载更多",
       "snapshotRecoverAction": "恢复",
       "snapshotRecoverTodo": "恢复功能待实现",
       "snapshotBrowserEmpty": "当前目录为空",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -1605,6 +1605,8 @@
   "protection.backupsPage.snapshotBrowserDownloadNotReady": "4f77f4cb6d9d3be1d6234838a95ca32a441c9b21626f1b33fcde0552fce8081b",
   "protection.backupsPage.snapshotBrowserDownloadFailed": "1fd304f48b074c502565c8d1b50372edefd0196aa880f3b7c0745e3591450426",
   "protection.backupsPage.snapshotBrowserDownloadTimeout": "a38396cc11ace0d557dae9065c0ecf7c5156952dad4367d4307134e7e8c60389",
+  "protection.backupsPage.snapshotBrowserPartialCount": "0625fbe6be1203180b11c5cbfecdc83fbb9302ced465e2014f9c6602a516be33",
+  "protection.backupsPage.snapshotBrowserLoadMore": "7a9c3041ba5bccca921ad676189b671e8200c15dc8af562676a93b98e5462344",
   "protection.backupsPage.snapshotRecoverAction": "9fb92d5ac48a197b0499952ff25f2e8a84937831504f23569b5b8ad549a4334d",
   "protection.backupsPage.snapshotRecoverTodo": "0b141badafcf15d5d1367dae0bf502247c9c38896388469002bea673d096c9e2",
   "protection.backupsPage.snapshotBrowserEmpty": "a72fd4e7bd6e675f69bdebc5e85a5d1862b717db22ade61b315615e1a5f295d9",

--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -2022,6 +2022,80 @@ type insightSnapshotBrowseCollector struct {
 	skippedSpecialCount int64
 }
 
+type snapshotBrowsePageCollector struct {
+	basePath string
+	offset   int
+	limit    int
+	seen     int
+	entries  []map[string]any
+	hasMore  bool
+	invalid  bool
+}
+
+func newSnapshotBrowsePageCollector(basePath string, limit int, cursor string) (*snapshotBrowsePageCollector, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	offset := 0
+	if strings.TrimSpace(cursor) != "" {
+		parsed, err := strconv.Atoi(strings.TrimSpace(cursor))
+		if err != nil || parsed < 0 {
+			return nil, fmt.Errorf("cursor must be a non-negative integer")
+		}
+		offset = parsed
+	}
+	return &snapshotBrowsePageCollector{
+		basePath: strings.Trim(strings.TrimSpace(basePath), "/\\"),
+		offset:   offset,
+		limit:    limit,
+		entries:  make([]map[string]any, 0, limit),
+	}, nil
+}
+
+func (collector *snapshotBrowsePageCollector) consume(line string) bool {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return true
+	}
+	mode, size, modTime, name, ok := parseSnapshotBrowseLongLine(line)
+	if !ok {
+		collector.invalid = true
+		return false
+	}
+	if collector.seen < collector.offset {
+		collector.seen++
+		return true
+	}
+	if len(collector.entries) >= collector.limit {
+		collector.hasMore = true
+		return false
+	}
+	collector.seen++
+	isDir := strings.HasPrefix(strings.ToLower(mode), "d")
+	path := normalizeSnapshotBrowsePath(name, name, collector.basePath, "")
+	collector.entries = append(collector.entries, map[string]any{
+		"name":         snapshotBrowseName(name, path),
+		"path":         path,
+		"type":         mapSnapshotBrowseType(isDir),
+		"is_dir":       isDir,
+		"size_bytes":   size,
+		"modified_at":  modTime,
+		"downloadable": true,
+		"has_children": nil,
+	})
+	return true
+}
+
+func (collector *snapshotBrowsePageCollector) nextCursor() string {
+	if !collector.hasMore {
+		return ""
+	}
+	return strconv.Itoa(collector.offset + len(collector.entries))
+}
+
 func newInsightSnapshotBrowseCollector(basePath string, limit int) *insightSnapshotBrowseCollector {
 	if limit <= 0 || limit > 500 {
 		limit = 500
@@ -2171,21 +2245,37 @@ func (e *Engine) runManagedSnapshotBrowse(
 	if prepErr != "" {
 		return "failed", result, prepErr
 	}
-	target := snapshotObjectPath(p.SnapshotID, p.Path)
-	args := []string{"--config-file=" + configFile, "ls", "--json", target}
-	res, runErr := process.Run(ctx, bin, args, env, "")
-	if runErr != nil && snapshotBrowseJsonUnsupported(res) {
-		args = []string{"--config-file=" + configFile, "ls", "-l", target}
-		res, runErr = process.Run(ctx, bin, args, env, "")
+	collector, collectorErr := newSnapshotBrowsePageCollector(p.Path, p.Limit, p.Cursor)
+	if collectorErr != nil {
+		return "failed", result, collectorErr.Error()
 	}
+	target := snapshotObjectPath(p.SnapshotID, p.Path)
+	runCtx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
+	res, runErr := process.RunStreamingDiscardStdout(
+		runCtx,
+		bin,
+		[]string{"--config-file=" + configFile, "ls", "-l", target},
+		env,
+		"",
+		func(line string, stderr bool) {
+			if !stderr && !collector.consume(line) {
+				cancelRun()
+			}
+		},
+	)
 	result["snapshot_browse"] = commandResult(res)
 	result["path"] = strings.Trim(strings.TrimSpace(p.Path), "/\\")
 	result["snapshot_id"] = p.SnapshotID
-	entries := parseSnapshotBrowseOutput(res.Stdout, p.Path, p.SnapshotID)
-	result["entries"] = entries
-	result["count"] = len(entries)
-	result["has_more"] = false
-	if runErr != nil {
+	result["entries"] = collector.entries
+	result["count"] = len(collector.entries)
+	result["has_more"] = collector.hasMore
+	result["next_cursor"] = collector.nextCursor()
+	if collector.invalid {
+		return "failed", result, "snapshot browse returned invalid directory entries"
+	}
+	limitReached := collector.hasMore && ctx.Err() == nil
+	if runErr != nil && !limitReached {
 		return "failed", result, snapshotBrowseFailureMessage(res, runErr)
 	}
 	return "success", result, ""

--- a/src/agent/internal/engine/managed_backup_test.go
+++ b/src/agent/internal/engine/managed_backup_test.go
@@ -1642,6 +1642,52 @@ func TestInsightSnapshotBrowseCollectorBoundsAndNormalizesEntries(t *testing.T) 
 	}
 }
 
+func TestSnapshotBrowsePageCollectorAdvancesWithoutDuplicates(t *testing.T) {
+	lines := []string{
+		"drwx------ 0 2026-08-12 11:15:59 UTC object-dir reports/",
+		"-rw------- 12 2026-08-12 11:15:59 UTC object-one one.pdf",
+		"-rw------- 18 2026-08-12 11:15:59 UTC object-two two.pdf",
+		"-rw------- 24 2026-08-12 11:15:59 UTC object-three three.pdf",
+	}
+
+	first, err := newSnapshotBrowsePageCollector("docs", 2, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range lines {
+		if !first.consume(line) {
+			break
+		}
+	}
+	if len(first.entries) != 2 || !first.hasMore || first.nextCursor() != "2" {
+		t.Fatalf("unexpected first page: %#v", first)
+	}
+
+	second, err := newSnapshotBrowsePageCollector("docs", 2, first.nextCursor())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range lines {
+		if !second.consume(line) {
+			break
+		}
+	}
+	if len(second.entries) != 2 || second.hasMore || second.nextCursor() != "" {
+		t.Fatalf("unexpected second page: %#v", second)
+	}
+	if first.entries[1]["path"] != "docs/one.pdf" || second.entries[0]["path"] != "docs/two.pdf" {
+		t.Fatalf("pages overlap or skip entries: first=%#v second=%#v", first.entries, second.entries)
+	}
+}
+
+func TestSnapshotBrowsePageCollectorRejectsInvalidCursor(t *testing.T) {
+	for _, cursor := range []string{"-1", "next"} {
+		if _, err := newSnapshotBrowsePageCollector("", 200, cursor); err == nil {
+			t.Fatalf("expected cursor %q to be rejected", cursor)
+		}
+	}
+}
+
 func TestInsightSnapshotBrowseCollectorRejectsMalformedOutput(t *testing.T) {
 	collector := newInsightSnapshotBrowseCollector("reports", 2)
 	collector.consume("unexpected kopia output")

--- a/src/backend/apps/protection/api/views/snapshot_browser.py
+++ b/src/backend/apps/protection/api/views/snapshot_browser.py
@@ -44,6 +44,19 @@ def _int_query(value: str | None, default: int, *, min_value: int, max_value: in
     return max(min_value, min(max_value, parsed))
 
 
+def _cursor_query(value: str | None) -> str:
+    cursor = str(value or "").strip()
+    if not cursor:
+        return ""
+    try:
+        offset = int(cursor)
+    except (TypeError, ValueError) as exc:
+        raise ValidationError({"cursor": "Must be a non-negative integer."}) from exc
+    if offset < 0:
+        raise ValidationError({"cursor": "Must be a non-negative integer."})
+    return str(offset)
+
+
 class SnapshotDirectoryBrowseView(APIView):
     permission_classes = [IsAuthenticated, IsOrgReader]
 
@@ -60,6 +73,7 @@ class SnapshotDirectoryBrowseView(APIView):
                     min_value=1,
                     max_value=1000,
                 ),
+                cursor=_cursor_query(request.query_params.get("cursor")),
             )
         except SnapshotBrowserForbidden as exc:
             raise PermissionDenied(str(exc)) from exc

--- a/src/backend/apps/protection/services/snapshot_browser.py
+++ b/src/backend/apps/protection/services/snapshot_browser.py
@@ -70,6 +70,19 @@ def _filename(path: str) -> str:
     return posixpath.basename(path.rstrip("/")) or "download"
 
 
+def _cursor_offset(cursor: str) -> int:
+    value = str(cursor or "").strip()
+    if not value:
+        return 0
+    try:
+        offset = int(value)
+    except (TypeError, ValueError) as exc:
+        raise SnapshotBrowserError("Cursor must be a non-negative integer.") from exc
+    if offset < 0:
+        raise SnapshotBrowserError("Cursor must be a non-negative integer.")
+    return offset
+
+
 def _get_directory(*, organization_id: int, directory_id: int) -> BackupSourceSnapshotDirectory:
     row = (
         BackupSourceSnapshotDirectory.objects.select_related("source_snapshot")
@@ -194,6 +207,10 @@ def _run_snapshot_agent_task(
         "snapshot_id": row.kopia_snapshot_id,
         "path": path,
     }
+    if "limit" in payload:
+        persisted_payload["limit"] = payload["limit"]
+    if payload.get("cursor"):
+        persisted_payload["cursor"] = payload["cursor"]
     if isinstance(payload.get("paths"), list):
         persisted_payload["paths"] = payload["paths"]
     if isinstance(payload.get("artifact_upload"), dict):
@@ -245,34 +262,46 @@ def browse_snapshot_directory(
     directory_id: int,
     path: str = "",
     limit: int = DEFAULT_SNAPSHOT_BROWSE_LIMIT,
+    cursor: str = "",
     wait_timeout_seconds: int | None = None,
 ) -> dict[str, Any]:
     clean_path = _clean_relative_path(path)
+    cursor_offset = _cursor_offset(cursor)
     row = _get_directory(organization_id=organization_id, directory_id=directory_id)
     outcome = _run_snapshot_agent_task(
         row=row,
         kind="snapshot.browse",
         path=clean_path,
         wait_timeout_seconds=_snapshot_browser_timeout_seconds() if wait_timeout_seconds is None else wait_timeout_seconds,
+        extra_payload={"limit": limit, "cursor": cursor},
     )
     if getattr(outcome, "timed_out", False):
         raise SnapshotBrowserError("Snapshot browse timed out.")
     if not getattr(outcome, "ok", False):
         raise SnapshotBrowserError(_agent_result_error(outcome, "Snapshot browse failed."))
     result = outcome.result if isinstance(outcome.result, dict) else {}
+    raw_entries = result.get("entries") if isinstance(result.get("entries"), list) else []
+    agent_paged = "next_cursor" in result
+    page_entries = raw_entries if agent_paged else raw_entries[cursor_offset:]
     entries = _normalize_entries(
-        result.get("entries"),
+        page_entries,
         base_path=clean_path,
         limit=limit,
     )
+    if agent_paged:
+        has_more = bool(result.get("has_more"))
+        next_cursor = str(result.get("next_cursor") or "")
+    else:
+        has_more = len(raw_entries) > cursor_offset + limit
+        next_cursor = str(cursor_offset + limit) if has_more else ""
     return {
         "directory_id": row.id,
         "snapshot_id": row.source_snapshot_id,
         "path": clean_path,
         "parent_path": _parent_path(clean_path),
         "entries": entries,
-        "has_more": bool(result.get("has_more")) or len(entries) >= limit,
-        "next_cursor": str(result.get("next_cursor") or ""),
+        "has_more": has_more,
+        "next_cursor": next_cursor,
     }
 
 

--- a/src/backend/apps/protection/tests/test_snapshot_browser_api.py
+++ b/src/backend/apps/protection/tests/test_snapshot_browser_api.py
@@ -154,6 +154,75 @@ class SnapshotBrowserApiTests(TestCase):
         self.assertEqual(payload["snapshot_id"], "kopia-snapshot-1")
 
     @patch("apps.protection.services.snapshot_browser.run_agent_task_sync")
+    def test_browse_snapshot_directory_forwards_pagination(self, mock_run_agent_task_sync):
+        mock_run_agent_task_sync.return_value = SimpleNamespace(
+            ok=True,
+            timed_out=False,
+            result={
+                "entries": [{"name": "part-0200.dat", "type": "file", "size": 12}],
+                "has_more": True,
+                "next_cursor": "250",
+            },
+            task=SimpleNamespace(last_error=""),
+        )
+
+        response = self.client.get(
+            f"/api/v1/protection/backup-source-snapshot-directories/{self.directory.id}/browse/"
+            "?path=archive&limit=50&cursor=200",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.data["next_cursor"], "250")
+        self.assertIs(response.data["has_more"], True)
+        payload = mock_run_agent_task_sync.call_args.kwargs["payload"]
+        self.assertEqual(payload["path"], "archive")
+        self.assertEqual(payload["limit"], 50)
+        self.assertEqual(payload["cursor"], "200")
+
+    def test_browse_snapshot_directory_rejects_invalid_cursor(self):
+        response = self.client.get(
+            f"/api/v1/protection/backup-source-snapshot-directories/{self.directory.id}/browse/"
+            "?cursor=next",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertIn(b"non-negative integer", response.content)
+
+    @patch("apps.protection.services.snapshot_browser.run_agent_task_sync")
+    def test_browse_snapshot_directory_pages_legacy_agent_results(self, mock_run_agent_task_sync):
+        mock_run_agent_task_sync.return_value = SimpleNamespace(
+            ok=True,
+            timed_out=False,
+            result={
+                "entries": [
+                    {"name": f"part-{index:04d}.dat", "type": "file", "size": index}
+                    for index in range(5)
+                ],
+            },
+            task=SimpleNamespace(last_error=""),
+        )
+
+        first = self.client.get(
+            f"/api/v1/protection/backup-source-snapshot-directories/{self.directory.id}/browse/"
+            "?limit=2",
+            **self._headers(),
+        )
+        second = self.client.get(
+            f"/api/v1/protection/backup-source-snapshot-directories/{self.directory.id}/browse/"
+            f"?limit=2&cursor={first.data['next_cursor']}",
+            **self._headers(),
+        )
+
+        self.assertEqual([row["name"] for row in first.data["entries"]], ["part-0000.dat", "part-0001.dat"])
+        self.assertEqual(first.data["next_cursor"], "2")
+        self.assertIs(first.data["has_more"], True)
+        self.assertEqual([row["name"] for row in second.data["entries"]], ["part-0002.dat", "part-0003.dat"])
+        self.assertEqual(second.data["next_cursor"], "4")
+        self.assertIs(second.data["has_more"], True)
+
+    @patch("apps.protection.services.snapshot_browser.run_agent_task_sync")
     def test_browse_proxy_bound_nas_snapshot_directory_uses_bound_proxy(self, mock_run_agent_task_sync):
         proxy = Node.objects.create(
             organization=self.org,

--- a/src/frontend/src/lib/protectionBackupConfigApi.ts
+++ b/src/frontend/src/lib/protectionBackupConfigApi.ts
@@ -431,7 +431,7 @@ export async function deleteBackupSourceSnapshot(id: number) {
 
 export async function browseBackupSnapshotDirectory(
   directoryId: number,
-  params?: { path?: string; limit?: number },
+  params?: { path?: string; limit?: number; cursor?: string },
 ) {
   const qs = query(params as Record<string, string | number | undefined>)
   const path = qs

--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -1223,6 +1223,8 @@ export const enProtectionPages = {
     snapshotBrowserDownloadNotReady: 'Download File Is Not Ready Yet',
     snapshotBrowserDownloadFailed: 'Download Task Failed',
     snapshotBrowserDownloadTimeout: 'Download Task Timed Out',
+    snapshotBrowserPartialCount: '{n} items loaded. More items are available.',
+    snapshotBrowserLoadMore: 'Load more',
     snapshotRecoverAction: 'Restore',
     snapshotRecoverTodo: 'Restore is not implemented yet',
     snapshotBrowserEmpty: 'This directory is empty',

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
@@ -358,6 +358,25 @@ describe('FlowBackupSourceDetailDrawer snapshot expansion state', () => {
     expect(downloader).not.toContain('.blob()')
   })
 
+  it('loads snapshot directory pages on demand and explains partial results', () => {
+    const pagination = sourceBetween(
+      'function browserPageTreeNodes(',
+      'function syncBrowserTreeCheckedKeys',
+    )
+
+    expect(pagination).toContain('result.has_more && result.next_cursor')
+    expect(pagination).toContain('async function loadMoreBrowserTreeEntries')
+    expect(pagination).toContain('cursor: data.nextCursor')
+    expect(pagination).toContain('replaceBrowserLoadMoreNode')
+    expect(pagination).toContain('browserTreeRef.value?.insertBefore(replacement, data)')
+    expect(pagination).toContain('browserTreeRef.value?.remove(data)')
+    expect(pagination).toContain('browserEntries.value = [...browserEntries.value, ...result.entries]')
+    expect(drawer).toContain("t('protection.backupsPage.snapshotBrowserPartialCount', { n: data.loadedCount })")
+    expect(drawer).toContain('@click.stop="loadMoreBrowserTreeEntries(data)"')
+    expect(enProtectionPages.backupsPage.snapshotBrowserPartialCount).toBe('{n} items loaded. More items are available.')
+    expect(enProtectionPages.backupsPage.snapshotBrowserLoadMore).toBe('Load more')
+  })
+
   it('clears cached expansion state when pagination changes', () => {
     const paginationWatcher = sourceBetween(
       '() => [snapshotPagination.page, snapshotPagination.pageSize] as const,',

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -148,7 +148,14 @@ type SnapshotBrowserTreeNode = BackupSnapshotBrowserEntry & {
   loaded?: boolean
   isLeaf?: boolean
   children?: SnapshotBrowserTreeNode[]
+  loadMore?: boolean
+  nextCursor?: string
+  parentPath?: string
+  loadedCount?: number
+  loadingMore?: boolean
 }
+
+const SNAPSHOT_BROWSER_PAGE_LIMIT = 200
 
 type ResourceDetailRow = {
   key: string
@@ -2098,11 +2105,14 @@ async function openSnapshotDirectory(dir: BackupSourceSnapshotDirectory, path = 
   selectedBrowserPaths.value = new Set()
   browserTreeRef.value?.setCheckedKeys([])
   try {
-    const result = await browseBackupSnapshotDirectory(dir.id, { path })
+    const result = await browseBackupSnapshotDirectory(dir.id, {
+      path,
+      limit: SNAPSHOT_BROWSER_PAGE_LIMIT,
+    })
     browserPath.value = result.path || ''
     browserParentPath.value = result.parent_path || ''
     browserEntries.value = result.entries
-    browserTreeEntries.value = result.entries.map((entry) => browserEntryToTreeNode(entry))
+    browserTreeEntries.value = browserPageTreeNodes(result, browserPath.value, 0)
     browserTreeVersion.value += 1
     refreshBrowserTreeDisabled()
   } catch (err) {
@@ -2137,6 +2147,34 @@ function browserEntryToTreeNode(entry: BackupSnapshotBrowserEntry): SnapshotBrow
   }
 }
 
+function browserPageTreeNodes(
+  result: Awaited<ReturnType<typeof browseBackupSnapshotDirectory>>,
+  parentPath: string,
+  previouslyLoaded: number,
+) {
+  const entries = result.entries.map((entry) => browserEntryToTreeNode(entry))
+  const loadedCount = previouslyLoaded + entries.length
+  if (result.has_more && result.next_cursor) {
+    entries.push({
+      id: `snapshot-browser-load-more:${parentPath}:${result.next_cursor}`,
+      label: t('protection.backupsPage.snapshotBrowserLoadMore'),
+      name: t('protection.backupsPage.snapshotBrowserLoadMore'),
+      path: parentPath,
+      type: 'load-more',
+      size_bytes: 0,
+      downloadable: false,
+      disabled: true,
+      loaded: true,
+      isLeaf: true,
+      loadMore: true,
+      nextCursor: result.next_cursor,
+      parentPath,
+      loadedCount,
+    })
+  }
+  return entries
+}
+
 function isRelatedBrowserPath(a: string, b: string) {
   return a === b || a.startsWith(`${b}/`) || b.startsWith(`${a}/`)
 }
@@ -2150,7 +2188,7 @@ function isBrowserPathDisabled(path: string) {
 
 function refreshBrowserTreeDisabled(nodes: SnapshotBrowserTreeNode[] = browserTreeEntries.value) {
   for (const node of nodes) {
-    node.disabled = isBrowserPathDisabled(node.path)
+    node.disabled = node.loadMore || isBrowserPathDisabled(node.path)
     if (node.children?.length) refreshBrowserTreeDisabled(node.children)
   }
   browserTreeEntries.value = [...browserTreeEntries.value]
@@ -2167,8 +2205,11 @@ async function loadBrowserTreeNode(node: { data?: SnapshotBrowserTreeNode; level
     return
   }
   try {
-    const result = await browseBackupSnapshotDirectory(selectedSnapshotDirectory.value.id, { path: data.path })
-    const children = result.entries.map((entry) => browserEntryToTreeNode(entry))
+    const result = await browseBackupSnapshotDirectory(selectedSnapshotDirectory.value.id, {
+      path: data.path,
+      limit: SNAPSHOT_BROWSER_PAGE_LIMIT,
+    })
+    const children = browserPageTreeNodes(result, data.path, 0)
     data.children = children
     data.loaded = true
     resolve(children)
@@ -2177,6 +2218,55 @@ async function loadBrowserTreeNode(node: { data?: SnapshotBrowserTreeNode; level
     data.loaded = false
     ElMessage.error({ message: apiErrorMessage(err, t('errors.generic.loadFailed')), grouping: true })
     resolve([])
+  }
+}
+
+function replaceBrowserLoadMoreNode(
+  nodes: SnapshotBrowserTreeNode[],
+  id: string,
+  replacements: SnapshotBrowserTreeNode[],
+): boolean {
+  const index = nodes.findIndex((node) => node.id === id)
+  if (index >= 0) {
+    nodes.splice(index, 1, ...replacements)
+    return true
+  }
+  return nodes.some((node) => node.children && replaceBrowserLoadMoreNode(node.children, id, replacements))
+}
+
+async function loadMoreBrowserTreeEntries(data: SnapshotBrowserTreeNode) {
+  const directory = selectedSnapshotDirectory.value
+  if (!directory || !data.loadMore || !data.nextCursor || data.loadingMore) return
+  const directoryId = directory.id
+  const parentPath = data.parentPath || ''
+  const treeVersion = browserTreeVersion.value
+  data.loadingMore = true
+  browserTreeEntries.value = [...browserTreeEntries.value]
+  try {
+    const result = await browseBackupSnapshotDirectory(directoryId, {
+      path: parentPath,
+      limit: SNAPSHOT_BROWSER_PAGE_LIMIT,
+      cursor: data.nextCursor,
+    })
+    if (selectedSnapshotDirectory.value?.id !== directoryId || browserTreeVersion.value !== treeVersion) return
+    const replacements = browserPageTreeNodes(result, parentPath, data.loadedCount || 0)
+    if (!replaceBrowserLoadMoreNode(browserTreeEntries.value, data.id, replacements)) return
+    for (const replacement of replacements) {
+      browserTreeRef.value?.insertBefore(replacement, data)
+    }
+    browserTreeRef.value?.remove(data)
+    if (parentPath === browserPath.value) {
+      browserEntries.value = [...browserEntries.value, ...result.entries]
+    }
+    browserTreeEntries.value = [...browserTreeEntries.value]
+    refreshBrowserTreeDisabled()
+    await nextTick()
+    syncBrowserTreeCheckedKeys()
+  } catch (err) {
+    ElMessage.error({ message: apiErrorMessage(err, t('errors.generic.loadFailed')), grouping: true })
+  } finally {
+    data.loadingMore = false
+    browserTreeEntries.value = [...browserTreeEntries.value]
   }
 }
 
@@ -4234,7 +4324,24 @@ function onClosed() {
                       @check-change="onBrowserTreeCheckChange"
                     >
                       <template #default="{ data }">
-                        <div class="dp-snapshot-file-browser__tree-row">
+                        <div
+                          v-if="data.loadMore"
+                          class="dp-snapshot-file-browser__load-more"
+                        >
+                          <span>{{ t('protection.backupsPage.snapshotBrowserPartialCount', { n: data.loadedCount }) }}</span>
+                          <ElButton
+                            type="primary"
+                            link
+                            :loading="data.loadingMore"
+                            @click.stop="loadMoreBrowserTreeEntries(data)"
+                          >
+                            {{ t('protection.backupsPage.snapshotBrowserLoadMore') }}
+                          </ElButton>
+                        </div>
+                        <div
+                          v-else
+                          class="dp-snapshot-file-browser__tree-row"
+                        >
                           <span class="dp-snapshot-file-browser__entry">
                             <Folder
                               v-if="data.type === 'dir'"
@@ -7938,6 +8045,21 @@ function onClosed() {
   min-width: 0;
   padding-right: 10px;
   font-size: 13px;
+}
+
+.dp-snapshot-file-browser__load-more {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding-right: 10px;
+  color: rgb(100 116 139);
+  font-size: 12px;
+}
+
+.dp-snapshot-file-browser__tree :deep(.el-tree-node__content:has(.dp-snapshot-file-browser__load-more) > .el-checkbox) {
+  visibility: hidden;
 }
 
 .dp-snapshot-file-browser__tree-path,


### PR DESCRIPTION
## Problem and root cause

Snapshot directory browsing materialized the full Kopia listing in the Agent,
then truncated it at the backend's 200-item limit. The UI discarded pagination
metadata, so large directories appeared empty or incomplete and could not be
continued.

## Solution

Stream bounded Kopia directory pages in the Agent and propagate validated
cursors through the backend API. The snapshot browser now shows an explicit
partial-results message and a Load more action for root and expanded
directories, appending non-overlapping entries while preserving selection and
expansion state. Legacy Agent responses remain compatible.

## Validation

- Agent pagination regression tests passed, including cursor progression,
  bounds, duplicate prevention, and invalid cursor handling.
- Snapshot browser API regression tests passed 20/20 in an isolated temporary
  PostgreSQL database.
- Full Protection backend suite passed 397/397 in the normal extension runtime.
- Frontend tests passed 1435/1435 with the localStorage test file; production
  build and ESLint completed with zero errors.
- Spanish and Simplified Chinese language packages built and source-lock
  validation passed.
- Manual testing: passed.
- The complete Community backend suite was explicitly skipped by request. The
  macOS Agent path-suite failures are baseline-equivalent to origin/main.

## Risks and compatibility

The Agent accepts bounded numeric cursors and limits, while the backend keeps a
fallback for older Agents that return unpaged entries. No schema, migration,
credential, tenancy, or destructive-data behavior changes are included.

Fixes #782
