### PR TITLE
Preserve host packages during offline NAS dependency installation

### DIFF
--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -444,6 +444,7 @@ jobs:
           ./tools/quality/test-docker-pull-retry.sh
           ./tools/quality/test-gh-release-upload-retry.sh
           ./tools/quality/test-offline-docker-package-plan.sh
+          ./tools/quality/test-offline-nas-package-plan.sh
           ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-upgrade-transaction.sh
           ./tools/quality/test-blue-green-recovery.sh

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -2048,6 +2048,67 @@ prepare_cifs_utf8_module() {
 	return 0
 }
 
+select_missing_nas_debs() {
+	local deps_dir="$1"
+	local deb package package_arch status
+	local -a bundled_debs=()
+	NAS_DEB_FILES=()
+
+	mapfile -t bundled_debs < <(find "${deps_dir}" -maxdepth 1 -type f -name '*.deb' -print | sort)
+	for deb in "${bundled_debs[@]}"; do
+		package="$(dpkg-deb --field "${deb}" Package 2>/dev/null || true)"
+		[[ "${package}" =~ ^[a-z0-9][a-z0-9+.-]+$ ]] \
+			|| log_fail "The NAS dependency bundle contains an invalid package: ${deb##*/}." 2
+		package_arch="$(dpkg-deb --field "${deb}" Architecture 2>/dev/null || true)"
+		[[ "${package_arch}" =~ ^[a-z0-9][a-z0-9-]*$ ]] \
+			|| log_fail "The NAS dependency bundle contains an invalid package architecture: ${deb##*/}." 2
+		status="$(dpkg-query -W -f='${db:Status-Abbrev}' -- "${package}:${package_arch}" 2>/dev/null || true)"
+		case "${status}" in
+		?i\ ) ;;
+		"" | ?n\  | ?c\ ) NAS_DEB_FILES+=("${deb}") ;;
+		*) log_fail "The installed package ${package} is not in a healthy state (${status}). Repair the host package state before retrying." 2 ;;
+		esac
+	done
+}
+
+validate_offline_nas_plan() {
+	(($# > 0)) || return 0
+	local plan_dir plan_log plan_sources plan_source_parts deb filename normalized
+	local -a plan_debs=()
+	plan_dir="$(mktemp -d /tmp/hfl-nas-plan-XXXXXX)"
+	plan_log="${plan_dir}/apt-plan.log"
+	plan_sources="${plan_dir}/sources.list"
+	plan_source_parts="${plan_dir}/sources.list.d"
+	: >"${plan_sources}"
+	mkdir "${plan_source_parts}"
+	for deb in "$@"; do
+		filename="${deb##*/}"
+		normalized="${plan_dir}/${filename//:/_}"
+		[[ ! -e "${normalized}" ]] \
+			|| { rm -rf "${plan_dir}"; log_fail "The NAS dependency bundle contains conflicting package filenames." 2; }
+		ln -s -- "${deb}" "${normalized}"
+		plan_debs+=("${normalized}")
+	done
+
+	if ! LC_ALL=C apt-get --simulate --no-download --no-install-recommends \
+		-o Dir::Etc::sourcelist="${plan_sources}" \
+		-o Dir::Etc::sourceparts="${plan_source_parts}" \
+		install "${plan_debs[@]}" \
+		>"${plan_log}" 2>&1; then
+		cat "${plan_log}" >&2
+		rm -rf "${plan_dir}"
+		log_fail "NAS dependencies cannot be installed safely from the offline package set." 2
+	fi
+	if grep -Eq \
+		'^The following packages will be (upgraded|REMOVED|DOWNGRADED):|^[1-9][0-9]* upgraded,| [1-9][0-9]* downgraded,| [1-9][0-9]* to remove' \
+		"${plan_log}"; then
+		cat "${plan_log}" >&2
+		rm -rf "${plan_dir}"
+		log_fail "NAS dependencies cannot be installed without changing existing system packages." 2
+	fi
+	rm -rf "${plan_dir}"
+}
+
 install_nas_deps() {
 	local role="${1:-}"
 	local package_root="${2:-${BUNDLE_ROOT}}"
@@ -2099,18 +2160,28 @@ install_nas_deps() {
 		echo "ERROR: dpkg is required to install bundled NAS dependencies" >&2
 		exit 2
 	fi
+	if ! command -v dpkg-deb >/dev/null 2>&1 || ! command -v apt-get >/dev/null 2>&1; then
+		echo "ERROR: dpkg-deb and apt-get are required to validate bundled NAS dependencies" >&2
+		exit 2
+	fi
 
 	log_ok "install NAS packages for role=${role} (offline ${ubuntu_flavor}/${arch})"
-	local -a deb_files=()
-	mapfile -t deb_files < <(find "${deps_dir}" -maxdepth 1 -type f -name '*.deb' -print | sort)
+	local -a NAS_DEB_FILES=()
+	select_missing_nas_debs "${deps_dir}"
+	validate_offline_nas_plan "${NAS_DEB_FILES[@]}"
 	local install_ok=0 attempt audit
-	for attempt in 1 2 3; do
-		if DEBIAN_FRONTEND=noninteractive dpkg -i "${deb_files[@]}"; then
-			install_ok=1
-			break
-		fi
-		log_warn "Offline NAS dependency install pass ${attempt}/3 reported unresolved package ordering; retrying..."
-	done
+	if ((${#NAS_DEB_FILES[@]} == 0)); then
+		install_ok=1
+		log_skip "all bundled NAS dependencies are already installed"
+	else
+		for attempt in 1 2 3; do
+			if DEBIAN_FRONTEND=noninteractive dpkg -i "${NAS_DEB_FILES[@]}"; then
+				install_ok=1
+				break
+			fi
+			log_warn "Offline NAS dependency install pass ${attempt}/3 reported unresolved package ordering; retrying..."
+		done
+	fi
 	audit="$(dpkg --audit 2>&1 || true)"
 	if [[ "${install_ok}" -ne 1 || -n "${audit}" ]]; then
 		[[ -z "${audit}" ]] || printf '%s\n' "${audit}" >&2

--- a/tools/quality/test-offline-nas-package-plan.sh
+++ b/tools/quality/test-offline-nas-package-plan.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Verify that offline NAS dependency installation preserves healthy host packages.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+installer="${ROOT}/src/agent/packaging/install/install.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+mkdir -p "${tmp}/bin" "${tmp}/debs"
+
+# Load helpers without dispatching the real installer.
+# shellcheck disable=SC1090
+source <(sed '/^case "$CMD" in/,$d' "${installer}")
+
+cat >"${tmp}/bin/dpkg-deb" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${3:-}" in
+Package)
+	case "${2##*/}" in
+	python3_*) printf 'python3\n' ;;
+	nfs-common_*) printf 'nfs-common\n' ;;
+	cifs-utils_*) printf 'cifs-utils\n' ;;
+	rpcbind_*) printf 'rpcbind\n' ;;
+	broken_*) printf 'broken\n' ;;
+	*) exit 2 ;;
+	esac
+	;;
+Architecture) printf 'amd64\n' ;;
+*) exit 2 ;;
+esac
+SH
+cat >"${tmp}/bin/dpkg-query" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${*: -1}" in
+python3:amd64) printf 'hi ' ;;
+nfs-common:amd64) printf 'un ' ;;
+rpcbind:amd64) printf 'rc ' ;;
+broken:amd64) printf 'iU ' ;;
+*) exit 1 ;;
+esac
+SH
+cat >"${tmp}/bin/apt-get" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >"${HFL_NAS_TEST_STATE}/apt-args"
+sources=""
+source_parts=""
+previous=""
+for argument in "$@"; do
+	case "${previous}" in
+	Dir::Etc::sourcelist) sources="${argument}" ;;
+	Dir::Etc::sourceparts) source_parts="${argument}" ;;
+	esac
+	case "${argument}" in
+	Dir::Etc::sourcelist=*) sources="${argument#*=}" ;;
+	Dir::Etc::sourceparts=*) source_parts="${argument#*=}" ;;
+	esac
+	previous="${argument}"
+done
+[[ -f "${sources}" && ! -s "${sources}" ]]
+[[ -d "${source_parts}" ]]
+case "${HFL_TEST_APT_RESULT:-safe}" in
+upgrade)
+	printf 'The following packages will be upgraded:\n  python3\n'
+	printf '1 upgraded, 3 newly installed, 0 to remove and 0 not upgraded.\n'
+	;;
+downgrade)
+	printf 'The following packages will be DOWNGRADED:\n  python3\n'
+	printf '0 upgraded, 3 newly installed, 1 downgraded, 0 to remove and 0 not upgraded.\n'
+	;;
+remove)
+	printf 'The following packages will be REMOVED:\n  python3\n'
+	printf '0 upgraded, 3 newly installed, 1 to remove and 0 not upgraded.\n'
+	;;
+unresolved)
+	printf 'Unable to satisfy the offline dependency plan.\n' >&2
+	exit 100
+	;;
+*) printf '0 upgraded, 3 newly installed, 0 to remove and 0 not upgraded.\n' ;;
+esac
+SH
+chmod +x "${tmp}/bin/"*
+
+for package in \
+	'python3_3.12.3_amd64.deb' \
+	'nfs-common_2.6.4_amd64.deb' \
+	'cifs-utils_2:7.0_amd64.deb' \
+	'rpcbind_1.2.6_amd64.deb'; do
+	: >"${tmp}/debs/${package}"
+done
+
+PATH="${tmp}/bin:${PATH}"
+export PATH
+export HFL_NAS_TEST_STATE="${tmp}"
+
+NAS_DEB_FILES=()
+select_missing_nas_debs "${tmp}/debs"
+[[ "${#NAS_DEB_FILES[@]}" -eq 3 ]]
+[[ " ${NAS_DEB_FILES[*]} " != *'python3_3.12.3_amd64.deb'* ]]
+[[ " ${NAS_DEB_FILES[*]} " == *'rpcbind_1.2.6_amd64.deb'* ]]
+validate_offline_nas_plan "${NAS_DEB_FILES[@]}"
+grep -F 'Dir::Etc::sourcelist=/tmp/hfl-nas-plan-' "${tmp}/apt-args" >/dev/null
+grep -F 'Dir::Etc::sourceparts=/tmp/hfl-nas-plan-' "${tmp}/apt-args" >/dev/null
+grep -F 'cifs-utils_2_7.0_amd64.deb' "${tmp}/apt-args" >/dev/null
+
+for scenario in upgrade downgrade remove; do
+	set +e
+	(
+		exec 3>&1 4>&2
+		HFL_TEST_APT_RESULT="${scenario}" validate_offline_nas_plan "${NAS_DEB_FILES[@]}"
+	) >"${tmp}/${scenario}.log" 2>&1
+	unsafe_status=$?
+	set -e
+	[[ "${unsafe_status}" -eq 2 ]]
+	grep -F 'cannot be installed without changing existing system packages' "${tmp}/${scenario}.log" >/dev/null
+done
+
+set +e
+(
+	exec 3>&1 4>&2
+	HFL_TEST_APT_RESULT=unresolved validate_offline_nas_plan "${NAS_DEB_FILES[@]}"
+) >"${tmp}/unresolved.log" 2>&1
+unresolved_status=$?
+set -e
+[[ "${unresolved_status}" -eq 2 ]]
+grep -F 'cannot be installed safely from the offline package set' "${tmp}/unresolved.log" >/dev/null
+
+: >"${tmp}/debs/broken_1.0_amd64.deb"
+set +e
+(
+	exec 3>&1 4>&2
+	NAS_DEB_FILES=()
+	select_missing_nas_debs "${tmp}/debs"
+) >"${tmp}/broken.log" 2>&1
+broken_status=$?
+set -e
+[[ "${broken_status}" -eq 2 ]]
+grep -F 'package broken is not in a healthy state' "${tmp}/broken.log" >/dev/null
+
+printf 'Offline NAS package plan checks passed.\n'


### PR DESCRIPTION
## Summary

- skip healthy host packages when installing bundled NAS dependencies
- reject incomplete package states and unsafe APT plans before changing the host
- validate the selected local packages without downloads or configured APT sources
- cover upgrades, downgrades, removals, unresolved dependencies, multiarch package lookup, and residual configurations in release checks

## Validation

- `./tools/quality/test-offline-nas-package-plan.sh`
- `./tools/quality/test-agent-installer-output.sh`
- `./tools/quality/test-offline-docker-package-plan.sh`
- `./tools/quality/test-agent-gateway-uninstall.sh`
- `./tools/quality/check-release-contracts.sh`
- Bash 4.2 compatibility check
- shell syntax and `git diff --check`
- offline plan checks with existing Ubuntu 20.04, 22.04, and 24.04 Agent bundles

## Compatibility note

The existing Ubuntu 20.04 Agent bundle does not contain `libssl1.1`, which is required by its bundled `libkrb5-3`. The new preflight safely rejects that incomplete package plan before modifying the host. Ubuntu 22.04 and 24.04 bundle plans pass.