### PR TITLE
Improve task error tooltips

### DIFF
--- a/src/frontend/src/directives/tableOverflowTitle.test.ts
+++ b/src/frontend/src/directives/tableOverflowTitle.test.ts
@@ -69,14 +69,19 @@ describe('tableOverflowTitle', () => {
     const gap = document.createElement('div')
     document.body.appendChild(gap)
     content.dispatchEvent(new MouseEvent('mouseout', { bubbles: true, relatedTarget: gap }))
+    vi.advanceTimersByTime(600)
+    expect(tooltip?.style.display).toBe('block')
+
     tooltip?.dispatchEvent(new MouseEvent('mouseenter'))
     cell.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
-    vi.advanceTimersByTime(200)
+    vi.advanceTimersByTime(700)
 
     expect(tooltip?.style.display).toBe('block')
 
     tooltip?.dispatchEvent(new MouseEvent('mouseleave', { relatedTarget: gap }))
-    vi.advanceTimersByTime(150)
+    vi.advanceTimersByTime(699)
+    expect(tooltip?.style.display).toBe('block')
+    vi.advanceTimersByTime(1)
     expect(tooltip?.style.display).toBe('none')
     gap.remove()
   })
@@ -241,6 +246,30 @@ describe('tableOverflowTitle', () => {
     expect(styles).toMatch(/\.hfl-table-overflow-tooltip\s*{[^}]*pointer-events:\s*auto;/s)
     expect(styles).toMatch(/\.hfl-table-overflow-tooltip\s*{[^}]*user-select:\s*text;/s)
     expect(styles).toMatch(/\.hfl-table-overflow-tooltip\s*{[^}]*white-space:\s*pre-line;/s)
+    expect(styles).toMatch(/\.hfl-table-overflow-tooltip--danger\s*{[^}]*color:\s*var\(--color-error-text\);/s)
+    expect(styles).toMatch(/\.hfl-table-overflow-tooltip--warning\s*{[^}]*color:\s*var\(--color-warning-text\);/s)
+  })
+
+  it('applies and clears the semantic tone supplied by the overflow target', async () => {
+    Object.defineProperty(content, 'clientWidth', { configurable: true, value: 80 })
+    Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 200 })
+    content.dataset.tableOverflowTitle = 'Connection refused'
+    content.dataset.tableOverflowTone = 'danger'
+
+    content.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    vi.advanceTimersByTime(300)
+    const tooltip = document.querySelector<HTMLElement>('#hfl-table-overflow-tooltip')!
+    expect(tooltip.classList).toContain('hfl-table-overflow-tooltip--danger')
+
+    content.dataset.tableOverflowTone = 'warning'
+    await Promise.resolve()
+    expect(tooltip.classList).toContain('hfl-table-overflow-tooltip--warning')
+    expect(tooltip.classList).not.toContain('hfl-table-overflow-tooltip--danger')
+
+    delete content.dataset.tableOverflowTone
+    await Promise.resolve()
+    expect(tooltip.className).toBe('hfl-table-overflow-tooltip')
+    delete content.dataset.tableOverflowTitle
   })
 
   it('refreshes an open tooltip when its explicit content changes', async () => {

--- a/src/frontend/src/directives/tableOverflowTitle.ts
+++ b/src/frontend/src/directives/tableOverflowTitle.ts
@@ -21,11 +21,18 @@ type OverflowTitleState = {
 const stateByElement = new WeakMap<HTMLElement, OverflowTitleState>()
 const MIN_TITLE_LENGTH = 2
 const TOOLTIP_ID = 'hfl-table-overflow-tooltip'
-const TOOLTIP_GAP = 8
+// Keep the floating panel adjacent to the cell so the pointer never has to
+// cross a dead zone before it can enter the tooltip.
+const TOOLTIP_GAP = 0
 const TOOLTIP_SHOW_AFTER_MS = 300
-const TOOLTIP_HIDE_AFTER_MS = 150
+// Leave enough time to cross the visual gap between a table cell and its
+// tooltip without making the tooltip feel sticky after the pointer leaves.
+const TOOLTIP_HIDE_AFTER_MS = 700
 const VIEWPORT_PADDING = 8
 const COLUMN_RESIZED_EVENT = 'hfl-table-column-resized'
+const TOOLTIP_TONES = ['danger', 'warning'] as const
+
+type TooltipTone = typeof TOOLTIP_TONES[number]
 
 let autoInstallStarted = false
 let activeState: OverflowTitleState | null = null
@@ -54,6 +61,22 @@ function ensureTooltip() {
   document.body.appendChild(tooltip)
   tooltipElement = tooltip
   return tooltip
+}
+
+function tooltipToneForTarget(target: HTMLElement): TooltipTone | null {
+  const toneTarget = target.hasAttribute('data-table-overflow-tone')
+    ? target
+    : target.querySelector<HTMLElement>('[data-table-overflow-tone]')
+  const tone = toneTarget?.dataset.tableOverflowTone
+  return TOOLTIP_TONES.find((candidate) => candidate === tone) || null
+}
+
+function applyTooltipTone(tooltip: HTMLElement, target: HTMLElement) {
+  const tone = tooltipToneForTarget(target)
+  tooltip.className = [
+    'hfl-table-overflow-tooltip',
+    tone ? `hfl-table-overflow-tooltip--${tone}` : '',
+  ].filter(Boolean).join(' ')
 }
 
 function isCurrentTableElement(el: HTMLElement, node: Element | null) {
@@ -227,6 +250,7 @@ function observeTooltipContent(state: OverflowTitleState, cell: HTMLElement) {
       'data-table-overflow-title',
       'data-table-overflow-title-always',
       'data-table-overflow-explicit-only',
+      'data-table-overflow-tone',
     ],
   })
   state.contentObserver = observer
@@ -241,6 +265,7 @@ function showTooltip(state: OverflowTitleState, cell: HTMLElement, text: string)
   state.active = cell
   activeState = state
   tooltip.textContent = text
+  applyTooltipTone(tooltip, cell)
   tooltip.style.display = 'block'
   cell.setAttribute('aria-describedby', TOOLTIP_ID)
   positionTooltip(cell)
@@ -256,6 +281,7 @@ function applyTooltip(state: OverflowTitleState, cell: HTMLElement) {
 
   if (state.active === cell) {
     if (tooltipElement?.textContent !== text) tooltipElement!.textContent = text
+    if (tooltipElement) applyTooltipTone(tooltipElement, cell)
     positionTooltip(cell)
     return
   }
@@ -314,7 +340,10 @@ function clearTooltip(state: OverflowTitleState) {
   state.tooltipHovered = false
   if (activeState === state) {
     activeState = null
-    if (tooltipElement) tooltipElement.style.display = 'none'
+    if (tooltipElement) {
+      tooltipElement.className = 'hfl-table-overflow-tooltip'
+      tooltipElement.style.display = 'none'
+    }
   }
 }
 

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -10236,7 +10236,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                     :content="t('protection.backupsPage.btnStartBackupCloudHint')"
                     placement="bottom"
                     :show-after="300"
-                    :hide-after="0"
+                    :hide-after="FLOW_DETAIL_POPOVER_HIDE_AFTER_MS"
                   >
                     <span class="dp-flow-step3-action-tooltip">
                       <ElButton
@@ -10259,7 +10259,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                     :content="t('protection.backupsPage.btnRecover')"
                     placement="bottom"
                     :show-after="300"
-                    :hide-after="0"
+                    :hide-after="FLOW_DETAIL_POPOVER_HIDE_AFTER_MS"
                   >
                     <span class="dp-flow-step3-action-tooltip">
                       <ElButton
@@ -11103,7 +11103,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                           <HflPopover
                             placement="right-start"
                             trigger="hover"
-                            :hide-after="0"
+                            :hide-after="FLOW_DETAIL_POPOVER_HIDE_AFTER_MS"
                             :width="400"
                             append-to-body
                           >

--- a/src/frontend/src/pages/protection/DataProtectionStep3ServerFilters.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3ServerFilters.test.ts
@@ -17,6 +17,12 @@ function sourceBetween(startMarker: string, endMarker: string) {
 }
 
 describe('Backup Wizard Step 3 server filters', () => {
+  it('keeps hover tooltips enterable while crossing the trigger gap', () => {
+    expect(page).not.toContain(':hide-after="0"')
+    expect(page).toContain('const FLOW_DETAIL_POPOVER_HIDE_AFTER_MS = 350')
+    expect(page.match(/:hide-after="FLOW_DETAIL_POPOVER_HIDE_AFTER_MS"/g)?.length).toBeGreaterThanOrEqual(6)
+  })
+
   it('uses a consistent compact font size for configuration summaries', () => {
     expect(page).toMatch(/\.flow-compression-cell__label\s*{[^}]*font-size:\s*13px;/s)
     expect(page).toContain('.protection-flow-table-block .flow-binding-empty {\n  font-size: 13px;')

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.test.ts
@@ -290,6 +290,13 @@ describe('FlowBackupSourceDetailDrawer snapshot expansion state', () => {
     expect(drawer).toContain('max-width: calc(100cqw - 49px); overflow-x: hidden; margin-left: 35px;')
   })
 
+  it('separates complete restore error codes from wrapped messages', () => {
+    expect(drawer.match(/class="restore-record-structure-entry__error-code"/g)).toHaveLength(2)
+    expect(drawer.match(/class="restore-record-structure-entry__error-message"/g)).toHaveLength(2)
+    expect(drawer).toMatch(/\.restore-record-structure-entry__error\s*{[^}]*display:\s*grid;[^}]*color:\s*var\(--color-error-text\);/s)
+    expect(drawer).toMatch(/\.restore-record-structure-entry__error-message\s*{[^}]*white-space:\s*pre-wrap;[^}]*overflow-wrap:\s*anywhere;/s)
+  })
+
   it('keeps restore record headers aligned while horizontally scrolling resized columns', () => {
     const restoreTab = sourceBetween(
       '<el-tab-pane :label="t(\'protection.backupsPage.flowSourceDetailTabRestoreRecords\')" name="restoreRecords">',

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -4782,7 +4782,14 @@ function onClosed() {
                               v-if="item.error_code || item.error_message"
                               class="restore-record-structure-entry__error"
                             >
-                              {{ item.error_code ? `[${item.error_code}] ` : '' }}{{ item.error_message }}
+                              <span
+                                v-if="item.error_code"
+                                class="restore-record-structure-entry__error-code"
+                              >[{{ item.error_code }}]</span>
+                              <span
+                                v-if="item.error_message"
+                                class="restore-record-structure-entry__error-message"
+                              >{{ item.error_message }}</span>
                             </div>
                           </div>
                         </div>
@@ -4841,7 +4848,14 @@ function onClosed() {
                             v-if="mapping.item.error_code || mapping.item.error_message"
                             class="restore-record-structure-entry__error"
                           >
-                            {{ mapping.item.error_code ? `[${mapping.item.error_code}] ` : '' }}{{ mapping.item.error_message }}
+                            <span
+                              v-if="mapping.item.error_code"
+                              class="restore-record-structure-entry__error-code"
+                            >[{{ mapping.item.error_code }}]</span>
+                            <span
+                              v-if="mapping.item.error_message"
+                              class="restore-record-structure-entry__error-message"
+                            >{{ mapping.item.error_message }}</span>
                           </div>
                         </div>
                       </div>
@@ -7049,15 +7063,29 @@ function onClosed() {
 }
 
 .restore-record-structure-entry__error {
+  display: grid;
+  gap: 3px;
   margin: 0 8px;
   padding: 7px 8px;
-  border: 1px solid rgb(254 202 202);
+  border: 1px solid color-mix(in srgb, var(--color-error-text) 24%, transparent);
   border-radius: 6px;
-  color: rgb(185 28 28);
-  background: rgb(254 242 242);
+  color: var(--color-error-text);
+  background: color-mix(in srgb, var(--color-error-text) 8%, transparent);
   font-size: 12px;
   line-height: 1.45;
+}
+
+.restore-record-structure-entry__error-code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-weight: 600;
   overflow-wrap: anywhere;
+}
+
+.restore-record-structure-entry__error-message {
+  min-width: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: normal;
 }
 
 .restore-record-status-progress {

--- a/src/frontend/src/pages/protection/components/TaskTerminalOutcomeCell.test.ts
+++ b/src/frontend/src/pages/protection/components/TaskTerminalOutcomeCell.test.ts
@@ -73,6 +73,8 @@ describe('TaskTerminalOutcomeCell', () => {
 
     expect(diagnostic.text()).toBe('[CONNECTION_REFUSED]Connection refused')
     expect(diagnostic.attributes('aria-label')).toBe('[CONNECTION_REFUSED] Connection refused')
+    expect(diagnostic.attributes('data-table-overflow-title')).toBe('[CONNECTION_REFUSED] Connection refused')
+    expect(diagnostic.attributes('data-table-overflow-tone')).toBe('danger')
     expect(wrapper.get('.task-terminal-outcome__code').text()).toBe('[CONNECTION_REFUSED]')
     expect(wrapper.get('.task-terminal-outcome__reason').text()).toBe('Connection refused')
   })
@@ -145,5 +147,16 @@ describe('TaskTerminalOutcomeCell', () => {
     expect(source).toContain('var(--color-warning-text)')
     expect(source).toContain('var(--color-text-secondary)')
     expect(source).toContain('var(--color-text-primary)')
+  })
+
+  it('exposes warning semantics to the shared overflow tooltip', () => {
+    const wrapper = mountCell({
+      status: 'partial',
+      error_code: 'MIXED_SOURCE_ERRORS',
+      error_message: 'Some source items could not be processed',
+    })
+
+    expect(wrapper.get('.task-terminal-outcome__diagnostic').attributes('data-table-overflow-tone'))
+      .toBe('warning')
   })
 })

--- a/src/frontend/src/pages/protection/components/TaskTerminalOutcomeCell.vue
+++ b/src/frontend/src/pages/protection/components/TaskTerminalOutcomeCell.vue
@@ -120,6 +120,8 @@ const outcome = computed(() => {
       v-if="outcome.showDiagnostic"
       class="task-terminal-outcome__diagnostic"
       :aria-label="outcome.diagnostic"
+      :data-table-overflow-title="outcome.diagnostic"
+      :data-table-overflow-tone="['danger', 'warning'].includes(outcome.tone) ? outcome.tone : undefined"
     >
       <span
         v-if="outcome.code"
@@ -209,6 +211,14 @@ const outcome = computed(() => {
   flex: 1 1 auto;
   color: var(--color-text-primary);
   font-weight: 400;
+}
+
+.task-terminal-outcome--danger .task-terminal-outcome__reason {
+  color: var(--color-error-text);
+}
+
+.task-terminal-outcome--warning .task-terminal-outcome__reason {
+  color: var(--color-warning-text);
 }
 
 .task-terminal-outcome--success { --task-outcome-tone: var(--color-success-text); }

--- a/src/frontend/src/styles/list-page-ui.css
+++ b/src/frontend/src/styles/list-page-ui.css
@@ -773,6 +773,18 @@ html[data-theme='dark'] {
   white-space: pre-line;
 }
 
+.hfl-table-overflow-tooltip--danger {
+  border-color: var(--color-error-border);
+  background: var(--color-error-light);
+  color: var(--color-error-text);
+}
+
+.hfl-table-overflow-tooltip--warning {
+  border-color: var(--color-warning-border);
+  background: var(--color-warning-light);
+  color: var(--color-warning-text);
+}
+
 .hfl-btn-with-icon.el-button > span {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Separate expanded Restore Record error codes from their messages for readable multiline diagnostics.
- Apply semantic error and warning tones to task reasons and matching overflow tooltips.
- Keep protection table overflow tooltips enterable, selectable, and available while moving from ellipsized cells.
- Replace immediate-hide protection popovers with a short enterable grace period.

Closes #1014

## Testing

- `npm run test -- --run src/directives/tableOverflowTitle.test.ts src/pages/protection/components/TaskTerminalOutcomeCell.test.ts src/pages/protection/DataProtectionStep3ServerFilters.test.ts`
- `npm run build`
- `npm run lint`
- `git diff --check`