### PR TITLE
fix(storage): preserve capacity samples during contention

### DIFF
--- a/src/backend/apps/storage/services/internal/repository_health.py
+++ b/src/backend/apps/storage/services/internal/repository_health.py
@@ -182,6 +182,7 @@ def dispatch_automatic_repository_observation(
     repository: Repository,
     retry_attempt: int = 0,
     include_usage: bool = False,
+    recorded_at=None,
 ) -> list[NodeTask] | None:
     """Serialize and dispatch one repository observation generation."""
 
@@ -222,11 +223,16 @@ def dispatch_automatic_repository_observation(
                 repository=current,
                 retry_attempt=retry_attempt,
                 include_usage=include_usage,
+                recorded_at=recorded_at,
             )
 
 
 def _dispatch_automatic_repository_observation_locked(
-    *, repository: Repository, retry_attempt: int = 0, include_usage: bool
+    *,
+    repository: Repository,
+    retry_attempt: int = 0,
+    include_usage: bool,
+    recorded_at=None,
 ) -> list[NodeTask]:
     """Dispatch durable repository health/usage observations without waiting.
 
@@ -313,6 +319,7 @@ def _dispatch_automatic_repository_observation_locked(
                 direct_nas=False,
                 transport_unknown=False,
                 include_usage=include_usage,
+                recorded_at=recorded_at,
             )
         ]
 
@@ -437,6 +444,7 @@ def _dispatch_automatic_repository_observation_locked(
                 direct_nas=True,
                 transport_unknown=len(online_nodes) < len(nodes),
                 include_usage=include_usage,
+                recorded_at=recorded_at,
                 usage_active=(
                     include_usage
                     and claim.state == RepositoryLocationClaim.State.OWNED
@@ -474,6 +482,7 @@ def _dispatch_repository_observation_task(
     direct_nas: bool,
     transport_unknown: bool,
     include_usage: bool,
+    recorded_at,
     usage_active: bool = True,
 ) -> NodeTask:
     handle = run_agent_task_async(
@@ -495,6 +504,9 @@ def _dispatch_repository_observation_task(
             "direct_nas": direct_nas,
             "transport_unknown": transport_unknown,
             "include_usage": include_usage,
+            "usage_recorded_at": (
+                recorded_at.isoformat() if include_usage and recorded_at else ""
+            ),
             "failure_affects_health": not include_usage,
             "usage_active": usage_active,
             "observation_group_id": group_id,
@@ -640,6 +652,10 @@ def _project_repository_observation_success(
         repository_subdir=str(persisted.get("repository_subdir") or ""),
     )
     checked_at = node_task.updated_at or timezone.now()
+    recorded_at = _repository_observation_recorded_at(
+        persisted=persisted,
+        fallback=checked_at,
+    )
     if persisted.get("direct_nas") is True:
         from apps.storage.services.internal.repository_usage import (
             _direct_nas_agent_config_groups,
@@ -672,6 +688,7 @@ def _project_repository_observation_success(
             _aggregate_direct_nas_observation(
                 repository=repository,
                 checked_at=checked_at,
+                recorded_at=recorded_at,
             )
         else:
             Repository.objects.filter(pk=repository.id).update(
@@ -695,7 +712,7 @@ def _project_repository_observation_success(
                     locked,
                     probe,
                     checked_at=checked_at,
-                    recorded_at=checked_at,
+                    recorded_at=recorded_at,
                 )
             Repository.objects.filter(pk=locked.id).update(
                 health=Repository.Health.ONLINE,
@@ -764,6 +781,11 @@ def _project_repository_observation_failure(
 ) -> bool:
     include_usage = persisted.get("include_usage") is True
     failure_affects_health = persisted.get("failure_affects_health", True) is True
+    checked_at = node_task.updated_at or timezone.now()
+    recorded_at = _repository_observation_recorded_at(
+        persisted=persisted,
+        fallback=checked_at,
+    )
     if persisted.get("direct_nas") is not True:
         if include_usage:
             apply_repository_usage_probe(
@@ -773,8 +795,8 @@ def _project_repository_observation_failure(
                     None,
                     error=str(node_task.last_error or "Repository observation failed.")[:1000],
                 ),
-                checked_at=node_task.updated_at or timezone.now(),
-                recorded_at=node_task.updated_at or timezone.now(),
+                checked_at=checked_at,
+                recorded_at=recorded_at,
             )
         if not failure_affects_health and not fail_immediately:
             return True
@@ -826,7 +848,14 @@ def _project_repository_observation_failure(
     )
 
 
-def _aggregate_direct_nas_observation(*, repository: Repository, checked_at) -> None:
+def _repository_observation_recorded_at(*, persisted: dict[str, Any], fallback):
+    value = parse_datetime(str(persisted.get("usage_recorded_at") or ""))
+    return value or fallback
+
+
+def _aggregate_direct_nas_observation(
+    *, repository: Repository, checked_at, recorded_at
+) -> None:
     shards = list(
         RepositoryUsageShard.objects.filter(
             organization_id=repository.organization_id,
@@ -855,7 +884,7 @@ def _aggregate_direct_nas_observation(*, repository: Repository, checked_at) -> 
                 ),
             ),
             checked_at=checked_at,
-            recorded_at=checked_at,
+            recorded_at=recorded_at,
         )
     Repository.objects.filter(pk=repository.id).update(
         health=Repository.Health.ONLINE,

--- a/src/backend/apps/storage/services/internal/repository_usage.py
+++ b/src/backend/apps/storage/services/internal/repository_usage.py
@@ -1148,6 +1148,7 @@ def _sync_repository_usage_candidates(
                 node_tasks = dispatch_automatic_repository_observation(
                     repository=repository,
                     include_usage=True,
+                    recorded_at=recorded_at,
                 )
                 observations_dispatched += len(node_tasks or [])
             else:

--- a/src/backend/apps/storage/tasks.py
+++ b/src/backend/apps/storage/tasks.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import CharField, Exists, OuterRef, Q
 from django.db.models.functions import Cast
 from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 
 from common.observability.celery_context import logged_celery_task
 
@@ -79,6 +80,10 @@ from apps.task.services.recovery import (
 )
 
 
+_REPOSITORY_USAGE_CAPACITY_RETRY_DELAY_SECONDS = 15
+_REPOSITORY_USAGE_CAPACITY_MAX_RETRIES = 3
+
+
 logger = logging.getLogger(__name__)
 
 _REPOSITORY_HEALTH_LOCK_TIMEOUT_SECONDS = 300
@@ -140,7 +145,14 @@ def enqueue_startup_repository_health_checks(sender=None, **_kwargs) -> None:
 @shared_task(name="apps.storage.tasks.reconcile_storage_repositories")
 @logged_celery_task(
     name="apps.storage.tasks.reconcile_storage_repositories",
-    trace_keys=("organization_id", "repo_type", "limit", "force", "background"),
+    trace_keys=(
+        "organization_id",
+        "repo_type",
+        "limit",
+        "force",
+        "background",
+        "capacity_retry_attempt",
+    ),
 )
 def reconcile_storage_repositories(
     *,
@@ -151,8 +163,16 @@ def reconcile_storage_repositories(
     force: bool = False,
     stale_after_seconds: int | None = 900,
     background: bool = False,
+    capacity_retry_attempt: int = 0,
+    sample_recorded_at: str | None = None,
 ):
     """Refresh repository capacity and usage metrics for dashboards and alerts."""
+    recorded_at = (
+        parse_datetime(sample_recorded_at) if sample_recorded_at else timezone.now()
+    )
+    if recorded_at is None:
+        raise ValueError("sample_recorded_at must be an ISO 8601 datetime.")
+    serialized_recorded_at = recorded_at.isoformat()
     background_lease = None
     if background:
         background_lease = try_acquire_background_storage_capacity(
@@ -160,6 +180,23 @@ def reconcile_storage_repositories(
             identity=str(uuid4()),
         )
         if background_lease is None:
+            retry_attempt = max(0, int(capacity_retry_attempt or 0))
+            retry_scheduled = retry_attempt < _REPOSITORY_USAGE_CAPACITY_MAX_RETRIES
+            if retry_scheduled:
+                reconcile_storage_repositories.apply_async(
+                    kwargs={
+                        "organization_id": organization_id,
+                        "repository_ids": repository_ids,
+                        "repo_type": repo_type,
+                        "limit": limit,
+                        "force": force,
+                        "stale_after_seconds": stale_after_seconds,
+                        "background": True,
+                        "capacity_retry_attempt": retry_attempt + 1,
+                        "sample_recorded_at": serialized_recorded_at,
+                    },
+                    countdown=_REPOSITORY_USAGE_CAPACITY_RETRY_DELAY_SECONDS,
+                )
             return {
                 "repositories_scanned": 0,
                 "repositories_synced": 0,
@@ -172,10 +209,11 @@ def reconcile_storage_repositories(
                 "snapshots_marked_deleted": 0,
                 "observations_dispatched": 0,
                 "status": "deferred_background_capacity",
+                "capacity_retry_attempt": retry_attempt,
+                "retry_scheduled": retry_scheduled,
             }
 
     def synchronize() -> dict:
-        recorded_at = timezone.now()
         if organization_id is not None:
             return sync_organization_repositories(
                 organization_id=int(organization_id),

--- a/src/backend/apps/storage/tests/test_repository_health_tasks.py
+++ b/src/backend/apps/storage/tests/test_repository_health_tasks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone as dt_timezone
 from types import SimpleNamespace
 from unittest import mock
 from uuid import uuid4
@@ -12,6 +12,7 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from apps.iam.models import Organization
+from apps.monitor.models import RepositoryUsageMetric
 from apps.node.models import Node, NodeTask
 from apps.node.models.base import NodeRole
 from apps.protection.models import BackupConfig
@@ -963,6 +964,14 @@ class RepositoryHealthResultProjectionTests(TestCase):
 
     def test_automatic_probe_success_projects_health_and_usage_together(self):
         task = self._repo_status_task()
+        sample_recorded_at = datetime(
+            2026,
+            9,
+            3,
+            5,
+            45,
+            tzinfo=dt_timezone.utc,
+        )
         task.payload = {
             "automatic_health_probe": True,
             "repository_id": self.repository.id,
@@ -972,6 +981,7 @@ class RepositoryHealthResultProjectionTests(TestCase):
             "legacy_compatibility_allowed": False,
             "direct_nas": False,
             "include_usage": True,
+            "usage_recorded_at": sample_recorded_at.isoformat(),
             "failure_affects_health": False,
         }
         task.result = {
@@ -1004,6 +1014,66 @@ class RepositoryHealthResultProjectionTests(TestCase):
         self.assertEqual(
             self.repository.usage_probe_status,
             Repository.MetricProbeStatus.SUCCESS,
+        )
+        self.assertEqual(
+            RepositoryUsageMetric.objects.get(
+                repository=self.repository,
+            ).recorded_at,
+            sample_recorded_at,
+        )
+
+    def test_automatic_probe_failure_projects_usage_at_original_sample_time(self):
+        task = self._repo_status_task()
+        sample_recorded_at = datetime(
+            2026,
+            9,
+            3,
+            5,
+            45,
+            tzinfo=dt_timezone.utc,
+        )
+        task.status = NodeTask.Status.FAILED
+        task.accepted_at = timezone.now()
+        task.last_error = "repository usage probe failed"
+        task.result = {"error_code": "REPOSITORY_STATUS_FAILED"}
+        task.payload = {
+            "automatic_health_probe": True,
+            "repository_id": self.repository.id,
+            "repository_revision": repository_observation_revision(self.repository),
+            "retry_attempt": 0,
+            "repository_subdir": "",
+            "legacy_compatibility_allowed": False,
+            "direct_nas": False,
+            "include_usage": True,
+            "usage_recorded_at": sample_recorded_at.isoformat(),
+            "failure_affects_health": False,
+        }
+        task.correlation_type = REPOSITORY_HEALTH_PROBE_CORRELATION_TYPE
+        task.save(
+            update_fields=[
+                "status",
+                "accepted_at",
+                "last_error",
+                "result",
+                "payload",
+                "correlation_type",
+                "updated_at",
+            ]
+        )
+
+        projected = project_repository_health_from_agent_result(node_task=task)
+
+        self.assertTrue(projected)
+        self.assertEqual(
+            RepositoryUsageMetric.objects.get(
+                repository=self.repository,
+            ).recorded_at,
+            sample_recorded_at,
+        )
+        self.repository.refresh_from_db()
+        self.assertEqual(
+            self.repository.usage_probe_status,
+            Repository.MetricProbeStatus.FAILED,
         )
 
     def test_automatic_probe_result_is_fenced_by_physical_target_revision(self):
@@ -1189,10 +1259,19 @@ class AutomaticDirectNASObservationTests(TestCase):
             return SimpleNamespace(task=task, task_id=task.id)
 
         run_async.side_effect = create_handle
+        sample_recorded_at = datetime(
+            2026,
+            9,
+            3,
+            5,
+            45,
+            tzinfo=dt_timezone.utc,
+        )
 
         tasks = dispatch_automatic_repository_observation(
             repository=self.repository,
             include_usage=True,
+            recorded_at=sample_recorded_at,
         )
 
         self.assertEqual({task.node_id for task in tasks or []}, {node_a.id, node_b.id})
@@ -1200,6 +1279,10 @@ class AutomaticDirectNASObservationTests(TestCase):
         for task in tasks or []:
             self.assertNotIn("kopia_password", str(task.payload))
             self.assertTrue(task.payload["direct_nas"])
+            self.assertEqual(
+                task.payload["usage_recorded_at"],
+                sample_recorded_at.isoformat(),
+            )
             self.assertEqual(
                 set(task.payload["expected_node_ids"]),
                 {node_a.id, node_b.id},
@@ -1265,6 +1348,14 @@ class AutomaticDirectNASObservationTests(TestCase):
         node_a = self._node("agent-a")
         node_b = self._node("agent-b")
         group_id = "observation-group"
+        sample_recorded_at = datetime(
+            2026,
+            9,
+            3,
+            5,
+            45,
+            tzinfo=dt_timezone.utc,
+        )
         revision = repository_observation_revision(self.repository)
         tasks = []
         for node, usage in ((node_a, 100), (node_b, 250)):
@@ -1282,6 +1373,7 @@ class AutomaticDirectNASObservationTests(TestCase):
                     "legacy_compatibility_allowed": False,
                     "direct_nas": True,
                     "include_usage": True,
+                    "usage_recorded_at": sample_recorded_at.isoformat(),
                     "failure_affects_health": False,
                     "usage_active": True,
                     "observation_group_id": group_id,
@@ -1323,6 +1415,12 @@ class AutomaticDirectNASObservationTests(TestCase):
                 status=RepositoryUsageShard.Status.SUCCESS,
             ).count(),
             2,
+        )
+        self.assertEqual(
+            RepositoryUsageMetric.objects.get(
+                repository=self.repository,
+            ).recorded_at,
+            sample_recorded_at,
         )
 
     @mock.patch("apps.storage.tasks.check_storage_repository_health.apply_async")

--- a/src/backend/apps/storage/tests/test_repository_usage.py
+++ b/src/backend/apps/storage/tests/test_repository_usage.py
@@ -200,6 +200,7 @@ class RepositoryUsageTests(TestCase):
         dispatch_observation.assert_called_once_with(
             repository=repository,
             include_usage=True,
+            recorded_at=None,
         )
         synchronous_probe.assert_not_called()
 
@@ -250,6 +251,7 @@ class RepositoryUsageTests(TestCase):
         dispatch_observation.assert_called_once_with(
             repository=failed_repository,
             include_usage=True,
+            recorded_at=None,
         )
         sync_usage.assert_called_once_with(
             healthy_repository,

--- a/src/backend/apps/storage/tests/test_repository_usage_schedule.py
+++ b/src/backend/apps/storage/tests/test_repository_usage_schedule.py
@@ -33,21 +33,99 @@ class RepositoryUsageScheduleTests(SimpleTestCase):
 
 
 class RepositoryUsageCapacityTests(SimpleTestCase):
+    @mock.patch(
+        "apps.storage.tasks.reconcile_storage_repositories.apply_async"
+    )
     @mock.patch("apps.storage.tasks.sync_all_repositories")
     @mock.patch(
         "apps.storage.tasks.try_acquire_background_storage_capacity",
         return_value=None,
     )
-    def test_periodic_sync_defers_without_background_capacity(
+    def test_periodic_sync_retries_without_changing_sample_time(
         self,
         _acquire_capacity,
         sync_all,
+        apply_async,
     ):
-        result = reconcile_storage_repositories.run(background=True)
+        sample_recorded_at = "2026-09-03T13:45:01+08:00"
+
+        result = reconcile_storage_repositories.run(
+            background=True,
+            sample_recorded_at=sample_recorded_at,
+        )
 
         self.assertEqual(result["status"], "deferred_background_capacity")
         self.assertEqual(result["repositories_scanned"], 0)
+        self.assertTrue(result["retry_scheduled"])
+        self.assertEqual(result["capacity_retry_attempt"], 0)
+        apply_async.assert_called_once()
+        retry = apply_async.call_args
+        self.assertEqual(retry.kwargs["countdown"], 15)
+        self.assertEqual(retry.kwargs["kwargs"]["capacity_retry_attempt"], 1)
+        self.assertEqual(
+            retry.kwargs["kwargs"]["sample_recorded_at"],
+            sample_recorded_at,
+        )
         sync_all.assert_not_called()
+
+    @mock.patch(
+        "apps.storage.tasks.reconcile_storage_repositories.apply_async"
+    )
+    @mock.patch("apps.storage.tasks.sync_all_repositories")
+    @mock.patch(
+        "apps.storage.tasks.try_acquire_background_storage_capacity",
+        return_value=None,
+    )
+    def test_periodic_sync_stops_after_three_retries(
+        self,
+        _acquire_capacity,
+        sync_all,
+        apply_async,
+    ):
+        result = reconcile_storage_repositories.run(
+            background=True,
+            capacity_retry_attempt=3,
+            sample_recorded_at="2026-09-03T13:45:01+08:00",
+        )
+
+        self.assertEqual(result["status"], "deferred_background_capacity")
+        self.assertFalse(result["retry_scheduled"])
+        self.assertEqual(result["capacity_retry_attempt"], 3)
+        apply_async.assert_not_called()
+        sync_all.assert_not_called()
+
+    @mock.patch(
+        "apps.storage.tasks.reconcile_storage_repositories.apply_async"
+    )
+    @mock.patch("apps.storage.tasks.sync_all_repositories")
+    @mock.patch(
+        "apps.storage.tasks.try_acquire_background_storage_capacity"
+    )
+    def test_successful_retry_collects_for_original_sample_time(
+        self,
+        _acquire_capacity,
+        sync_all,
+        apply_async,
+    ):
+        sync_all.return_value = {
+            "repositories_attempted": 1,
+            "repositories_synced": 1,
+            "repositories_failed": 0,
+        }
+        sample_recorded_at = "2026-09-03T13:45:01+08:00"
+
+        result = reconcile_storage_repositories.run(
+            background=True,
+            capacity_retry_attempt=2,
+            sample_recorded_at=sample_recorded_at,
+        )
+
+        self.assertEqual(result["repositories_synced"], 1)
+        self.assertEqual(
+            sync_all.call_args.kwargs["recorded_at"].isoformat(),
+            sample_recorded_at,
+        )
+        apply_async.assert_not_called()
 
     @mock.patch(
         "apps.storage.tasks.try_acquire_background_storage_capacity"


### PR DESCRIPTION
## Summary

- Retry periodic repository capacity collection every 15 seconds when the shared background storage slot is temporarily occupied, with at most three delayed retries.
- Carry the original logical sample timestamp through retries and through synchronous S3 and asynchronous NAS/proxy result projection.
- Preserve completion-time fallback for older Agent tasks while leaving interactive refreshes, worker concurrency, shared slot capacity, schemas, and public APIs unchanged.

## Validation

- Targeted Storage regression tests: 55 passed.
- Full affected Storage component suite (`apps.storage.tests`): 534 passed.
- Storage Ruff checks passed.
- Diff and English-source boundary checks passed.
- Migration drift: not applicable because no models or migrations changed.
- Manual testing: passed.
- Complete Community backend suite: skipped at the request of the reporter.

## Risk

The retry path applies only to periodic background capacity collection and is bounded to three delayed tasks. It does not retry remote probe failures or increase runtime concurrency.

Fixes #1002
