### PR TITLE
Refresh the development gateway automatically and refine CLI help

### DIFF
--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -427,7 +427,10 @@ EOF
 	if ! (
 		cd "${COMPOSE_DIR}"
 		compose_args=(up -d --pull never)
-		if [[ -n "${current_container}" && "${previous_image_id}" != "${desired_image_id}" ]]; then
+		if [[ "${HFL_FORCE_SIDECAR_RECREATE:-0}" == "1" ]]; then
+			hfl_step "Recreating the AI engine because a forced refresh was requested."
+			compose_args+=(--force-recreate)
+		elif [[ -n "${current_container}" && "${previous_image_id}" != "${desired_image_id}" ]]; then
 			hfl_step "Recreating the AI engine because its loaded image ID changed."
 			compose_args+=(--force-recreate)
 		fi

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -91,97 +91,154 @@ EXTENSION_SOURCES=()
 EXTENSION_SOURCES_CSV=""
 DEV_PUBLIC_URL=""
 DEV_ADMIN_PUBLIC_URL=""
-UPGRADE_GATEWAY=0
 
 usage() {
 	cat <<'USAGE'
-Usage: ./dev/stack.sh <command> [options]
+Usage:
+  ./dev/stack.sh <command> [options]
+  ./dev/stack.sh --print-config
+  ./dev/stack.sh --help
 
 Commands:
-  up                 Prepare dependencies and start the development stack
-  up|restart --upgrade-gateway
-                     Force reinstall the local Data Gateway host Agent from the
-                     newest published release (env: HFL_UPGRADE_GATEWAY=1)
-  down               Stop HyperFileLens + bundled SourceLens
-  down --hfl-only    Stop HyperFileLens only; leave SourceLens running
-  restart            Refresh dependencies/configuration and recreate changed services
-  restart --force    Clean caches and rebuild development dependency images without cache
-  status             Show HFL and SourceLens service state and published ports
-  doctor             Check host tools, configuration, images, permissions, and ports
-  smoke              Run pinned Playwright login/HMR smoke tests against the running stack
-  clean --runtime    Remove containers, Compose networks, and the frontend modules volume
-  clean --cache      Remove generated build cache and local development images
-  clean --data --yes Remove runtime databases, logs, and generated media
-  clean --all --yes  Remove runtime, cache, and data
+  up         Prepare dependencies and start the development stack
+  restart    Refresh dependencies and recreate changed services
+  down       Stop HyperFileLens and bundled SourceLens
+  status     Show HFL and SourceLens service state and published ports
+  doctor     Check host tools, configuration, images, permissions, and ports
+  smoke      Run pinned Playwright login and HMR smoke tests
+  clean      Remove selected development resources
 
-Prepare (up / restart) always includes:
-  .env (create from .env.example if missing)
-  Repository-pinned default TLS certificates
-  Unified Kopia binary matrix for Backend and Agent packages
-  backend source bind mount with automatic API/worker/scheduler restart
-  frontend source bind mount with Vite HMR and persistent node_modules
-  Website static artifact served by the shared Nginx gateway (no Website container)
-  agent publish (full bundle) → data/media/agent-releases/
-  local public Data Gateway auto-deploy when HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=true (default; Linux amd64)
-  SourceLens bundled mode (default): clone/update only as a build input, then run images
-  SourceLens external mode: prepare the Gateway LensNode bundle without touching the external stack
+Command-specific options:
+  restart:
+    --force       Rebuild development dependency images without cache
 
-SourceLens options (default: enabled for up/restart):
-  --no-sourcelens                  Skip SourceLens clone/build/start
-  --sourcelens-ref REF             SourceLens release tag in vX.Y.Z form
-  --sourcelens-git-url URL         Override SourceLens repository URL (env: SOURCELENS_GIT_URL)
+  down:
+    --hfl-only    Stop HyperFileLens and leave SourceLens running
 
-Extensions (optional overlay; community default = empty socket):
-  --extension-source SRC           Local path or git/HTTPS URL[+@ref]. Repeatable.
-                                     Not read from .env (prepare/packaging input only).
-                                     Private HTTPS uses --github-token or
-                                     HFL_EXTENSION_GIT_TOKEN (SSH uses your agent).
-  stack.sh materializes sources → build/docker-compose.extensions.yml.
-  Runtime containers see HFL_EXTENSIONS paths only (never git clone in api/web).
+  clean:
+    --runtime     Remove containers, Compose networks, and the frontend
+                  modules volume
+    --cache       Remove generated build caches and local development images
+    --data        Remove runtime databases, logs, and generated media
+                  (requires --yes)
+    --all         Remove runtime, cache, and data (requires --yes)
+    --yes         Confirm removal of runtime data
+
+Default up/restart workflow:
+  .env                Create from .env.example if missing
+  TLS certificates    Validate repository-pinned default certificates
+  Kopia               Prepare the unified Backend and Agent binary matrix
+  Backend             Bind-mount source with automatic API, worker, and
+                      scheduler restart
+  Frontend            Bind-mount source with Vite HMR and persistent
+                      node_modules
+  Website             Serve the static artifact through the shared Nginx
+                      gateway; no Website container
+  Agent               Publish the full bundle to data/media/agent-releases/
+  Platform Gateway    Install or refresh the local Agent and LensNode on
+                      Linux amd64 when HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=true
+  SourceLens          Use bundled mode by default; clone or update the source
+                      as a build input, then run the images. External mode
+                      prepares the Gateway LensNode bundle without touching
+                      the external stack
+
+SourceLens options (enabled by default for up/restart):
+  --no-sourcelens             Skip SourceLens clone, build, and start
+  --sourcelens-ref REF        SourceLens release tag in vX.Y.Z form
+  --sourcelens-git-url URL    Override the SourceLens repository URL
+                              (env: SOURCELENS_GIT_URL)
+
+Extensions (optional overlay; Open Source default: no extensions):
+  --extension-source SRC      Local path or Git/HTTPS URL[@REF]. Repeatable.
+                              Not read from .env (prepare/packaging input only).
+                              Private HTTPS uses --github-token or
+                              HFL_EXTENSION_GIT_TOKEN; SSH uses your agent.
+                              Materializes sources to
+                              build/docker-compose.extensions.yml.
+                              Runtime containers receive only materialized
+                              HFL_EXTENSIONS paths; API and Web never clone
+                              extension repositories at runtime.
 
 Deployment identity (optional for source deployments reached from another host):
-  --public-url URL                 Canonical tenant origin used by remote Agents and links.
-  --admin-public-url URL           Canonical Admin Console origin.
+  --public-url URL            Canonical tenant origin used by remote Agents
+                              and generated links
+  --admin-public-url URL      Canonical Admin Console origin
 
-Mirror options (Kopia fetch + Agent publishing + SourceLens git clone; env fallback):
-  --github-download-mirror URL     GitHub Git/release mirror (env: GITHUB_DOWNLOAD_MIRROR)
-  --github-token TOKEN             GitHub token for API/release fetch, private SourceLens
-                                     clone, and private extension git sources (env:
-                                     GITHUB_TOKEN / HFL_EXTENSION_GIT_TOKEN)
-  --docker-download-mirror URL     Docker Hub mirror for builds and runtime images (env: DOCKER_DOWNLOAD_MIRROR)
-  --apt-mirror URL                 Ubuntu apt mirror for NAS container (env: APT_MIRROR)
-  --ubuntu2404-arch ARCH           NAS deb arch for agent bundle: amd64 | arm64 | all (default: amd64)
-  --kopia-mode MODE                build or download
-  --kopia-git-url URL              Kopia source repository URL
-  --kopia-ref REF                  Kopia release ref in vX.Y.Z form
-  --go-proxy URL                   Go module proxy (env: GOPROXY)
-  --go-sumdb VALUE                 Go checksum database (env: GOSUMDB)
-  --pip-index-url URL              Python package index (env: PIP_INDEX_URL)
-  --pip-trusted-host HOST          Trusted pip host (env: PIP_TRUSTED_HOST)
-  --npm-registry URL               npm registry (env: NPM_REGISTRY)
-  --pull                           Refresh runtime images with valid local fallback
-  --offline                        Forbid registry, Git, and dependency network access
-  --pull-timeout SECONDS           Per-attempt Docker pull timeout (default: 180)
-  --pull-retries COUNT             Docker pull attempts (default: 2)
+Mirror and dependency options (environment variables are used as fallbacks):
+  --github-download-mirror URL    GitHub Git and release mirror
+                                  (env: GITHUB_DOWNLOAD_MIRROR)
+  --github-token TOKEN            GitHub API or release token, private
+                                  SourceLens clone token, and private extension
+                                  source token
+                                  (env: GITHUB_TOKEN or HFL_EXTENSION_GIT_TOKEN)
+  --docker-download-mirror URL    Docker Hub mirror for builds and runtime
+                                  images
+                                  (env: DOCKER_DOWNLOAD_MIRROR)
+  --apt-mirror URL                Ubuntu apt mirror for NAS dependencies
+                                  (env: APT_MIRROR)
+  --ubuntu2404-arch ARCH          Ubuntu 24.04 NAS package architecture:
+                                  amd64, arm64, or all (default: amd64)
+  --kopia-mode MODE               Kopia artifact mode: build or download
+  --kopia-git-url URL             Kopia source repository URL
+  --kopia-ref REF                 Kopia release ref in vX.Y.Z form
+  --go-proxy URL                  Go module proxy (env: GOPROXY)
+  --go-sumdb VALUE                Go checksum database (env: GOSUMDB)
+  --pip-index-url URL             Python package index (env: PIP_INDEX_URL)
+  --pip-trusted-host HOST         Trusted pip host (env: PIP_TRUSTED_HOST)
+  --npm-registry URL              npm registry (env: NPM_REGISTRY)
+  --pull                          Refresh runtime images with a valid local
+                                  fallback
+  --offline                       Forbid registry, Git, and dependency network
+                                  access
+  --pull-timeout SECONDS          Docker pull timeout per attempt (default: 180)
+  --pull-retries COUNT            Docker pull attempts (default: 2)
 
 Output options:
-  --log-file FILE                  Write complete stdout/stderr to FILE with timestamps
-                                     (default: build/logs/dev-<command>-<time>-<pid>.log)
-  --verbose                        Enable debug logs
-  --print-config                   Print effective non-secret configuration and exit
-  -h, --help                       Show this help
+  --log-file FILE             Write complete stdout and stderr to FILE with
+                              timestamps
+                              (default path:
+                              build/logs/dev-<command>-<time>-<pid>.log)
+  --verbose                   Enable debug logs
+  --print-config              Print effective non-secret configuration and exit
+  -h, --help                  Show this help
 
 Examples:
   ./dev/stack.sh up
-  ./dev/stack.sh up --extension-source ../hyperfilelens-ee
-  ./dev/stack.sh up --upgrade-gateway
-  ./dev/stack.sh up --public-url https://192.168.8.69:11443 \
-    --admin-public-url https://192.168.8.69:11444
+
+  ./dev/stack.sh up --public-url https://192.168.8.66:11443 \
+    --admin-public-url https://192.168.8.66:11444
+
   ./dev/stack.sh up --ubuntu2404-arch amd64
+
   ./dev/stack.sh down
+
+  ./dev/stack.sh down --hfl-only
+
   ./dev/stack.sh restart
+
   ./dev/stack.sh restart --force
+
+  ./dev/stack.sh clean --runtime
+
+  ./dev/stack.sh clean --cache
+
+  ./dev/stack.sh clean --data --yes
+
+  ./dev/stack.sh clean --all --yes
+
+  # Open Source Edition
   ./dev/stack.sh up \
+    --github-download-mirror https://ghfast.top \
+    --docker-download-mirror docker.m.daocloud.io \
+    --apt-mirror https://mirrors.tuna.tsinghua.edu.cn \
+    --go-proxy https://goproxy.cn,direct \
+    --go-sumdb sum.golang.google.cn \
+    --pip-index-url https://pypi.tuna.tsinghua.edu.cn/simple \
+    --npm-registry https://registry.npmmirror.com
+
+  # Enterprise Edition
+  ./dev/stack.sh up \
+    --extension-source ../hyperfilelens-ee \
     --github-download-mirror https://ghfast.top \
     --docker-download-mirror docker.m.daocloud.io \
     --apt-mirror https://mirrors.tuna.tsinghua.edu.cn \
@@ -294,7 +351,6 @@ docker_pull_timeout=${DOCKER_PULL_TIMEOUT}
 docker_pull_retries=${DOCKER_PULL_RETRIES}
 offline=${DEV_OFFLINE}
 force_pull=${FORCE_PULL}
-upgrade_gateway=${UPGRADE_GATEWAY}
 state_file=${STATE_FILE#${ROOT}/}
 log_file=${LOG_FILE:-<none>}
 verbose=${VERBOSE}
@@ -1372,11 +1428,7 @@ platform_gateway_auto_deploy_enabled() {
 # Failures warn instead of aborting stack up so Darwin/non-root hosts stay usable.
 ensure_local_platform_gateway_dev() {
 	if ! platform_gateway_auto_deploy_enabled; then
-		if [[ "${UPGRADE_GATEWAY}" -eq 1 ]]; then
-			warn "--upgrade-gateway ignored: local platform Gateway auto-deploy is disabled (HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=false)"
-		else
-			log "Local platform Gateway auto-deploy is disabled (HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=false)"
-		fi
+		log "Local platform Gateway auto-deploy is disabled (HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=false)"
 		return 0
 	fi
 	if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
@@ -1501,9 +1553,9 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 	# --reinstall mirrors helper InstallState.Installed, which stat()s the agent
 	# binary (not agent.env), so gate on the same path (-e) to avoid a misleading error.
 	local agent_bin="/opt/hyperfilelens-agent/bin/hfl-agent"
-	if [[ "${UPGRADE_GATEWAY}" -eq 1 && -e "${agent_bin}" ]]; then
+	if [[ -e "${agent_bin}" ]]; then
 		gateway_args+=(--reinstall)
-		hfl_log_info "Refreshing local Platform Data Gateway host Agent (upgrade requested)"
+		hfl_log_info "Refreshing local Platform Data Gateway host Agent from the current development bundle"
 	fi
 
 	hfl_log_info "Running local Platform Data Gateway installer"
@@ -1524,6 +1576,7 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 		HFL_WSS_URL="${wss_url}" \
 		HFL_INSECURE_TLS=1 \
 		HFL_FORCE_SIDECAR_INSTALL=1 \
+		HFL_FORCE_SIDECAR_RECREATE=1 \
 		HFL_OUTPUT=json \
 		HFL_ENROLL_NO_COLOR=1 \
 		HFL_NO_BANNER=1 \
@@ -2065,9 +2118,6 @@ main() {
 
 	local cmd=""
 	local restart_force=0
-	if [[ "${HFL_UPGRADE_GATEWAY:-0}" == "1" ]]; then
-		UPGRADE_GATEWAY=1
-	fi
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -2078,10 +2128,6 @@ main() {
 			;;
 		--force)
 			restart_force=1
-			shift
-			;;
-		--upgrade-gateway)
-			UPGRADE_GATEWAY=1
 			shift
 			;;
 		--runtime | --cache | --data | --all)
@@ -2169,9 +2215,6 @@ main() {
 
 	if [[ "${restart_force}" -eq 1 && "${cmd}" != "restart" ]]; then
 		die "--force is only valid with restart" 2
-	fi
-	if [[ "${UPGRADE_GATEWAY}" -eq 1 && "${cmd}" != "up" && "${cmd}" != "restart" ]]; then
-		die "--upgrade-gateway is only valid with up or restart" 2
 	fi
 	if [[ "${HFL_ONLY_DOWN}" -eq 1 && "${cmd}" != "down" ]]; then
 		die "--hfl-only is only valid with down" 2

--- a/tools/quality/test-dev-stack-upgrade.sh
+++ b/tools/quality/test-dev-stack-upgrade.sh
@@ -156,6 +156,7 @@ refresh_website_web_mount
 cmd_up_body="$(sed -n '/^cmd_up()/,/^}/p' "${ROOT_REPO}/dev/stack.sh")"
 cmd_restart_body="$(sed -n '/^cmd_restart()/,/^}/p' "${ROOT_REPO}/dev/stack.sh")"
 run_dev_migration_gate_body="$(sed -n '/^run_dev_migration_gate()/,/^}/p' "${ROOT_REPO}/dev/stack.sh")"
+gateway_refresh_body="$(sed -n '/^ensure_local_platform_gateway_dev()/,/^}/p' "${ROOT_REPO}/dev/stack.sh")"
 grep -F 'refresh_website_web_mount' <<<"${cmd_up_body}" >/dev/null
 grep -F 'refresh_website_web_mount' <<<"${cmd_restart_body}" >/dev/null
 for command_body in "${cmd_up_body}" "${cmd_restart_body}"; do
@@ -167,7 +168,25 @@ for command_body in "${cmd_up_body}" "${cmd_restart_body}"; do
 	model_repair_line="$(grep -nF 'repair_existing_multimodal_model' <<<"${command_body}" | cut -d: -f1)"
 	[[ -n "${model_repair_line}" ]]
 	((application_line < model_repair_line))
+	grep -F 'ensure_local_platform_gateway_dev' <<<"${command_body}" >/dev/null
 done
+
+# An enabled development Gateway always consumes the current Agent and LensNode
+# artifacts. The auto-deploy setting remains the only public control: when it is
+# disabled, the function returns before inspecting or changing the host runtime.
+if grep -En 'UPGRADE_GATEWAY|HFL_UPGRADE_GATEWAY|upgrade-gateway' \
+	"${ROOT_REPO}/dev/stack.sh" >/dev/null; then
+	printf 'ERROR: obsolete manual Platform Gateway refresh control remains\n' >&2
+	exit 1
+fi
+grep -F 'if [[ -e "${agent_bin}" ]]; then' <<<"${gateway_refresh_body}" >/dev/null
+grep -F 'gateway_args+=(--reinstall)' <<<"${gateway_refresh_body}" >/dev/null
+grep -F 'HFL_FORCE_SIDECAR_RECREATE=1 \' <<<"${gateway_refresh_body}" >/dev/null
+disabled_line="$(grep -nF 'if ! platform_gateway_auto_deploy_enabled; then' <<<"${gateway_refresh_body}" | cut -d: -f1)"
+disabled_return_line="$(grep -nF 'return 0' <<<"${gateway_refresh_body}" | cut -d: -f1 | head -n 1)"
+helper_line="$(grep -nF 'local helper=' <<<"${gateway_refresh_body}" | cut -d: -f1)"
+[[ -n "${disabled_line}" && -n "${disabled_return_line}" && -n "${helper_line}" ]]
+((disabled_line < disabled_return_line && disabled_return_line < helper_line))
 repair_model_body="$(sed -n '/^repair_existing_multimodal_model()/,/^}/p' "${ROOT_REPO}/dev/stack.sh")"
 grep -F '{"role":"multimodal","repair_existing":true}' <<<"${repair_model_body}" >/dev/null
 grep -F 'ensure_platform_ai_model' <<<"${repair_model_body}" >/dev/null

--- a/tools/quality/test-gateway-lifecycle-upgrade.sh
+++ b/tools/quality/test-gateway-lifecycle-upgrade.sh
@@ -260,6 +260,78 @@ EOF
 	grep -Fx -- '-p hyperfilelens-gateway down --remove-orphans' "${calls}" >/dev/null
 }
 
+test_forced_sidecar_recreate_is_opt_in() {
+	local fake_compose="${tmp}/fake-refresh-compose" fake_docker="${tmp}/fake-refresh-docker"
+	local calls="${tmp}/refresh-compose-calls"
+	cat >"${fake_compose}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${TEST_COMPOSE_CALLS}"
+case "$*" in
+  *" config --quiet") exit 0 ;;
+  "-p hyperfilelens-gateway ps -q lensnode") printf '%s\n' current-lensnode ;;
+  "-p hyperfilelens-gateway up -d --pull never"|\
+  "-p hyperfilelens-gateway up -d --pull never --force-recreate") exit 0 ;;
+  *) printf 'unexpected compose invocation: %s\n' "$*" >&2; exit 90 ;;
+esac
+EOF
+	cat >"${fake_docker}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "image inspect desired:test") exit 0 ;;
+  "image inspect --format {{.Id}} desired:test") printf '%s\n' sha256:same ;;
+  "inspect --format {{.Image}} current-lensnode") printf '%s\n' sha256:same ;;
+  "inspect --format {{.State.Running}} current-lensnode") printf '%s\n' true ;;
+  *) printf 'unexpected docker invocation: %s\n' "$*" >&2; exit 91 ;;
+esac
+EOF
+	chmod 755 "${fake_compose}" "${fake_docker}"
+
+	run_refresh_case() (
+		local force_refresh="$1" compose_dir="${tmp}/sidecar-refresh-$1/runtime/lensnode"
+		mkdir -p "${compose_dir}" "${tmp}/sidecar-refresh-$1/workspace/org-42/data"
+		# shellcheck disable=SC1090
+		source <(sed -n '/^install_docker_sidecar() {/,/^}/p' "${SIDECAR_INSTALLER}")
+		COMPOSE_DIR="${compose_dir}"
+		COMPOSE_PROJECT=hyperfilelens-gateway
+		SENTRY_PRIVACY_FILE="${compose_dir}/hfl-sentry-sitecustomize.py"
+		HFL_WORKSPACE_ROOT="${tmp}/sidecar-refresh-$1/workspace/org-42/data"
+		HFL_SOURCELENS_MOUNTPOINT="${HFL_WORKSPACE_ROOT}/.sourcelens"
+		HFL_SOURCELENS_STATE_ROOT="${tmp}/sidecar-refresh-$1/workspace/org-42/.hyperfilelens/sourcelens"
+		HFL_GATEWAY_TRASH_ROOT="${HFL_WORKSPACE_ROOT}/.hyperfilelens-trash"
+		LENSNODE_TOKEN=test-token LENSNODE_NAME=test-gateway
+		LENS_CONTAINER_URL=https://host.docker.internal/sourcelens SENTRY_ENABLED=false HFL_INSECURE_TLS=1
+		if [[ "${force_refresh}" == "forced" ]]; then
+			HFL_FORCE_SIDECAR_RECREATE=1
+		else
+			unset HFL_FORCE_SIDECAR_RECREATE
+		fi
+		hfl_step() { :; }
+		hfl_ok() { :; }
+		hfl_warn() { :; }
+		hfl_fail() { exit "${2:-1}"; }
+		lens_url_needs_extra_hosts() { return 0; }
+		resolve_compose() { COMPOSE=("${fake_compose}"); }
+		docker() { "${fake_docker}" "$@"; }
+		remove_owned_legacy_gateway_containers() { :; }
+		export TEST_COMPOSE_CALLS="${calls}"
+		install_docker_sidecar desired:test
+	)
+
+	: >"${calls}"
+	run_refresh_case default
+	grep -Fx -- '-p hyperfilelens-gateway up -d --pull never' "${calls}" >/dev/null
+	if grep -F -- '--force-recreate' "${calls}" >/dev/null; then
+		printf 'normal sidecar convergence forced recreation for an unchanged image\n' >&2
+		return 1
+	fi
+
+	: >"${calls}"
+	run_refresh_case forced
+	grep -Fx -- '-p hyperfilelens-gateway up -d --pull never --force-recreate' "${calls}" >/dev/null
+}
+
 test_upgrade_keeps_existing_sidecar_until_replacement_starts() {
 	local body
 	body="$(sed -n '/^cmd_upgrade_sidecar() {/,/^}/p' "${LIFECYCLE}")"
@@ -466,6 +538,7 @@ test_failed_staging_reports_and_preserves_sidecar
 test_legacy_layout_adoption_is_retryable
 test_sidecar_start_failure_restores_previous_compose
 test_first_sidecar_start_failure_cleans_partial_project
+test_forced_sidecar_recreate_is_opt_in
 test_upgrade_keeps_existing_sidecar_until_replacement_starts
 test_lifecycle_accepts_persisted_node_credential
 test_lifecycle_rejects_relative_persisted_agent_root


### PR DESCRIPTION
## Summary

- refresh the installer-managed development Agent and LensNode on every `up` and `restart` when Platform Gateway auto-deploy is enabled
- remove the obsolete manual Gateway upgrade option while preserving the auto-deploy opt-out and production convergence behavior
- reorganize and align the development stack help output, including complete Open Source and Enterprise examples
- add regression coverage for development refresh behavior and opt-in sidecar recreation

## Validation

- `./tools/quality/test-dev-stack-upgrade.sh`
- `./tools/quality/test-gateway-lifecycle-upgrade.sh`
- `./tools/quality/test-platform-gateway-auto-deploy.sh`
- `./tools/quality/test-lifecycle-output-contract.sh`
- `./tools/quality/check-release-contracts.sh`
- `bash -n dev/stack.sh`
- `git diff --check`