### PR TITLE
fix(restore): report selected subtree progress totals

### DIFF
--- a/src/agent/internal/engine/managed_backup.go
+++ b/src/agent/internal/engine/managed_backup.go
@@ -2962,8 +2962,32 @@ func (e *Engine) runManagedRestore(
 	if len(selectedPaths) == 0 {
 		selectedPaths = []string{""}
 	}
+	entrySummaries := make(map[string]kopia.EntrySummary, len(selectedPaths))
+	scopeTotals := restoreScopeTotals{}
+	scopeTotalsKnown := true
+	for _, selectedPath := range selectedPaths {
+		summary, _, summaryErr := inspectManagedRestoreEntrySummary(
+			ctx,
+			bin,
+			configFile,
+			env,
+			p.SnapshotID,
+			selectedPath,
+		)
+		if summaryErr != nil {
+			scopeTotalsKnown = false
+			continue
+		}
+		entrySummaries[selectedPath] = summary
+		var totalsOK bool
+		scopeTotals, totalsOK = addRestoreEntrySummary(scopeTotals, summary)
+		if !totalsOK {
+			scopeTotalsKnown = false
+		}
+	}
 	restored := make([]map[string]any, 0, len(selectedPaths))
 	var completedBytes int64
+	var completedCount int64
 	var skippedSpecialCount int64
 	progressState := newKopiaProgressReporter()
 	runCtx, cancelRun := context.WithCancel(ctx)
@@ -2972,6 +2996,9 @@ func (e *Engine) runManagedRestore(
 	stallDone := make(chan struct{})
 	go monitorKopiaProgressStall(runCtx, cancelRun, progressState, stallSeconds, stallDone)
 	defer close(stallDone)
+	if scopeTotalsKnown {
+		_ = sendProgress(ctx, rep, taskID, scopeTotals.progressPayload(0, 0))
+	}
 
 	for pathIndex, selectedPath := range selectedPaths {
 		source := snapshotObjectPath(p.SnapshotID, selectedPath)
@@ -2982,19 +3009,30 @@ func (e *Engine) runManagedRestore(
 		if err := validateLensManagedRestoreTarget(p, restoreTarget); err != nil {
 			return "failed", result, err.Error()
 		}
-		sourceIsDir, inspectRes, inspectErr := snapshotDownloadTargetIsDir(ctx, bin, configFile, env, source)
-		sourceObjectType := "directory"
-		if inspectErr != nil {
-			sourceObjectType = "unknown"
-		} else if !sourceIsDir {
-			sourceObjectType = "file"
+		summary, hasSummary := entrySummaries[selectedPath]
+		sourceIsDir := hasSummary && summary.PathType == "directory"
+		sourceObjectType := summary.PathType
+		var inspectRes process.Result
+		var inspectErr error
+		if !hasSummary || sourceObjectType == "unsupported" {
+			sourceIsDir, inspectRes, inspectErr = snapshotDownloadTargetIsDir(ctx, bin, configFile, env, source)
+			sourceObjectType = "directory"
+			if inspectErr != nil {
+				sourceObjectType = "unknown"
+			} else if !sourceIsDir {
+				sourceObjectType = "file"
+			}
 		}
 		restoreEntry := map[string]any{
 			"snapshot_path":      source,
 			"target_path":        restoreTarget,
 			"source_is_dir":      sourceIsDir,
 			"source_object_type": sourceObjectType,
-			"snapshot_inspect":   managedRestoreCommandResult(inspectRes, spec, p),
+		}
+		if hasSummary {
+			restoreEntry["snapshot_summary"] = summary
+		} else {
+			restoreEntry["snapshot_inspect"] = managedRestoreCommandResult(inspectRes, spec, p)
 		}
 		if inspectErr != nil {
 			restored = append(restored, restoreEntry)
@@ -3017,9 +3055,11 @@ func (e *Engine) runManagedRestore(
 			return "failed", result, mkErr.Error()
 		}
 		pathOffset := completedBytes
+		pathCountOffset := completedCount
 		pathIndexValue := pathIndex + 1
 		pathTotal := len(selectedPaths)
 		var lastPathTotal int64
+		var lastPathCount int64
 		onProgressLine := func(line string, _ bool) {
 			snapshot, ok := kopia.ParseRestoreProgressLine(line)
 			if !ok {
@@ -3028,17 +3068,13 @@ func (e *Engine) runManagedRestore(
 			if snapshot.TotalBytes > 0 {
 				lastPathTotal = snapshot.TotalBytes
 			}
+			if snapshot.TotalCount > 0 {
+				lastPathCount = snapshot.TotalCount
+			}
 			payload := kopia.RestoreProgressPayload(snapshot)
 			payload["path_index"] = pathIndexValue
 			payload["path_total"] = pathTotal
-			if pathOffset > 0 {
-				if done, ok := payload["bytes_done"].(int64); ok {
-					payload["bytes_done"] = done + pathOffset
-				}
-				if total, ok := payload["bytes_total"].(int64); ok && total > 0 {
-					payload["bytes_total"] = total + pathOffset
-				}
-			}
+			applyRestoreScopeProgress(payload, scopeTotals, scopeTotalsKnown, pathOffset, pathCountOffset)
 			progressState.maybeSendRestore(runCtx, rep, taskID, payload)
 		}
 		restoreArgs := []string{
@@ -3069,8 +3105,12 @@ func (e *Engine) runManagedRestore(
 			skippedSpecialCount += skipped
 			restoreEntry["skipped_special_count"] = skipped
 		}
-		if lastPathTotal > 0 {
+		if hasSummary && summary.Complete {
+			completedBytes += summary.SizeBytes
+			completedCount += summary.TotalCount()
+		} else if lastPathTotal > 0 || lastPathCount > 0 {
 			completedBytes += lastPathTotal
+			completedCount += lastPathCount
 		}
 	}
 	if err := validateLensManagedRestoreTarget(p, targetPath); err != nil {
@@ -3081,11 +3121,14 @@ func (e *Engine) runManagedRestore(
 	result["selected_paths"] = selectedPaths
 	result["restore_results"] = restored
 	result["count"] = len(restored)
+	if scopeTotalsKnown {
+		result["restore_scope_summary"] = restoreScopeSummaryResult(scopeTotals)
+	}
 	if insightContentPolicy == insightRegularFilesOnlyPolicy {
 		result["insight_content_policy"] = insightRegularFilesOnlyPolicy
 		result["skipped_special_count"] = skippedSpecialCount
 	}
-	_ = sendProgress(ctx, rep, taskID, map[string]any{
+	completionProgress := map[string]any{
 		"phase":             "kopia_transfer",
 		"kopia_phase":       "restore_completed",
 		"kopia_percent":     100,
@@ -3093,7 +3136,16 @@ func (e *Engine) runManagedRestore(
 		"bytes_done":        maxInt64(completedBytes, 1),
 		"bytes_total":       maxInt64(completedBytes, 1),
 		"bytes_total_known": true,
-	})
+		"processed_count":   completedCount,
+		"total_count":       completedCount,
+	}
+	if scopeTotalsKnown {
+		completionProgress = scopeTotals.progressPayload(scopeTotals.SizeBytes, scopeTotals.totalCount())
+		completionProgress["kopia_phase"] = "restore_completed"
+		completionProgress["kopia_percent"] = 100
+		completionProgress["percent"] = 100
+	}
+	_ = sendProgress(ctx, rep, taskID, completionProgress)
 	return "success", result, ""
 }
 
@@ -3401,16 +3453,40 @@ func restoreSelectedPaths(p Payload) []string {
 	}
 	paths := make([]string, 0, len(raw))
 	for _, item := range raw {
-		value := strings.Trim(strings.TrimSpace(fmt.Sprint(item)), "/\\")
+		value := strings.TrimSpace(fmt.Sprint(item))
 		if value == "" || value == "." {
+			return []string{""}
+		}
+		value = strings.Trim(path.Clean(filepath.ToSlash(value)), "/")
+		if value == "" || value == "." {
+			return []string{""}
+		}
+		covered := false
+		for _, existing := range paths {
+			if restorePathCoversSelection(existing, value) {
+				covered = true
+				break
+			}
+		}
+		if covered {
 			continue
 		}
-		paths = append(paths, filepath.ToSlash(value))
+		filtered := paths[:0]
+		for _, existing := range paths {
+			if !restorePathCoversSelection(value, existing) {
+				filtered = append(filtered, existing)
+			}
+		}
+		paths = append(filtered, value)
 	}
 	if len(paths) == 0 {
 		return []string{""}
 	}
 	return paths
+}
+
+func restorePathCoversSelection(ancestor string, candidate string) bool {
+	return candidate == ancestor || strings.HasPrefix(candidate, ancestor+"/")
 }
 
 func restoreTargetPathForSelection(p Payload, targetPath string, selectedPath string) string {

--- a/src/agent/internal/engine/restore_scope_summary.go
+++ b/src/agent/internal/engine/restore_scope_summary.go
@@ -1,0 +1,170 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"hyperfilelens/agent/internal/platform/kopia"
+	"hyperfilelens/agent/internal/platform/process"
+)
+
+type restoreScopeTotals struct {
+	SizeBytes      int64
+	FileCount      int64
+	DirectoryCount int64
+	SymlinkCount   int64
+}
+
+func inspectManagedRestoreEntrySummary(
+	ctx context.Context,
+	bin string,
+	configFile string,
+	env map[string]string,
+	snapshotID string,
+	selectedPath string,
+) (kopia.EntrySummary, process.Result, error) {
+	result, err := process.Run(
+		ctx,
+		bin,
+		[]string{
+			"--config-file=" + configFile,
+			"ls",
+			"--hfl-summary",
+			snapshotObjectPath(snapshotID, selectedPath),
+		},
+		env,
+		"",
+	)
+	if err != nil {
+		return kopia.EntrySummary{}, result, err
+	}
+	summary, ok := kopia.ParseEntrySummary(result.Stdout)
+	if !ok {
+		return kopia.EntrySummary{}, result, fmt.Errorf("invalid Kopia entry summary")
+	}
+	return summary, result, nil
+}
+
+func addRestoreEntrySummary(total restoreScopeTotals, summary kopia.EntrySummary) (restoreScopeTotals, bool) {
+	if !summary.Complete {
+		return total, false
+	}
+	var ok bool
+	if total.SizeBytes, ok = addRestoreSummaryCounter(total.SizeBytes, summary.SizeBytes); !ok {
+		return restoreScopeTotals{}, false
+	}
+	if total.FileCount, ok = addRestoreSummaryCounter(total.FileCount, summary.FileCount); !ok {
+		return restoreScopeTotals{}, false
+	}
+	if total.DirectoryCount, ok = addRestoreSummaryCounter(total.DirectoryCount, summary.DirectoryCount); !ok {
+		return restoreScopeTotals{}, false
+	}
+	if total.SymlinkCount, ok = addRestoreSummaryCounter(total.SymlinkCount, summary.SymlinkCount); !ok {
+		return restoreScopeTotals{}, false
+	}
+	filesAndDirs, ok := addRestoreSummaryCounter(total.FileCount, total.DirectoryCount)
+	if !ok {
+		return restoreScopeTotals{}, false
+	}
+	if _, ok = addRestoreSummaryCounter(filesAndDirs, total.SymlinkCount); !ok {
+		return restoreScopeTotals{}, false
+	}
+	return total, true
+}
+
+func addRestoreSummaryCounter(current int64, next int64) (int64, bool) {
+	if current < 0 || next < 0 || current > math.MaxInt64-next {
+		return 0, false
+	}
+	return current + next, true
+}
+
+func (t restoreScopeTotals) totalCount() int64 {
+	filesAndDirs, ok := addRestoreSummaryCounter(t.FileCount, t.DirectoryCount)
+	if !ok {
+		return 0
+	}
+	total, ok := addRestoreSummaryCounter(filesAndDirs, t.SymlinkCount)
+	if !ok {
+		return 0
+	}
+	return total
+}
+
+func (t restoreScopeTotals) progressPayload(bytesDone int64, processedCount int64) map[string]any {
+	return map[string]any{
+		"progress_schema_version": 1,
+		"phase":                   "kopia_transfer",
+		"kopia_phase":             "restoring",
+		"kopia_percent":           0,
+		"percent":                 0,
+		"bytes_done":              bytesDone,
+		"processed_bytes":         bytesDone,
+		"bytes_total":             t.SizeBytes,
+		"total_bytes":             t.SizeBytes,
+		"bytes_total_known":       true,
+		"processed_count":         processedCount,
+		"file_done":               processedCount,
+		"total_count":             t.totalCount(),
+		"file_total":              t.totalCount(),
+		"total_file_count":        t.FileCount,
+		"total_directory_count":   t.DirectoryCount,
+		"total_symlink_count":     t.SymlinkCount,
+		"totals_source":           "snapshot_summary",
+	}
+}
+
+func restoreScopeSummaryResult(t restoreScopeTotals) map[string]any {
+	return map[string]any{
+		"size_bytes":      t.SizeBytes,
+		"file_count":      t.FileCount,
+		"directory_count": t.DirectoryCount,
+		"symlink_count":   t.SymlinkCount,
+		"total_count":     t.totalCount(),
+		"complete":        true,
+		"source":          "snapshot_summary",
+	}
+}
+
+func int64ValueOrZero(raw any) int64 {
+	value, _ := int64Value(raw)
+	return value
+}
+
+func applyRestoreScopeProgress(
+	payload map[string]any,
+	totals restoreScopeTotals,
+	totalsKnown bool,
+	bytesOffset int64,
+	countOffset int64,
+) {
+	bytesDone, _ := addRestoreSummaryCounter(int64ValueOrZero(payload["bytes_done"]), bytesOffset)
+	processedCount, _ := addRestoreSummaryCounter(int64ValueOrZero(payload["processed_count"]), countOffset)
+	payload["bytes_done"] = bytesDone
+	payload["processed_bytes"] = bytesDone
+	payload["processed_count"] = processedCount
+	payload["file_done"] = processedCount
+
+	if totalsKnown {
+		for key, value := range totals.progressPayload(bytesDone, processedCount) {
+			if key != "kopia_percent" && key != "percent" && key != "kopia_phase" {
+				payload[key] = value
+			}
+		}
+		return
+	}
+
+	if pathTotal := int64ValueOrZero(payload["bytes_total"]); pathTotal > 0 {
+		if total, ok := addRestoreSummaryCounter(pathTotal, bytesOffset); ok {
+			payload["bytes_total"] = total
+			payload["total_bytes"] = total
+		}
+	}
+	if pathCount := int64ValueOrZero(payload["total_count"]); pathCount > 0 {
+		if total, ok := addRestoreSummaryCounter(pathCount, countOffset); ok {
+			payload["total_count"] = total
+			payload["file_total"] = total
+		}
+	}
+}

--- a/src/agent/internal/engine/restore_scope_summary_test.go
+++ b/src/agent/internal/engine/restore_scope_summary_test.go
@@ -1,0 +1,92 @@
+package engine
+
+import (
+	"math"
+	"testing"
+
+	"hyperfilelens/agent/internal/platform/kopia"
+)
+
+func TestAddRestoreEntrySummary(t *testing.T) {
+	total, ok := addRestoreEntrySummary(restoreScopeTotals{}, kopia.EntrySummary{
+		Complete:       true,
+		SizeBytes:      100,
+		FileCount:      3,
+		DirectoryCount: 2,
+		SymlinkCount:   1,
+	})
+	if !ok {
+		t.Fatal("expected complete summary to aggregate")
+	}
+	total, ok = addRestoreEntrySummary(total, kopia.EntrySummary{
+		Complete:       true,
+		SizeBytes:      20,
+		FileCount:      1,
+		DirectoryCount: 1,
+	})
+	if !ok || total.SizeBytes != 120 || total.FileCount != 4 || total.DirectoryCount != 3 || total.SymlinkCount != 1 {
+		t.Fatalf("unexpected aggregate: %#v, ok=%v", total, ok)
+	}
+	if total.totalCount() != 8 {
+		t.Fatalf("totalCount() = %d, want 8", total.totalCount())
+	}
+	payload := total.progressPayload(12, 2)
+	if payload["bytes_total"] != int64(120) || payload["total_count"] != int64(8) || payload["totals_source"] != "snapshot_summary" {
+		t.Fatalf("unexpected progress payload: %#v", payload)
+	}
+}
+
+func TestAddRestoreEntrySummaryRejectsIncompleteAndOverflow(t *testing.T) {
+	if _, ok := addRestoreEntrySummary(restoreScopeTotals{}, kopia.EntrySummary{Complete: false}); ok {
+		t.Fatal("expected incomplete summary to remain unknown")
+	}
+	if _, ok := addRestoreEntrySummary(
+		restoreScopeTotals{SizeBytes: math.MaxInt64},
+		kopia.EntrySummary{Complete: true, SizeBytes: 1},
+	); ok {
+		t.Fatal("expected overflowing summary to remain unknown")
+	}
+}
+
+func TestRestoreSelectedPathsDeduplicatesCoveredDescendants(t *testing.T) {
+	payload := Payload{Extra: map[string]any{
+		"selected_paths": []any{"docs/reports", "docs", "images", "images"},
+	}}
+	paths := restoreSelectedPaths(payload)
+	if len(paths) != 2 || paths[0] != "docs" || paths[1] != "images" {
+		t.Fatalf("restoreSelectedPaths() = %#v, want [docs images]", paths)
+	}
+
+	payload.Extra["selected_paths"] = []any{"docs", ""}
+	paths = restoreSelectedPaths(payload)
+	if len(paths) != 1 || paths[0] != "" {
+		t.Fatalf("root selection must cover descendants, got %#v", paths)
+	}
+}
+
+func TestApplyRestoreScopeProgressUsesAggregateSummary(t *testing.T) {
+	payload := map[string]any{
+		"kopia_phase":     "restoring",
+		"kopia_percent":   50,
+		"bytes_done":      int64(20),
+		"bytes_total":     int64(40),
+		"processed_count": int64(2),
+		"total_count":     int64(4),
+	}
+	applyRestoreScopeProgress(payload, restoreScopeTotals{
+		SizeBytes:      150,
+		FileCount:      5,
+		DirectoryCount: 2,
+		SymlinkCount:   1,
+	}, true, 50, 3)
+
+	if payload["bytes_done"] != int64(70) || payload["processed_bytes"] != int64(70) {
+		t.Fatalf("unexpected byte progress: %#v", payload)
+	}
+	if payload["bytes_total"] != int64(150) || payload["processed_count"] != int64(5) || payload["total_count"] != int64(8) {
+		t.Fatalf("unexpected scoped totals: %#v", payload)
+	}
+	if payload["kopia_percent"] != 50 {
+		t.Fatalf("Kopia percent must remain live: %#v", payload)
+	}
+}

--- a/src/agent/internal/platform/kopia/entry_summary.go
+++ b/src/agent/internal/platform/kopia/entry_summary.go
@@ -1,0 +1,61 @@
+package kopia
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// EntrySummary is the bounded recursive metadata emitted by the HFL Kopia
+// list --hfl-summary operation. DirectoryCount includes the selected directory.
+type EntrySummary struct {
+	Version           int    `json:"version"`
+	PathType          string `json:"path_type"`
+	SizeBytes         int64  `json:"size_bytes"`
+	FileCount         int64  `json:"file_count"`
+	DirectoryCount    int64  `json:"directory_count"`
+	SymlinkCount      int64  `json:"symlink_count"`
+	SummaryAvailable  bool   `json:"summary_available"`
+	Complete          bool   `json:"complete"`
+	IncompleteReason  string `json:"incomplete_reason,omitempty"`
+	FatalErrorCount   int    `json:"fatal_error_count,omitempty"`
+	IgnoredErrorCount int    `json:"ignored_error_count,omitempty"`
+}
+
+// ParseEntrySummary validates one HFL Kopia entry-summary response.
+func ParseEntrySummary(raw string) (EntrySummary, bool) {
+	var summary EntrySummary
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &summary); err != nil {
+		return EntrySummary{}, false
+	}
+	if summary.Version != 1 || summary.SizeBytes < 0 || summary.FileCount < 0 ||
+		summary.DirectoryCount < 0 || summary.SymlinkCount < 0 ||
+		summary.FatalErrorCount < 0 || summary.IgnoredErrorCount < 0 {
+		return EntrySummary{}, false
+	}
+	switch summary.PathType {
+	case "directory":
+		if summary.Complete && !summary.SummaryAvailable {
+			return EntrySummary{}, false
+		}
+	case "file":
+		if summary.FileCount != 1 || summary.DirectoryCount != 0 || summary.SymlinkCount != 0 {
+			return EntrySummary{}, false
+		}
+	case "symlink":
+		if summary.SizeBytes != 0 || summary.FileCount != 0 || summary.DirectoryCount != 0 || summary.SymlinkCount != 1 {
+			return EntrySummary{}, false
+		}
+	case "unsupported":
+		if summary.Complete {
+			return EntrySummary{}, false
+		}
+	default:
+		return EntrySummary{}, false
+	}
+	return summary, true
+}
+
+// TotalCount matches Kopia restore's file, directory, and symlink item count.
+func (s EntrySummary) TotalCount() int64 {
+	return s.FileCount + s.DirectoryCount + s.SymlinkCount
+}

--- a/src/agent/internal/platform/kopia/entry_summary_test.go
+++ b/src/agent/internal/platform/kopia/entry_summary_test.go
@@ -1,0 +1,57 @@
+package kopia
+
+import "testing"
+
+func TestParseEntrySummary(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantOK    bool
+		wantType  string
+		wantSize  int64
+		wantItems int64
+	}{
+		{
+			name:      "complete directory",
+			raw:       `{"version":1,"path_type":"directory","size_bytes":8388608,"file_count":5,"directory_count":2,"symlink_count":1,"summary_available":true,"complete":true}`,
+			wantOK:    true,
+			wantType:  "directory",
+			wantSize:  8388608,
+			wantItems: 8,
+		},
+		{
+			name:      "incomplete directory remains usable for type detection",
+			raw:       `{"version":1,"path_type":"directory","summary_available":true,"complete":false,"incomplete_reason":"incomplete snapshot"}`,
+			wantOK:    true,
+			wantType:  "directory",
+			wantItems: 0,
+		},
+		{
+			name:      "file",
+			raw:       `{"version":1,"path_type":"file","size_bytes":12,"file_count":1,"complete":true}`,
+			wantOK:    true,
+			wantType:  "file",
+			wantSize:  12,
+			wantItems: 1,
+		},
+		{name: "missing summary cannot be complete", raw: `{"version":1,"path_type":"directory","complete":true}`, wantOK: false},
+		{name: "negative count", raw: `{"version":1,"path_type":"directory","file_count":-1}`, wantOK: false},
+		{name: "unknown version", raw: `{"version":2,"path_type":"file","file_count":1,"complete":true}`, wantOK: false},
+		{name: "invalid json", raw: `{`, wantOK: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			summary, ok := ParseEntrySummary(test.raw)
+			if ok != test.wantOK {
+				t.Fatalf("ParseEntrySummary() ok = %v, want %v", ok, test.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if summary.PathType != test.wantType || summary.SizeBytes != test.wantSize || summary.TotalCount() != test.wantItems {
+				t.Fatalf("ParseEntrySummary() = %#v, want type=%q size=%d items=%d", summary, test.wantType, test.wantSize, test.wantItems)
+			}
+		})
+	}
+}

--- a/src/agent/scripts/package.sh
+++ b/src/agent/scripts/package.sh
@@ -347,6 +347,11 @@ def validate_kopia_info() -> dict:
             "KOPIA_INFO.json is missing the HFL managed dot-ignore capability; "
             "prepare Kopia in build mode before packaging an Agent"
         )
+    if features.get("hfl_entry_summary_v1") is not True:
+        raise PrerequisiteError(
+            "KOPIA_INFO.json is missing the HFL entry-summary capability; "
+            "prepare Kopia in build mode before packaging an Agent"
+        )
     return info
 
 

--- a/src/backend/apps/protection/services/progress/kopia_fields.py
+++ b/src/backend/apps/protection/services/progress/kopia_fields.py
@@ -91,7 +91,13 @@ def normalize_lane_progress(
 
     schema_version = progress_int(progress.get("progress_schema_version")) or 1
     bytes_done = progress_int(progress.get("bytes_done"))
+    raw_bytes_total = progress_number(progress.get("bytes_total"))
     bytes_total = progress_int(progress.get("bytes_total"))
+    explicit_zero_total = (
+        bool(progress.get("bytes_total_known"))
+        and raw_bytes_total is not None
+        and raw_bytes_total == 0
+    )
     bytes_total_known = bool(progress.get("bytes_total_known")) or bytes_total > 0
     uploaded = progress_int(progress.get("uploaded_bytes"))
     hashed = progress_int(progress.get("hashed_bytes"))
@@ -122,7 +128,7 @@ def normalize_lane_progress(
         bytes_done = processed or hashed + cached or uploaded
     if bytes_total <= 0:
         bytes_total = progress_int(progress.get("estimated_bytes")) or progress_int(progress.get("total_bytes"))
-        bytes_total_known = bytes_total > 0
+        bytes_total_known = bytes_total > 0 or explicit_zero_total
     reference = max(
         0,
         int(reference_bytes_total or 0),
@@ -163,7 +169,7 @@ def normalize_lane_progress(
     ):
         bytes_total = None
         bytes_total_known = False
-    elif bytes_total_known and bytes_total is not None and not credible_bytes_total(
+    elif bytes_total_known and bytes_total is not None and bytes_total > 0 and not credible_bytes_total(
         bytes_done=bytes_done,
         bytes_total=bytes_total,
     ):
@@ -239,6 +245,7 @@ def normalize_lane_progress(
         kopia_eta_seconds=kopia_eta,
         percent_source=percent_source,
         bytes_total_reference=bytes_total_reference,
+        bytes_total_known=bytes_total_known,
         schema_version=schema_version,
     )
 
@@ -256,9 +263,13 @@ def _lane_from_bytes(
     kopia_eta_seconds: int | None = None,
     percent_source: str | None = None,
     bytes_total_reference: bool = False,
+    bytes_total_known: bool | None = None,
     schema_version: int = 1,
 ) -> dict[str, Any]:
-    bytes_total_known = bytes_total is not None and bytes_total > 0
+    if bytes_total_known is None:
+        bytes_total_known = bytes_total is not None and bytes_total > 0
+    elif bytes_total is None:
+        bytes_total_known = False
     return {
         "kopia_phase": kopia_phase,
         "progress_schema_version": schema_version,

--- a/src/backend/apps/protection/services/progress/restore_runtime.py
+++ b/src/backend/apps/protection/services/progress/restore_runtime.py
@@ -151,7 +151,9 @@ def _lane_from_item(
     sample = item.last_progress_sample if isinstance(item.last_progress_sample, dict) else {}
     normalized = normalize_lane_progress(progress=raw, status=status)
     snapshot_total = int(snapshot_directory.size_bytes or 0) if snapshot_directory is not None else 0
-    if snapshot_total > 0 and status in {s.value for s in _ITEM_ACTIVE}:
+    selected_paths = getattr(item, "selected_paths", None)
+    restores_whole_directory = not any(str(path or "").strip() for path in (selected_paths or []))
+    if snapshot_total > 0 and restores_whole_directory and status in {s.value for s in _ITEM_ACTIVE}:
         lane_total = int(normalized.get("bytes_total") or 0) if normalized.get("bytes_total_known") else 0
         if not normalized.get("bytes_total_known") or lane_total < snapshot_total:
             normalized["bytes_total"] = snapshot_total

--- a/src/backend/apps/protection/services/progress/step3_progress.py
+++ b/src/backend/apps/protection/services/progress/step3_progress.py
@@ -520,6 +520,8 @@ def restore_snapshot_bytes_total(record) -> int:
     from apps.protection.models import BackupSourceSnapshotDirectory
 
     items = list(record.items.all())
+    if any(_restore_item_has_selected_paths(item) for item in items):
+        return 0
     directory_ids = [item.source_snapshot_directory_id for item in items if item.source_snapshot_directory_id]
     if not directory_ids:
         return 0
@@ -534,6 +536,8 @@ def restore_file_count_seed(record) -> int:
     from apps.protection.models import BackupSourceSnapshotDirectory
 
     items = list(record.items.all())
+    if any(_restore_item_has_selected_paths(item) for item in items):
+        return 0
     directory_ids = [item.source_snapshot_directory_id for item in items if item.source_snapshot_directory_id]
     if not directory_ids:
         return 0
@@ -542,6 +546,13 @@ def restore_file_count_seed(record) -> int:
         id__in=directory_ids,
     )
     return sum(max(0, int(directory.file_count or 0)) for directory in directories)
+
+
+def _restore_item_has_selected_paths(item) -> bool:
+    return any(
+        str(path or "").strip()
+        for path in (getattr(item, "selected_paths", None) or [])
+    )
 
 
 def restore_terminal_counts(record) -> dict[str, int] | None:

--- a/src/backend/apps/protection/tests/test_kopia_progress.py
+++ b/src/backend/apps/protection/tests/test_kopia_progress.py
@@ -134,6 +134,26 @@ class KopiaProgressAggregatorTests(SimpleTestCase):
         self.assertIsNone(aggregate["speed_bps"])
         self.assertIsNone(aggregate["eta_seconds"])
 
+    def test_explicit_zero_restore_total_remains_known(self):
+        lane = normalize_lane_progress(
+            progress={
+                "phase": "kopia_transfer",
+                "kopia_phase": "restoring",
+                "bytes_done": 0,
+                "bytes_total": 0,
+                "bytes_total_known": True,
+                "processed_count": 0,
+                "total_count": 1,
+                "kopia_percent": 0,
+            },
+            status="running",
+        )
+
+        self.assertEqual(lane["bytes_total"], 0)
+        self.assertTrue(lane["bytes_total_known"])
+        self.assertEqual(lane["total_count"], 1)
+        self.assertEqual(lane["percent"], 0)
+
     def test_schema_v2_3ec_uses_processed_bytes_for_progress(self):
         processed = 3_478_373_863
         estimated = 4_130_621_356

--- a/src/backend/apps/protection/tests/test_restore_progress.py
+++ b/src/backend/apps/protection/tests/test_restore_progress.py
@@ -46,6 +46,48 @@ class RestoreProgressLaneTests(SimpleTestCase):
         self.assertEqual(progress["bytes_total"], 563_000_000)
         self.assertFalse(progress["bytes_total_reference"])
 
+    def test_selected_path_keeps_scoped_kopia_total(self):
+        item = SimpleNamespace(
+            id=1,
+            status=RestoreRecordItem.Status.RUNNING,
+            selected_paths=["onepro"],
+            last_progress_snapshot={
+                "phase": "kopia_transfer",
+                "kopia_phase": "restoring",
+                "bytes_done": 1_000_000_000,
+                "bytes_total": 7_800_000_000,
+                "bytes_total_known": True,
+                "processed_count": 5_000,
+                "total_count": 59_886,
+            },
+            last_progress_sample={},
+            source_path="/Users/ghw",
+            target_path="/restore/onepro",
+        )
+        snapshot_directory = SimpleNamespace(size_bytes=41_900_000_000)
+        lane = _lane_from_item(item, snapshot_directory=snapshot_directory)
+        progress = lane["progress"]
+        self.assertEqual(progress["bytes_total"], 7_800_000_000)
+        self.assertEqual(progress["total_count"], 59_886)
+        self.assertFalse(progress["bytes_total_reference"])
+
+    def test_selected_path_without_summary_does_not_use_snapshot_root_total(self):
+        item = SimpleNamespace(
+            id=1,
+            status=RestoreRecordItem.Status.RUNNING,
+            selected_paths=["onepro"],
+            last_progress_snapshot={},
+            last_progress_sample={},
+            source_path="/Users/ghw",
+            target_path="/restore/onepro",
+        )
+        snapshot_directory = SimpleNamespace(size_bytes=41_900_000_000)
+        progress = _lane_from_item(item, snapshot_directory=snapshot_directory)[
+            "progress"
+        ]
+        self.assertFalse(progress["bytes_total_known"])
+        self.assertIsNone(progress["bytes_total"])
+
     def test_restore_lane_uses_processed_bytes_not_uploaded(self):
         item = SimpleNamespace(
             id=1,

--- a/src/backend/apps/protection/tests/test_step3_progress.py
+++ b/src/backend/apps/protection/tests/test_step3_progress.py
@@ -11,12 +11,25 @@ from apps.protection.services.progress.step3_progress import (
     compute_step3_eta_seconds,
     enrich_step3_backup_transfer,
     enrich_step3_restore_transfer,
+    restore_file_count_seed,
+    restore_snapshot_bytes_total,
     restore_terminal_counts,
     should_latch_kopia_switch,
 )
 
 
 class Step3ProgressTests(SimpleTestCase):
+    @staticmethod
+    def _restore_record_with_items(items):
+        return SimpleNamespace(items=SimpleNamespace(all=lambda: items))
+
+    def test_selected_paths_disable_snapshot_root_seeds(self):
+        record = self._restore_record_with_items(
+            [SimpleNamespace(source_snapshot_directory_id=11, selected_paths=["onepro"])]
+        )
+        self.assertEqual(restore_snapshot_bytes_total(record), 0)
+        self.assertEqual(restore_file_count_seed(record), 0)
+
     def test_restore_terminal_counts_sum_all_restore_results(self):
         record = SimpleNamespace(
             items=SimpleNamespace(

--- a/tools/kopia/common.sh
+++ b/tools/kopia/common.sh
@@ -19,6 +19,7 @@ KOPIA_PATCH_FILES=(
 	"${KOPIA_TOOLS_DIR}/patches/0002-add-structured-progress.patch"
 	"${KOPIA_TOOLS_DIR}/patches/0003-disable-managed-dot-ignore.patch"
 	"${KOPIA_TOOLS_DIR}/patches/0004-snapshot-estimator-best-effort-errors.patch"
+	"${KOPIA_TOOLS_DIR}/patches/0005-add-entry-summary.patch"
 )
 KOPIA_DEFAULT_MATRIX="linux:amd64 linux:arm64 darwin:amd64 darwin:arm64 windows:amd64"
 

--- a/tools/kopia/patches/0005-add-entry-summary.patch
+++ b/tools/kopia/patches/0005-add-entry-summary.patch
@@ -1,0 +1,276 @@
+diff --git a/cli/command_ls.go b/cli/command_ls.go
+index 7b830d38..6faf99f0 100644
+--- a/cli/command_ls.go
++++ b/cli/command_ls.go
+@@ -2,6 +2,7 @@
+ 
+ import (
+ 	"context"
++	"encoding/json"
+ 	"fmt"
+ 	"strings"
+ 
+@@ -10,6 +11,7 @@
+ 	"github.com/kopia/kopia/fs"
+ 	"github.com/kopia/kopia/repo"
+ 	"github.com/kopia/kopia/repo/object"
++	"github.com/kopia/kopia/snapshot"
+ 	"github.com/kopia/kopia/snapshot/snapshotfs"
+ )
+ 
+@@ -19,6 +21,7 @@ type commandList struct {
+ 	recursive     bool
+ 	showOID       bool
+ 	errorSummary  bool
++	hflSummary    bool
+ 	path          string
+ 
+ 	out textOutput
+@@ -32,6 +35,7 @@ func (c *commandList) setup(svc appServices, parent commandParent) {
+ 	cmd.Flag("recursive", "Recursive output").Short('r').BoolVar(&c.recursive)
+ 	cmd.Flag("show-object-id", "Show object IDs").Short('o').BoolVar(&c.showOID)
+ 	cmd.Flag("error-summary", "Emit error summary").Default("true").BoolVar(&c.errorSummary)
++	cmd.Flag("hfl-summary", "Emit the selected entry summary as JSON").Hidden().BoolVar(&c.hflSummary)
+ 	cmd.Arg("object-path", "Path").Required().StringVar(&c.path)
+ 	cmd.Action(svc.repositoryReaderAction(c.run))
+ 
+@@ -39,6 +43,15 @@ func (c *commandList) setup(svc appServices, parent commandParent) {
+ }
+ 
+ func (c *commandList) run(ctx context.Context, rep repo.Repository) error {
++	if c.hflSummary {
++		entry, err := snapshotfs.FilesystemEntryFromIDWithPath(ctx, rep, c.path, false)
++		if err != nil {
++			return errors.Wrap(err, "unable to get filesystem entry")
++		}
++
++		return c.printHFLSummary(entry)
++	}
++
+ 	dir, err := snapshotfs.FilesystemDirectoryFromIDWithPath(ctx, rep, c.path, false)
+ 	if err != nil {
+ 		return errors.Wrap(err, "unable to get filesystem directory entry")
+@@ -55,6 +68,65 @@ func (c *commandList) run(ctx context.Context, rep repo.Repository) error {
+ 	return c.listDirectory(ctx, dir, prefix, "")
+ }
+ 
++type hflEntrySummary struct {
++	Version           int    `json:"version"`
++	PathType          string `json:"path_type"`
++	SizeBytes         int64  `json:"size_bytes"`
++	FileCount         int64  `json:"file_count"`
++	DirectoryCount    int64  `json:"directory_count"`
++	SymlinkCount      int64  `json:"symlink_count"`
++	SummaryAvailable  bool   `json:"summary_available"`
++	Complete          bool   `json:"complete"`
++	IncompleteReason  string `json:"incomplete_reason,omitempty"`
++	FatalErrorCount   int    `json:"fatal_error_count,omitempty"`
++	IgnoredErrorCount int    `json:"ignored_error_count,omitempty"`
++}
++
++func (c *commandList) printHFLSummary(entry fs.Entry) error {
++	result, err := hflSummaryForEntry(entry)
++	if err != nil {
++		return err
++	}
++
++	return json.NewEncoder(c.out.stdout()).Encode(result)
++}
++
++func hflSummaryForEntry(entry fs.Entry) (hflEntrySummary, error) {
++	result := hflEntrySummary{Version: 1}
++
++	switch typed := entry.(type) {
++	case fs.Directory:
++		result.PathType = "directory"
++		if metadata, ok := typed.(snapshot.HasDirEntry); ok {
++			if dirEntry := metadata.DirEntry(); dirEntry != nil && dirEntry.DirSummary != nil {
++				summary := dirEntry.DirSummary
++				result.SizeBytes = summary.TotalFileSize
++				result.FileCount = summary.TotalFileCount
++				result.DirectoryCount = summary.TotalDirCount
++				result.SymlinkCount = summary.TotalSymlinkCount
++				result.SummaryAvailable = true
++				result.IncompleteReason = summary.IncompleteReason
++				result.FatalErrorCount = summary.FatalErrorCount
++				result.IgnoredErrorCount = summary.IgnoredErrorCount
++				result.Complete = summary.IncompleteReason == "" && summary.FatalErrorCount == 0
++			}
++		}
++	case fs.File:
++		result.PathType = "file"
++		result.SizeBytes = entry.Size()
++		result.FileCount = 1
++		result.Complete = true
++	case fs.Symlink:
++		result.PathType = "symlink"
++		result.SymlinkCount = 1
++		result.Complete = true
++	default:
++		result.PathType = "unsupported"
++	}
++
++	return result, nil
++}
++
+ func (c *commandList) listDirectory(ctx context.Context, d fs.Directory, prefix, indent string) error {
+ 	iter, err := d.Iterate(ctx)
+ 	if err != nil {
+diff --git a/cli/command_ls_hfl_internal_test.go b/cli/command_ls_hfl_internal_test.go
+new file mode 100644
+index 00000000..7b3dcd0a
+--- /dev/null
++++ b/cli/command_ls_hfl_internal_test.go
+@@ -0,0 +1,71 @@
++package cli
++
++import (
++	"context"
++	"testing"
++
++	"github.com/stretchr/testify/require"
++
++	"github.com/kopia/kopia/fs"
++	"github.com/kopia/kopia/internal/mockfs"
++	"github.com/kopia/kopia/snapshot"
++)
++
++type hflTestSummaryDirectory struct {
++	fs.Directory
++	entry *snapshot.DirEntry
++}
++
++func (d hflTestSummaryDirectory) Summary(context.Context) (*fs.DirectorySummary, error) {
++	panic("entry summary must not load the selected directory")
++}
++
++func (d hflTestSummaryDirectory) DirEntry() *snapshot.DirEntry {
++	return d.entry
++}
++
++func TestHFLEntrySummaryFallbackStates(t *testing.T) {
++	directory := mockfs.NewDirectory()
++
++	missing, err := hflSummaryForEntry(hflTestSummaryDirectory{
++		Directory: directory,
++	})
++	require.NoError(t, err)
++	require.Equal(t, "directory", missing.PathType)
++	require.False(t, missing.SummaryAvailable)
++	require.False(t, missing.Complete)
++
++	incomplete, err := hflSummaryForEntry(hflTestSummaryDirectory{
++		Directory: directory,
++		entry: &snapshot.DirEntry{
++			DirSummary: &fs.DirectorySummary{
++				TotalFileSize:     42,
++				TotalFileCount:    3,
++				TotalDirCount:     2,
++				TotalSymlinkCount: 1,
++				IncompleteReason:  "incomplete snapshot",
++			},
++		},
++	})
++	require.NoError(t, err)
++	require.Equal(t, int64(42), incomplete.SizeBytes)
++	require.Equal(t, int64(3), incomplete.FileCount)
++	require.Equal(t, int64(2), incomplete.DirectoryCount)
++	require.Equal(t, int64(1), incomplete.SymlinkCount)
++	require.True(t, incomplete.SummaryAvailable)
++	require.False(t, incomplete.Complete)
++	require.Equal(t, "incomplete snapshot", incomplete.IncompleteReason)
++
++	symlink, err := hflSummaryForEntry(
++		directory.AddSymlink("link", "target", 0o777),
++	)
++	require.NoError(t, err)
++	require.Equal(t, "symlink", symlink.PathType)
++	require.Equal(t, int64(1), symlink.SymlinkCount)
++	require.True(t, symlink.Complete)
++
++	unsupported, err := hflSummaryForEntry(struct{ fs.Entry }{})
++	require.NoError(t, err)
++	require.Equal(t, "unsupported", unsupported.PathType)
++	require.False(t, unsupported.Complete)
++}
+diff --git a/cli/command_ls_hfl_test.go b/cli/command_ls_hfl_test.go
+new file mode 100644
+index 00000000..33e9d2e9
+--- /dev/null
++++ b/cli/command_ls_hfl_test.go
+@@ -0,0 +1,75 @@
++package cli_test
++
++import (
++	"os"
++	"path/filepath"
++	"testing"
++
++	"github.com/stretchr/testify/require"
++
++	"github.com/kopia/kopia/cli"
++	"github.com/kopia/kopia/internal/testutil"
++	"github.com/kopia/kopia/tests/testenv"
++)
++
++type hflEntrySummary struct {
++	Version          int    `json:"version"`
++	PathType         string `json:"path_type"`
++	SizeBytes        int64  `json:"size_bytes"`
++	FileCount        int64  `json:"file_count"`
++	DirectoryCount   int64  `json:"directory_count"`
++	SymlinkCount     int64  `json:"symlink_count"`
++	SummaryAvailable bool   `json:"summary_available"`
++	Complete         bool   `json:"complete"`
++}
++
++func TestHFLListSummary(t *testing.T) {
++	t.Parallel()
++
++	env := testenv.NewCLITest(t, testenv.RepoFormatNotImportant, testenv.NewInProcRunner(t))
++	defer env.RunAndExpectSuccess(t, "repo", "disconnect")
++	env.RunAndExpectSuccess(t, "repo", "create", "filesystem", "--path", env.RepoDir)
++
++	source := testutil.TempDirectory(t)
++	require.NoError(t, os.MkdirAll(filepath.Join(source, "selected", "nested"), 0o755))
++	require.NoError(t, os.Mkdir(filepath.Join(source, "empty"), 0o755))
++	require.NoError(t, os.WriteFile(filepath.Join(source, "selected", "one.txt"), []byte("one"), 0o644))
++	require.NoError(t, os.WriteFile(filepath.Join(source, "selected", "nested", "two.txt"), []byte("two!"), 0o644))
++
++	var manifest cli.SnapshotManifest
++	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(t, "snapshot", "create", source, "--json"), &manifest)
++
++	var directory hflEntrySummary
++	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(
++		t, "ls", "--hfl-summary", string(manifest.ID)+"/selected",
++	), &directory)
++	require.Equal(t, 1, directory.Version)
++	require.Equal(t, "directory", directory.PathType)
++	require.Equal(t, int64(7), directory.SizeBytes)
++	require.Equal(t, int64(2), directory.FileCount)
++	require.Equal(t, int64(2), directory.DirectoryCount)
++	require.Zero(t, directory.SymlinkCount)
++	require.True(t, directory.SummaryAvailable)
++	require.True(t, directory.Complete)
++
++	var file hflEntrySummary
++	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(
++		t, "ls", "--hfl-summary", string(manifest.ID)+"/selected/one.txt",
++	), &file)
++	require.Equal(t, "file", file.PathType)
++	require.Equal(t, int64(3), file.SizeBytes)
++	require.Equal(t, int64(1), file.FileCount)
++	require.Zero(t, file.DirectoryCount)
++	require.True(t, file.Complete)
++
++	var empty hflEntrySummary
++	testutil.MustParseJSONLines(t, env.RunAndExpectSuccess(
++		t, "ls", "--hfl-summary", string(manifest.ID)+"/empty",
++	), &empty)
++	require.Equal(t, "directory", empty.PathType)
++	require.Zero(t, empty.SizeBytes)
++	require.Zero(t, empty.FileCount)
++	require.Equal(t, int64(1), empty.DirectoryCount)
++	require.True(t, empty.SummaryAvailable)
++	require.True(t, empty.Complete)
++}

--- a/tools/kopia/prepare.sh
+++ b/tools/kopia/prepare.sh
@@ -260,6 +260,11 @@ build_matrix() {
 		cd "${KOPIA_SOURCE_DIR}"
 		GOTOOLCHAIN="go${KOPIA_GO_VERSION}" go test ./cli -run '^TestHFLStructuredProgress$'
 	)
+	log "Testing the Kopia HFL entry-summary patch"
+	(
+		cd "${KOPIA_SOURCE_DIR}"
+		GOTOOLCHAIN="go${KOPIA_GO_VERSION}" go test ./cli -run '^TestHFLListSummary$'
+	)
 	log "Testing the Kopia managed dot-ignore patch"
 	(
 		cd "${KOPIA_SOURCE_DIR}"
@@ -435,6 +440,7 @@ payload = {
         "s3_url_style": os.environ["MODE"] == "build",
         "hfl_structured_progress_v2": os.environ["MODE"] == "build",
         "hfl_managed_dot_ignore_v1": os.environ["MODE"] == "build",
+        "hfl_entry_summary_v1": os.environ["MODE"] == "build",
     },
     "files": files,
     "built_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -471,7 +477,7 @@ EOF
 		KOPIA_PATCH_SHA256="$(patch_set_sha256)"
 		KOPIA_PATCH_NAMES="$(patch_names)"
 		KOPIA_PATCH_DIGESTS="$(patch_digests)"
-		KOPIA_BUILD_PROFILE="cgo-disabled,trimpath,strip,embedded-html-ui,hfl-buildinfo-v2,s3-patch-tests-v1,structured-progress-v2-tests-v1,managed-dot-ignore-v1"
+		KOPIA_BUILD_PROFILE="cgo-disabled,trimpath,strip,embedded-html-ui,hfl-buildinfo-v2,s3-patch-tests-v1,structured-progress-v2-tests-v1,managed-dot-ignore-v1,entry-summary-v1"
 	else
 		KOPIA_PATCH_SHA256=""
 		KOPIA_PATCH_NAMES=""

--- a/tools/quality/test-kopia-build-config.sh
+++ b/tools/quality/test-kopia-build-config.sh
@@ -158,10 +158,18 @@ grep -F 'withBestEffortErrorHandling()' \
 	"${ROOT}/tools/kopia/patches/0004-snapshot-estimator-best-effort-errors.patch" >/dev/null
 grep -F 'TestSnapshotCreateEstimatorSkipsUnreadableSubdirectory' \
 	"${ROOT}/tools/kopia/patches/0004-snapshot-estimator-best-effort-errors.patch" >/dev/null
+grep -F 'hfl-summary' \
+	"${ROOT}/tools/kopia/patches/0005-add-entry-summary.patch" >/dev/null
+grep -F 'TestHFLEntrySummaryFallbackStates' \
+	"${ROOT}/tools/kopia/patches/0005-add-entry-summary.patch" >/dev/null
+grep -F 'features.get("hfl_entry_summary_v1") is not True' \
+	"${ROOT}/src/agent/scripts/package.sh" >/dev/null
+grep -F 'KOPIA_INFO.json is missing the HFL entry-summary capability' \
+	"${ROOT}/src/agent/scripts/package.sh" >/dev/null
 
-[[ "${#KOPIA_PATCH_FILES[@]}" -eq 4 ]]
+[[ "${#KOPIA_PATCH_FILES[@]}" -eq 5 ]]
 patch_set_digest="$(patch_set_sha256)"
 [[ "${patch_set_digest}" =~ ^[0-9a-f]{64}$ ]]
-[[ "$(patch_names)" == '0001-add-s3-url-style.patch 0002-add-structured-progress.patch 0003-disable-managed-dot-ignore.patch 0004-snapshot-estimator-best-effort-errors.patch ' ]]
+[[ "$(patch_names)" == '0001-add-s3-url-style.patch 0002-add-structured-progress.patch 0003-disable-managed-dot-ignore.patch 0004-snapshot-estimator-best-effort-errors.patch 0005-add-entry-summary.patch ' ]]
 
 printf 'Kopia build configuration checks passed.\n'


### PR DESCRIPTION
## Problem and root cause

Restores limited to selected paths reused the size and file-count metadata of
the owning snapshot directory. That metadata describes the entire snapshot
root, so restore progress substantially overstated the selected subtree.

## Solution

- Add a hidden `kopia ls --hfl-summary` contract that reads the selected
  entry's stored recursive `DirEntry.DirSummary` metadata.
- Normalize and ancestor-deduplicate selected paths, aggregate their logical
  size and file, directory, and symlink counts, and seed Agent progress with
  those scoped totals.
- Keep live Kopia progress as the fallback for older binaries and incomplete
  summaries, and prevent backend snapshot-root seeds from overriding scoped
  Agent totals.
- Preserve explicit zero-byte totals for empty selected directories.

The metadata lookup resolves the selected snapshot entry without recursively
enumerating its descendants. Directory counts include the selected directory
itself, matching Kopia restore item accounting.

## Validation

- Manual testing: passed
- Issue-specific Agent engine tests: passed
- Agent Kopia integration package tests: passed
- Patched Kopia entry-summary CLI tests: passed
- Restore API and progress tests: 153 passed in isolated database
- Targeted Community progress tests: 65 passed with extensions disabled
- Kopia build matrix: passed for Linux amd64/arm64, macOS amd64/arm64, and
  Windows amd64
- Shell syntax, Go formatting, diff whitespace, English-source boundary, Kopia
  build configuration, and Linux Agent release-contract checks: passed
- Full Agent tests: baseline-equivalent to clean
  `19d483df981cb9b8d2aa8d5d99e8bbe34bd67432`; only existing platform/runtime
  fixture failures were present, with no changed or affected package failures
- Complete Community backend suite: skipped as requested
- Post-sync product retesting: skipped because the rebase onto
  `origin/main@4b6c4069fee434847f24641749ce139731a9fe29` was conflict-free and the stable
  Issue patch ID was unchanged

## Risks and compatibility

Older patched Kopia binaries and snapshots without a complete stored summary
continue restoring with live progress rather than failing. The totals represent
logical restored size, not deduplicated repository storage. No database schema,
migration, or frontend contract changes are required.

Fixes #1009
