### PR TITLE
Simplify Turnstile visibility handling

### DIFF
--- a/src/frontend/src/components/auth/AuthTurnstileField.test.ts
+++ b/src/frontend/src/components/auth/AuthTurnstileField.test.ts
@@ -8,16 +8,12 @@ import { describe, expect, it } from 'vitest'
 import AuthTurnstileField from './AuthTurnstileField.vue'
 
 const baseProps = {
-  pending: false,
   ready: false,
   blocked: false,
-  configError: false,
   verified: false,
   siteKey: 'test-site-key',
   action: 'login',
-  loadingMessage: 'Loading Cloudflare human verification...',
   blockedMessage: 'Cloudflare verification unavailable.',
-  configErrorMessage: 'Something went wrong. Please try again.',
   retryLabel: 'Retry',
   manualRetryLabel: 'Verification taking longer than expected? Reload',
   errorCodeLabel: '',
@@ -36,12 +32,11 @@ function mountField(overrides: Partial<typeof baseProps> & { errorMessage?: stri
 }
 
 describe('AuthTurnstileField display states', () => {
-  it('renders the configuration loading state without mounting the widget', () => {
-    const wrapper = mountField({ pending: true })
+  it('renders nothing until Turnstile is known to be enabled', () => {
+    const wrapper = mountField()
 
-    expect(wrapper.find('.auth-turnstile-field__loading').exists()).toBe(true)
+    expect(wrapper.find('.auth-turnstile-field').exists()).toBe(false)
     expect(wrapper.find('.auth-turnstile-field__widget').exists()).toBe(false)
-    expect(wrapper.text()).toContain(baseProps.loadingMessage)
   })
 
   it('keeps verification errors visible below a ready Cloudflare widget', () => {
@@ -107,17 +102,6 @@ describe('AuthTurnstileField display states', () => {
     expect(wrapper.emitted('retry')).toHaveLength(1)
   })
 
-  it('shows a configuration error only once and exposes retry', () => {
-    const wrapper = mountField({
-      configError: true,
-      errorMessage: baseProps.configErrorMessage,
-    })
-
-    expect(wrapper.find('.auth-turnstile-field__blocked').exists()).toBe(true)
-    expect(wrapper.find('.auth-turnstile-field__error').exists()).toBe(false)
-    expect(wrapper.text().match(/Something went wrong\. Please try again\./g)).toHaveLength(1)
-  })
-
   it('assigns exactly one frame owner to every visual state', () => {
     const fieldSource = readFileSync(
       resolve(process.cwd(), 'src/components/auth/AuthTurnstileField.vue'),
@@ -129,7 +113,7 @@ describe('AuthTurnstileField display states', () => {
     )
 
     expect(fieldSource).toMatch(
-      /\.auth-turnstile-field__loading,\s*\.auth-turnstile-field__blocked\s*{[^}]*background:\s*#313131;[^}]*border:\s*1px solid #3a3b40;[^}]*border-radius:[^}]*overflow:\s*hidden;/s,
+      /\.auth-turnstile-field__blocked\s*{[^}]*background:\s*#313131;[^}]*border:\s*1px solid #3a3b40;[^}]*border-radius:[^}]*overflow:\s*hidden;/s,
     )
     expect(fieldSource).toMatch(
       /\.auth-turnstile-field__widget\s*{[^}]*background:\s*transparent;[^}]*border:\s*0;[^}]*border-radius:\s*0;[^}]*overflow:\s*visible;/s,
@@ -145,9 +129,6 @@ describe('AuthTurnstileField display states', () => {
     )
     expect(fieldSource).toMatch(
       /\.auth-turnstile-field__control\s*{[^}]*min-height:\s*65px;/s,
-    )
-    expect(fieldSource).toMatch(
-      /\.auth-turnstile-field__spinner\s*{[^}]*width:\s*16px;[^}]*height:\s*16px;/s,
     )
     expect(fieldSource).toMatch(
       /\.auth-turnstile-field__manual-retry\s*{[^}]*width:\s*100%;[^}]*background:\s*color-mix\(in srgb, var\(--color-primary\) 6%, transparent\);[^}]*border:\s*1px solid color-mix\(in srgb, var\(--color-primary\) 22%, transparent\);/s,

--- a/src/frontend/src/components/auth/AuthTurnstileField.vue
+++ b/src/frontend/src/components/auth/AuthTurnstileField.vue
@@ -5,16 +5,12 @@ import { KeyRound, RotateCcw } from 'lucide-vue-next'
 import TurnstileWidget from '../TurnstileWidget.vue'
 
 defineProps<{
-  pending: boolean
   ready: boolean
   blocked: boolean
-  configError?: boolean
   verified: boolean
   siteKey: string
   action: string
-  loadingMessage: string
   blockedMessage: string
-  configErrorMessage?: string
   retryLabel: string
   manualRetryLabel: string
   errorCodeLabel?: string
@@ -76,23 +72,11 @@ defineExpose({ reset })
 
 <template>
   <div
-    v-if="pending || ready || blocked || configError"
+    v-if="ready || blocked"
     class="auth-turnstile-field"
   >
     <div
-      v-if="pending"
-      class="auth-turnstile-field__control auth-turnstile-field__loading"
-      role="status"
-    >
-      <span
-        class="auth-turnstile-field__spinner"
-        aria-hidden="true"
-      />
-      <span>{{ loadingMessage }}</span>
-    </div>
-
-    <div
-      v-else-if="ready && siteKey"
+      v-if="ready && siteKey"
       class="auth-turnstile-field__control auth-turnstile-field__widget"
     >
       <div class="auth-turnstile-field__viewport">
@@ -128,7 +112,7 @@ defineExpose({ reset })
     </button>
 
     <div
-      v-if="blocked || configError"
+      v-if="blocked"
       class="auth-turnstile-field__control auth-turnstile-field__blocked"
       role="alert"
     >
@@ -137,7 +121,7 @@ defineExpose({ reset })
         aria-hidden="true"
       />
       <span class="auth-turnstile-field__blocked-text">
-        <span>{{ configError ? (configErrorMessage || blockedMessage) : blockedMessage }}</span>
+        <span>{{ blockedMessage }}</span>
         <span
           v-if="errorCodeLabel"
           class="auth-turnstile-field__reference-code"
@@ -155,7 +139,7 @@ defineExpose({ reset })
     </div>
 
     <p
-      v-if="errorMessage && !blocked && !configError"
+      v-if="errorMessage && !blocked"
       class="auth-turnstile-field__error"
       role="alert"
     >
@@ -179,7 +163,6 @@ defineExpose({ reset })
   align-items: center;
 }
 
-.auth-turnstile-field__loading,
 .auth-turnstile-field__blocked {
   gap: 10px;
   padding: 0 14px;
@@ -220,16 +203,6 @@ defineExpose({ reset })
 .auth-turnstile-field__viewport :deep(.turnstile-widget__loading) {
   border: 0;
   border-radius: 0;
-}
-
-.auth-turnstile-field__spinner {
-  width: 16px;
-  height: 16px;
-  flex: 0 0 auto;
-  border: 2px solid rgba(255, 255, 255, 0.18);
-  border-top-color: var(--color-primary);
-  border-radius: 999px;
-  animation: auth-turnstile-spin 0.8s linear infinite;
 }
 
 .auth-turnstile-field__blocked-text {
@@ -317,19 +290,6 @@ defineExpose({ reset })
   color: var(--color-error);
   font-size: 12px;
   line-height: 1.4;
-}
-
-@keyframes auth-turnstile-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .auth-turnstile-field__spinner {
-    animation: none;
-  }
-
 }
 
 @media (max-width: 479.98px) {

--- a/src/frontend/src/components/auth/ResetPasswordCard.vue
+++ b/src/frontend/src/components/auth/ResetPasswordCard.vue
@@ -30,7 +30,6 @@ const {
   isTurnstilePending,
   isTurnstileReady,
   isTurnstileBlocked,
-  isTurnstileConfigError,
   loadTurnstileConfig,
   retryTurnstileConfig,
   buildTurnstilePayload,
@@ -87,7 +86,7 @@ const maskedEmail = computed(() => maskEmail(savedEmail.value))
 const canSendResetCode = computed(() => {
   if (submitLoading.value) return false
   if (isTurnstilePending.value) return false
-  if (isTurnstileBlocked.value || isTurnstileConfigError.value) return false
+  if (isTurnstileBlocked.value) return false
   if (isTurnstileReady.value) return Boolean(turnstileToken.value)
   return true
 })
@@ -245,10 +244,8 @@ function validateRequestForm() {
   if (isTurnstilePending.value) {
     turnstileError.value = t('login.captchaLoading')
     hasError = true
-  } else if (isTurnstileBlocked.value || isTurnstileConfigError.value) {
-    turnstileError.value = isTurnstileConfigError.value
-      ? t('errors.generic.requestFailed')
-      : t('login.captchaUnavailable')
+  } else if (isTurnstileBlocked.value) {
+    turnstileError.value = t('login.captchaUnavailable')
     hasError = true
   } else if (isTurnstileReady.value) {
     if (!turnstileToken.value) {
@@ -495,16 +492,12 @@ onUnmounted(() => {
 
         <AuthTurnstileField
           ref="turnstileFieldRef"
-          :pending="isTurnstilePending"
           :ready="isTurnstileReady"
           :blocked="isTurnstileBlocked"
-          :config-error="isTurnstileConfigError"
           :verified="Boolean(turnstileToken)"
           :site-key="turnstileSiteKey"
           action="forgot_password"
-          :loading-message="t('login.captchaLoading')"
           :blocked-message="t('login.captchaUnavailable')"
-          :config-error-message="t('errors.generic.requestFailed')"
           :retry-label="t('login.captchaRetry')"
           :manual-retry-label="t('login.captchaManualRetry')"
           :error-code-label="turnstileErrorCode ? t('login.captchaReferenceCode', { code: turnstileErrorCode }) : ''"

--- a/src/frontend/src/composables/useTurnstileConfig.test.ts
+++ b/src/frontend/src/composables/useTurnstileConfig.test.ts
@@ -4,51 +4,44 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   api: vi.fn(),
-  isAbortError: vi.fn(() => false),
   preloadTurnstileScript: vi.fn(),
   resetTurnstileScriptLoad: vi.fn(),
 }))
 
-vi.mock('../lib/api', () => ({
-  api: mocks.api,
-  isAbortError: mocks.isAbortError,
-}))
+vi.mock('../lib/api', () => ({ api: mocks.api }))
 vi.mock('../lib/turnstileLoader', () => ({
   preloadTurnstileScript: mocks.preloadTurnstileScript,
   resetTurnstileScriptLoad: mocks.resetTurnstileScriptLoad,
 }))
 
-describe('Turnstile configuration retry', () => {
+describe('Turnstile configuration visibility', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
-    mocks.isAbortError.mockReturnValue(false)
     mocks.preloadTurnstileScript.mockResolvedValue(undefined)
   })
 
-  it('recovers after one transient configuration failure', async () => {
-    mocks.api
-      .mockRejectedValueOnce(new Error('network unavailable'))
-      .mockResolvedValueOnce({
-        code: '0000',
-        data: {
-          enabled: true,
-          configured: true,
-          site_key: 'test-site-key',
-        },
-      })
+  it('shows the challenge when Turnstile is enabled and configured', async () => {
+    mocks.api.mockResolvedValue({
+      code: '0000',
+      data: {
+        enabled: true,
+        configured: true,
+        site_key: 'test-site-key',
+      },
+    })
 
     const { useTurnstileConfig } = await import('./useTurnstileConfig')
     const turnstile = useTurnstileConfig()
 
     await turnstile.loadTurnstileConfig()
     expect(turnstile.isTurnstileReady.value).toBe(true)
-    expect(mocks.api).toHaveBeenCalledTimes(2)
+    expect(mocks.api).toHaveBeenCalledTimes(1)
     expect(turnstile.turnstileSiteKey.value).toBe('test-site-key')
     expect(mocks.preloadTurnstileScript).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps retry fail-closed when the configuration request still fails', async () => {
+  it('keeps the optional field hidden when configuration cannot be loaded', async () => {
     mocks.api.mockRejectedValue(new Error('network unavailable'))
 
     const { useTurnstileConfig } = await import('./useTurnstileConfig')
@@ -56,25 +49,26 @@ describe('Turnstile configuration retry', () => {
 
     await turnstile.loadTurnstileConfig()
 
-    expect(mocks.api).toHaveBeenCalledTimes(2)
-    expect(turnstile.isTurnstileConfigError.value).toBe(true)
+    expect(mocks.api).toHaveBeenCalledTimes(1)
+    expect(turnstile.isTurnstileDisabled.value).toBe(true)
     expect(turnstile.turnstileSiteKey.value).toBe('')
+    expect(mocks.preloadTurnstileScript).not.toHaveBeenCalled()
   })
 
-  it('does not surface an error when the request is aborted', async () => {
-    const aborted = new Error('route changed')
-    aborted.name = 'AbortError'
-    mocks.api.mockRejectedValue(aborted)
-    mocks.isAbortError.mockReturnValue(true)
+  it('shows an unavailable state when Turnstile is enabled without complete keys', async () => {
+    mocks.api.mockResolvedValue({
+      code: '0000',
+      data: { enabled: true, configured: false },
+    })
 
     const { useTurnstileConfig } = await import('./useTurnstileConfig')
     const turnstile = useTurnstileConfig()
 
     await turnstile.loadTurnstileConfig()
 
-    expect(turnstile.isTurnstileConfigError.value).toBe(false)
-    expect(turnstile.isTurnstilePending.value).toBe(true)
+    expect(turnstile.isTurnstileBlocked.value).toBe(true)
     expect(mocks.api).toHaveBeenCalledTimes(1)
+    expect(mocks.preloadTurnstileScript).not.toHaveBeenCalled()
   })
 
   it('does not load the Cloudflare script when Turnstile is disabled', async () => {
@@ -92,30 +86,20 @@ describe('Turnstile configuration retry', () => {
     expect(mocks.preloadTurnstileScript).not.toHaveBeenCalled()
   })
 
-  it('reloads configuration after a forced retry is aborted', async () => {
-    mocks.api.mockResolvedValueOnce({
-      code: '0000',
-      data: { enabled: true, configured: true, site_key: 'test-site-key' },
-    })
+  it('retries a failed request only when configuration is requested again', async () => {
+    mocks.api
+      .mockRejectedValueOnce(new Error('network unavailable'))
+      .mockResolvedValueOnce({
+        code: '0000',
+        data: { enabled: true, configured: true, site_key: 'test-site-key' },
+      })
 
     const { useTurnstileConfig } = await import('./useTurnstileConfig')
     const turnstile = useTurnstileConfig()
     await turnstile.loadTurnstileConfig()
-
-    const aborted = new Error('route changed')
-    aborted.name = 'AbortError'
-    mocks.api.mockRejectedValueOnce(aborted)
-    mocks.isAbortError.mockReturnValue(true)
-    await turnstile.retryTurnstileConfig()
-
-    mocks.isAbortError.mockReturnValue(false)
-    mocks.api.mockResolvedValueOnce({
-      code: '0000',
-      data: { enabled: false, configured: false },
-    })
     await turnstile.loadTurnstileConfig()
 
-    expect(turnstile.isTurnstileDisabled.value).toBe(true)
-    expect(mocks.api).toHaveBeenCalledTimes(3)
+    expect(turnstile.isTurnstileReady.value).toBe(true)
+    expect(mocks.api).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/frontend/src/composables/useTurnstileConfig.ts
+++ b/src/frontend/src/composables/useTurnstileConfig.ts
@@ -1,11 +1,11 @@
 import { computed, nextTick, ref } from 'vue'
-import { api, isAbortError } from '../lib/api'
+import { api } from '../lib/api'
 import {
   preloadTurnstileScript,
   resetTurnstileScriptLoad,
 } from '../lib/turnstileLoader'
 
-export type TurnstileState = 'pending' | 'disabled' | 'ready' | 'blocked' | 'config-error'
+export type TurnstileState = 'pending' | 'disabled' | 'ready' | 'blocked'
 
 interface TurnstileConfigResponse {
   code: string
@@ -22,35 +22,17 @@ const configLoaded = ref(false)
 let configLoadPromise: Promise<void> | null = null
 let configRetryPromise: Promise<void> | null = null
 const authTurnstileMountGeneration = ref(0)
-const MAX_CONFIG_ATTEMPTS = 2
+async function loadTurnstileConfig(force = false): Promise<void> {
+  if (configLoadPromise) return configLoadPromise
+  if (configLoaded.value && !force) return
 
-async function fetchTurnstileConfig(): Promise<TurnstileConfigResponse> {
-  let lastError: unknown
-  for (let attempt = 0; attempt < MAX_CONFIG_ATTEMPTS; attempt += 1) {
+  state.value = 'pending'
+  configLoadPromise = (async () => {
     try {
       const res = await api<TurnstileConfigResponse>('/api/v1/auth/turnstile/config')
       if (res.code !== '0000' || !res.data) {
         throw new Error('Invalid Turnstile configuration response')
       }
-      return res
-    } catch (error) {
-      if (isAbortError(error)) throw error
-      lastError = error
-    }
-  }
-  throw lastError ?? new Error('Unable to load Turnstile configuration')
-}
-
-async function loadTurnstileConfig(force = false): Promise<void> {
-  if (configLoadPromise) return configLoadPromise
-  if (configLoaded.value && !force) return
-
-  const previousState = state.value
-  const previousConfigLoaded = configLoaded.value
-  state.value = 'pending'
-  configLoadPromise = (async () => {
-    try {
-      const res = await fetchTurnstileConfig()
       if (!res.data.enabled) {
         state.value = 'disabled'
         siteKey.value = ''
@@ -71,13 +53,10 @@ async function loadTurnstileConfig(force = false): Promise<void> {
       // rejection before the lazy authentication page finishes mounting.
       void preloadTurnstileScript().catch(() => undefined)
       configLoaded.value = true
-    } catch (error) {
-      if (isAbortError(error)) {
-        state.value = previousState
-        configLoaded.value = previousConfigLoaded
-        return
-      }
-      state.value = 'config-error'
+    } catch {
+      // A failed request does not establish that Turnstile is enabled. Keep
+      // the optional field hidden; auth endpoints remain the security boundary.
+      state.value = 'disabled'
       siteKey.value = ''
       configLoaded.value = false
     } finally {
@@ -124,7 +103,6 @@ export function useTurnstileConfig() {
   const isTurnstileDisabled = computed(() => state.value === 'disabled')
   const isTurnstileReady = computed(() => state.value === 'ready')
   const isTurnstileBlocked = computed(() => state.value === 'blocked')
-  const isTurnstileConfigError = computed(() => state.value === 'config-error')
 
   function blockTurnstile(): void {
     if (state.value !== 'disabled') state.value = 'blocked'
@@ -142,7 +120,6 @@ export function useTurnstileConfig() {
     isTurnstileDisabled,
     isTurnstileReady,
     isTurnstileBlocked,
-    isTurnstileConfigError,
     loadTurnstileConfig,
     retryTurnstileConfig,
     buildTurnstilePayload,

--- a/src/frontend/src/pages/auth/AuthTurnstileRetryFlows.test.ts
+++ b/src/frontend/src/pages/auth/AuthTurnstileRetryFlows.test.ts
@@ -43,7 +43,6 @@ vi.mock('../../composables/useTurnstileConfig', () => ({
     isTurnstilePending: ref(false),
     isTurnstileReady: ref(true),
     isTurnstileBlocked: ref(false),
-    isTurnstileConfigError: ref(false),
     authTurnstileMountGeneration: ref(0),
     loadTurnstileConfig: mocks.loadTurnstileConfig,
     retryTurnstileConfig: mocks.retryTurnstileConfig,

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -50,7 +50,6 @@ const {
   isTurnstilePending,
   isTurnstileReady,
   isTurnstileBlocked,
-  isTurnstileConfigError,
   authTurnstileMountGeneration,
   loadTurnstileConfig,
   retryTurnstileConfig,
@@ -305,10 +304,8 @@ function validateForm() {
   if (isTurnstilePending.value) {
     turnstileError.value = t('login.captchaLoading')
     hasError = true
-  } else if (isTurnstileBlocked.value || isTurnstileConfigError.value) {
-    turnstileError.value = isTurnstileConfigError.value
-      ? t('errors.generic.requestFailed')
-      : t('login.captchaUnavailable')
+  } else if (isTurnstileBlocked.value) {
+    turnstileError.value = t('login.captchaUnavailable')
     hasError = true
   } else if (isTurnstileReady.value) {
     if (!turnstileToken.value) {
@@ -672,7 +669,7 @@ const canSubmitLogin = computed(() => {
   if (submitLoading.value) return false
   if (!credentialsPresent.value) return false
   if (isTurnstilePending.value) return false
-  if (isTurnstileBlocked.value || isTurnstileConfigError.value) return false
+  if (isTurnstileBlocked.value) return false
   if (isTurnstileReady.value) return Boolean(turnstileToken.value)
   return true
 })
@@ -942,16 +939,12 @@ onMounted(async () => {
               v-if="authMode === 'password'"
               :key="authTurnstileMountGeneration"
               ref="turnstileFieldRef"
-              :pending="isTurnstilePending"
               :ready="isTurnstileReady"
               :blocked="isTurnstileBlocked"
-              :config-error="isTurnstileConfigError"
               :verified="Boolean(turnstileToken)"
               :site-key="turnstileSiteKey"
               action="login"
-              :loading-message="t('login.captchaLoading')"
               :blocked-message="t('login.captchaUnavailable')"
-              :config-error-message="t('errors.generic.requestFailed')"
               :retry-label="t('login.captchaRetry')"
               :manual-retry-label="t('login.captchaManualRetry')"
               :error-code-label="turnstileErrorCode ? t('login.captchaReferenceCode', { code: turnstileErrorCode }) : ''"

--- a/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
+++ b/src/frontend/src/pages/auth/LoginTurnstileLifecycle.test.ts
@@ -53,7 +53,6 @@ vi.mock('../../composables/useTurnstileConfig', () => ({
     isTurnstilePending: ref(false),
     isTurnstileReady: ref(true),
     isTurnstileBlocked: ref(mocks.turnstileBlocked),
-    isTurnstileConfigError: ref(false),
     authTurnstileMountGeneration: ref(0),
     loadTurnstileConfig: mocks.loadTurnstileConfig,
     retryTurnstileConfig: mocks.retryTurnstileConfig,

--- a/src/frontend/src/pages/auth/Register.vue
+++ b/src/frontend/src/pages/auth/Register.vue
@@ -25,7 +25,6 @@ const {
   isTurnstilePending,
   isTurnstileReady,
   isTurnstileBlocked,
-  isTurnstileConfigError,
   authTurnstileMountGeneration,
   loadTurnstileConfig,
   retryTurnstileConfig,
@@ -279,10 +278,8 @@ function validateSendCodeForm() {
   if (isTurnstilePending.value) {
     turnstileError.value = t('login.captchaLoading')
     hasError = true
-  } else if (isTurnstileBlocked.value || isTurnstileConfigError.value) {
-    turnstileError.value = isTurnstileConfigError.value
-      ? t('errors.generic.requestFailed')
-      : t('login.captchaUnavailable')
+  } else if (isTurnstileBlocked.value) {
+    turnstileError.value = t('login.captchaUnavailable')
     hasError = true
   } else if (isTurnstileReady.value) {
     if (!turnstileToken.value) {
@@ -479,16 +476,12 @@ onUnmounted(() => {
         <AuthTurnstileField
           :key="authTurnstileMountGeneration"
           ref="turnstileFieldRef"
-          :pending="isTurnstilePending"
           :ready="isTurnstileReady"
           :blocked="isTurnstileBlocked"
-          :config-error="isTurnstileConfigError"
           :verified="Boolean(turnstileToken)"
           :site-key="turnstileSiteKey"
           action="register_send_code"
-          :loading-message="t('login.captchaLoading')"
           :blocked-message="t('login.captchaUnavailable')"
-          :config-error-message="t('errors.generic.requestFailed')"
           :retry-label="t('login.captchaRetry')"
           :manual-retry-label="t('login.captchaManualRetry')"
           :error-code-label="turnstileErrorCode ? t('login.captchaReferenceCode', { code: turnstileErrorCode }) : ''"


### PR DESCRIPTION
## Summary

- hide the Turnstile area when the feature is disabled or its configuration cannot be loaded
- show the challenge or unavailable state only after the backend reports Turnstile as enabled
- remove redundant configuration-error state, automatic retries, and duplicated auth-page handling
- preserve backend enforcement and manual challenge recovery

## Validation

- targeted Turnstile tests (40 passed)
- full frontend test suite (1441 passed; four timeout-only cases rerun successfully with the CI timeout)
- ESLint
- Vue TypeScript checks
- production build
- git diff --check