### PR TITLE
Harden SourceLens WebSocket capacity

### DIFF
--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -396,7 +396,7 @@ ${sentry_volume_block}
       # Hide the host Agent's same-filesystem deletion quarantine from LensNode.
       - ${HFL_GATEWAY_TRASH_ROOT}:mode=0700
     mem_limit: 2g
-    cpus: 0.50
+    cpus: 1.00
 EOF
 	)
 	chmod 0600 "${compose_temporary}"

--- a/deploy/installer/sourcelens/docker-compose.template.yml
+++ b/deploy/installer/sourcelens/docker-compose.template.yml
@@ -12,6 +12,8 @@ services:
       - ./.env
     environment:
       API_WORKERS: "1"
+      UVICORN_WS_PING_INTERVAL: "45"
+      UVICORN_WS_PING_TIMEOUT: "180"
       SENTRY_COMPONENT: sourcelens-backend
       SENTRY_RELEASE: ${SENTRY_RELEASE:-}
       SENTRY_SERVICE: api
@@ -40,7 +42,7 @@ services:
         condition: service_healthy
     command: gunicorn
     mem_limit: 2g
-    cpus: 0.50
+    cpus: 1.00
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
       interval: 30s
@@ -141,7 +143,7 @@ services:
       api:
         condition: service_healthy
     mem_limit: 2g
-    cpus: 0.50
+    cpus: 1.00
 # HFL_EMBED_LENSNODE_SERVICE_END
 
   nginx:

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1640,7 +1640,15 @@ done
 sourcelens_compose_template="${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml"
 [[ "$(grep -Fc '    mem_limit: 2g' "${sourcelens_compose_template}" || true)" -eq 2 ]] \
 	|| { printf 'ERROR: bundled SourceLens API and LensNode must both use a 2 GiB limit\n' >&2; exit 1; }
+[[ "$(grep -Fc '    cpus: 1.00' "${sourcelens_compose_template}" || true)" -eq 2 ]] \
+	|| { printf 'ERROR: bundled SourceLens API and LensNode must both use a 1 CPU limit\n' >&2; exit 1; }
+grep -F '      UVICORN_WS_PING_INTERVAL: "45"' \
+	"${sourcelens_compose_template}" >/dev/null
+grep -F '      UVICORN_WS_PING_TIMEOUT: "180"' \
+	"${sourcelens_compose_template}" >/dev/null
 grep -F '    mem_limit: 2g' \
+	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
+grep -F '    cpus: 1.00' \
 	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
 if grep -E 'mem_limit: (64|320|384|448)m|cpus: (0\.05|0\.10|0\.15|0\.20|0\.30)' \
 	"${ROOT}/deploy/docker-compose.yml" \


### PR DESCRIPTION
## Summary

- increase the bundled SourceLens API CPU limit from 0.5 to 1 CPU
- increase both embedded and private Data Gateway LensNode CPU limits from 0.5 to 1 CPU
- configure a 45-second WebSocket ping interval with a 180-second timeout
- enforce the deployment resource and keepalive settings in release contract checks

## Scope

This is a deployment-only stability hardening change. It does not modify Chat lifecycle, queueing, concurrency, retry, or cleanup behavior.

Related upstream tracking: oneprolabs/sourcelens#498

## Validation

- Release contract checks
- Compose command compatibility checks
- Gateway sidecar resumable upgrade contracts
- Platform Gateway auto-deploy contracts
- Docker Compose template parsing
- Shell syntax checks
- Git diff checks