### PR TITLE
fix(protection): retain transfer metrics across sparse samples

### DIFF
--- a/src/backend/apps/protection/services/progress/lane_sampler.py
+++ b/src/backend/apps/protection/services/progress/lane_sampler.py
@@ -7,7 +7,11 @@ from django.utils import timezone
 
 _MIN_SPEED_BPS = 100
 _MIN_SAMPLE_GAP_SECONDS = 2.0
-_METRIC_FRESHNESS_SECONDS = 6.0
+# Kopia can remain quiet between parsed progress events even while a transfer
+# is healthy. Retain the last measured throughput across a bounded number of
+# nominal three-second reporting intervals so two-second UI polling does not
+# make speed and ETA flicker, while genuinely stale metrics still expire.
+_METRIC_FRESHNESS_SECONDS = 30.0
 _KOPIA_ETA_MIN_REMAINING_RATIO = 0.1
 _KOPIA_ETA_MAX_COMPUTED_RATIO = 3.0
 
@@ -105,6 +109,18 @@ def apply_speed_and_eta(
         processing_speed_bps = None
         upload_speed_bps = None
 
+    # A Kopia snapshot can be valid while omitting throughput fields (for
+    # example, during a phase transition). Keep the last measured values in
+    # the task-scoped sample so read-only runtime refreshes do not turn a
+    # transiently sparse snapshot into an empty speed/ETA display.
+    if metrics_fresh:
+        if processing_speed_bps is None:
+            processing_speed_bps = _optional_int(prev, "processing_speed_bps")
+            processing_speed_source = prev.get("processing_speed_source")
+        if upload_speed_bps is None:
+            upload_speed_bps = _optional_int(prev, "upload_speed_bps")
+            upload_speed_source = prev.get("upload_speed_source")
+
     prev_processing = int(prev.get("processing_counter") or prev.get("counter") or prev.get("bytes_done") or 0)
     prev_uploaded = int(prev.get("uploaded_counter") or 0)
     counter_at = metrics_at or now
@@ -187,6 +203,10 @@ def apply_speed_and_eta(
             "sampled_at": now.isoformat(),
             "counter_sampled_at": counter_at.isoformat(),
             "_max_bytes_total": max_total,
+            "processing_speed_bps": processing_speed_bps,
+            "processing_speed_source": processing_speed_source,
+            "upload_speed_bps": upload_speed_bps,
+            "upload_speed_source": upload_speed_source,
         }
     elif prev:
         result["last_sample"] = dict(prev)
@@ -199,5 +219,9 @@ def apply_speed_and_eta(
             "sampled_at": now.isoformat(),
             "counter_sampled_at": counter_at.isoformat(),
             "_max_bytes_total": max_total,
+            "processing_speed_bps": processing_speed_bps,
+            "processing_speed_source": processing_speed_source,
+            "upload_speed_bps": upload_speed_bps,
+            "upload_speed_source": upload_speed_source,
         }
     return result

--- a/src/backend/apps/protection/tests/test_bytes_sanity.py
+++ b/src/backend/apps/protection/tests/test_bytes_sanity.py
@@ -144,9 +144,111 @@ class LaneSamplerTests(SimpleTestCase):
         self.assertEqual(result["upload_speed_bps"], 0)
         self.assertEqual(result["speed_bps"], 0)
 
-    def test_stale_speed_and_eta_expire(self):
+    def test_active_backup_metrics_survive_short_progress_gap(self):
         now = timezone.now()
         sampled_at = now - timedelta(seconds=7)
+        result = apply_speed_and_eta(
+            lane={
+                "progress_schema_version": 2,
+                "kopia_phase": "processing",
+                "processed_bytes": 2_000,
+                "uploaded_bytes": 100,
+                "bytes_done": 2_000,
+                "bytes_total": 10_000,
+                "bytes_total_known": True,
+                "processing_speed_bps": 1_000,
+                "upload_speed_bps": 100,
+                "kopia_eta_seconds": 8,
+                "metrics_sampled_at": sampled_at.isoformat(),
+            },
+            sample={"sampled_at": sampled_at.isoformat(), "processing_counter": 2_000},
+            now=now,
+            persist_sample=False,
+        )
+        self.assertEqual(result["processing_speed_bps"], 1_000)
+        self.assertEqual(result["upload_speed_bps"], 100)
+        self.assertEqual(result["eta_seconds"], 8)
+
+    def test_active_restore_metrics_survive_short_progress_gap(self):
+        now = timezone.now()
+        sampled_at = now - timedelta(seconds=7)
+        result = apply_speed_and_eta(
+            lane={
+                "progress_schema_version": 2,
+                "kopia_phase": "restoring",
+                "processed_bytes": 2_000,
+                "uploaded_bytes": 2_000,
+                "bytes_done": 2_000,
+                "bytes_total": 10_000,
+                "bytes_total_known": True,
+                "processing_speed_bps": 1_000,
+                "upload_speed_bps": 100,
+                "kopia_eta_seconds": 80,
+                "metrics_sampled_at": sampled_at.isoformat(),
+            },
+            sample={"sampled_at": sampled_at.isoformat(), "processing_counter": 2_000},
+            now=now,
+            persist_sample=False,
+        )
+        self.assertEqual(result["upload_speed_bps"], 100)
+        self.assertEqual(result["speed_bps"], 100)
+        self.assertEqual(result["eta_seconds"], 80)
+
+    def test_sparse_active_snapshot_reuses_last_valid_speed_and_recomputes_eta(self):
+        now = timezone.now()
+        sampled_at = now - timedelta(seconds=7)
+        result = apply_speed_and_eta(
+            lane={
+                "progress_schema_version": 2,
+                "kopia_phase": "processing",
+                "processed_bytes": 3_000,
+                "bytes_done": 3_000,
+                "bytes_total": 10_000,
+                "bytes_total_known": True,
+                "metrics_sampled_at": sampled_at.isoformat(),
+            },
+            sample={
+                "sampled_at": sampled_at.isoformat(),
+                "processing_counter": 2_000,
+                "processing_speed_bps": 1_000,
+                "processing_speed_source": "kopia",
+            },
+            now=now,
+            persist_sample=False,
+        )
+        self.assertEqual(result["processing_speed_bps"], 1_000)
+        self.assertEqual(result["processing_speed_source"], "kopia")
+        self.assertEqual(result["eta_seconds"], 7)
+
+    def test_sparse_restore_snapshot_reuses_last_valid_upload_speed(self):
+        now = timezone.now()
+        sampled_at = now - timedelta(seconds=7)
+        result = apply_speed_and_eta(
+            lane={
+                "progress_schema_version": 2,
+                "kopia_phase": "restoring",
+                "processed_bytes": 3_000,
+                "bytes_done": 3_000,
+                "bytes_total": 10_000,
+                "bytes_total_known": True,
+                "metrics_sampled_at": sampled_at.isoformat(),
+            },
+            sample={
+                "sampled_at": sampled_at.isoformat(),
+                "processing_counter": 2_000,
+                "upload_speed_bps": 500,
+                "upload_speed_source": "kopia",
+            },
+            now=now,
+            persist_sample=False,
+        )
+        self.assertEqual(result["upload_speed_bps"], 500)
+        self.assertEqual(result["speed_bps"], 500)
+        self.assertEqual(result["eta_seconds"], 14)
+
+    def test_stale_speed_and_eta_expire_after_retention_window(self):
+        now = timezone.now()
+        sampled_at = now - timedelta(seconds=31)
         result = apply_speed_and_eta(
             lane={
                 "progress_schema_version": 2,


### PR DESCRIPTION
## Problem and root cause

Active backup and restore tasks intermittently lost their speed and estimated
remaining-time metrics between progress refreshes. The shared progress sampler
treated sparse Kopia snapshots as having no throughput and persisted only
counters, so a valid snapshot could overwrite the last usable metrics.

## Solution

Persist the latest valid processing and upload speeds with the task progress
sample. Reuse those values when a fresh active snapshot omits throughput fields,
and recompute ETA from the current remaining bytes. Keep a bounded 30-second
freshness window and continue suppressing ETA for finalizing and terminal
phases. Backup ETA remains based on logical processing speed; restore ETA uses
restore transfer speed.

## Validation

- Targeted Django regression tests: `apps.protection.tests.test_bytes_sanity`
  (18 tests passed).
- Changed-file Ruff check passed.
- `git diff --check` passed.
- English source boundary check passed.
- Manual testing: passed for backup and restore task progress.
- Complete Community backend test suite: skipped at the user's explicit
  request; it is outside candidate and broad validation accounting.

## Risks and compatibility

The retention window is bounded, so genuinely stale samples still expire.
No API, schema, migration, permission, tenancy, Agent, dependency, or
destructive-data behavior changes are introduced.

Fixes #1004
