### PR TITLE
Share private data gateways within organizations

### DIFF
--- a/src/backend/apps/lens_bridge/api/serializers.py
+++ b/src/backend/apps/lens_bridge/api/serializers.py
@@ -211,22 +211,19 @@ class LensKnowledgeSourceCreateSerializer(serializers.ModelSerializer):
         provisioning.require_gateway_node(org, gateway.id)
         expected_scope = self.context.get(
             "gateway_scope",
-            LensGatewayLink.GatewayScope.USER,
+            LensGatewayLink.GatewayScope.ORGANIZATION,
         )
-        if expected_scope == LensGatewayLink.GatewayScope.USER:
+        if expected_scope in {
+            LensGatewayLink.GatewayScope.ORGANIZATION,
+            LensGatewayLink.GatewayScope.USER,
+        }:
             from apps.lens_bridge.services.gateway_execution import (
-                require_user_gateway_link,
+                require_organization_gateway_link,
             )
 
-            owner_user_id = self.context.get("gateway_owner_user_id")
-            if owner_user_id is None:
-                raise serializers.ValidationError(
-                    {"gateway": "Private Data Gateway owner is required."}
-                )
-            link = require_user_gateway_link(
+            link = require_organization_gateway_link(
                 tenant_organization=org,
                 gateway_id=gateway.id,
-                owner_user_id=owner_user_id,
                 require_ready=False,
             )
         else:
@@ -465,6 +462,8 @@ class LensGatewayInsightSerializer(serializers.Serializer):
     sl_runtime_status = serializers.CharField(required=False, allow_blank=True)
     owner_user_id = serializers.IntegerField(required=False, allow_null=True)
     owner_username = serializers.CharField(required=False, allow_blank=True)
+    created_by_id = serializers.IntegerField(required=False, allow_null=True)
+    created_by_username = serializers.CharField(required=False, allow_blank=True)
     owner_organization_id = serializers.IntegerField(required=False, allow_null=True)
     is_platform_default = serializers.BooleanField(required=False)
     agent_release = serializers.DictField(required=False, allow_null=True)
@@ -688,7 +687,13 @@ class LensSessionLinkSerializer(serializers.ModelSerializer):
 
     def get_gateway_scope(self, obj: LensSessionLink) -> str | None:
         link = obj.gateway_link
-        return link.scope if link else None
+        if link is None:
+            return None
+        from apps.lens_bridge.services.gateway_ownership import (
+            external_gateway_scope,
+        )
+
+        return external_gateway_scope(link)
 
     def get_has_unread(self, obj: LensSessionLink) -> bool:
         if obj.last_assistant_message_at is None:

--- a/src/backend/apps/lens_bridge/api/views.py
+++ b/src/backend/apps/lens_bridge/api/views.py
@@ -661,8 +661,7 @@ class LensKnowledgeSourceViewSet(OrgScopedMixin, viewsets.ModelViewSet):
     def get_serializer_context(self):
         ctx = super().get_serializer_context()
         ctx["org"] = self.org
-        ctx["gateway_scope"] = LensGatewayLink.GatewayScope.USER
-        ctx["gateway_owner_user_id"] = self.request.user.id
+        ctx["gateway_scope"] = LensGatewayLink.GatewayScope.ORGANIZATION
         return ctx
 
     def list(self, request, *args, **kwargs):
@@ -680,14 +679,13 @@ class LensKnowledgeSourceViewSet(OrgScopedMixin, viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         from apps.lens_bridge.services.gateway_execution import (
-            require_user_gateway_link,
+            require_organization_gateway_link,
         )
 
         with transaction.atomic():
-            gateway_link = require_user_gateway_link(
+            gateway_link = require_organization_gateway_link(
                 tenant_organization=self.org,
                 gateway_id=serializer.validated_data["gateway"].id,
-                owner_user_id=self.request.user.id,
                 lock=True,
             )
             ks = serializer.save(
@@ -771,10 +769,15 @@ class LensGatewayViewSet(OrgScopedMixin, viewsets.ViewSet):
 
     def list(self, request):
         from apps.lens_bridge.services.gateway_insights import (
-            list_user_gateway_insight_rows,
+            list_organization_gateway_insight_rows,
         )
 
-        return Response(list_user_gateway_insight_rows(user=request.user))
+        return Response(
+            list_organization_gateway_insight_rows(
+                organization=self.org,
+                user=request.user,
+            )
+        )
 
     @action(detail=True, methods=["post"], url_path="enable-ai")
     def enable_ai(self, request, pk=None):
@@ -784,8 +787,10 @@ class LensGatewayViewSet(OrgScopedMixin, viewsets.ViewSet):
         link = LensGatewayLink.objects.filter(
             organization=self.org,
             gateway=gateway,
-            scope=LensGatewayLink.GatewayScope.USER,
-            owner_user=request.user,
+            scope__in=(
+                LensGatewayLink.GatewayScope.ORGANIZATION,
+                LensGatewayLink.GatewayScope.USER,
+            ),
         ).first()
         if link and link.sl_lensnode_uuid:
             provisioning.sync_gateway_lensnode_status(link)
@@ -793,8 +798,8 @@ class LensGatewayViewSet(OrgScopedMixin, viewsets.ViewSet):
             org=self.org,
             gateway=gateway,
             name=body.validated_data.get("name") or None,
-            owner_user=request.user,
-            scope=LensGatewayLink.GatewayScope.USER,
+            created_by=request.user,
+            scope=LensGatewayLink.GatewayScope.ORGANIZATION,
         )
         payload = provisioning.build_gateway_ai_payload(
             gateway=gateway,
@@ -807,13 +812,12 @@ class LensGatewayViewSet(OrgScopedMixin, viewsets.ViewSet):
     def ai_status(self, request, pk=None):
         gateway = provisioning.require_gateway_node(self.org, int(pk))
         from apps.lens_bridge.services.gateway_execution import (
-            require_user_gateway_link,
+            require_organization_gateway_link,
         )
 
-        link = require_user_gateway_link(
+        link = require_organization_gateway_link(
             tenant_organization=self.org,
             gateway_id=gateway.id,
-            owner_user_id=request.user.id,
             require_ready=False,
         )
         if link and link.sl_lensnode_uuid:
@@ -830,13 +834,12 @@ class LensGatewayViewSet(OrgScopedMixin, viewsets.ViewSet):
     def chat_workload(self, request, pk=None):
         gateway = provisioning.require_gateway_node(self.org, int(pk))
         from apps.lens_bridge.services.gateway_execution import (
-            require_user_gateway_link,
+            require_organization_gateway_link,
         )
 
-        link = require_user_gateway_link(
+        link = require_organization_gateway_link(
             tenant_organization=self.org,
             gateway_id=gateway.id,
-            owner_user_id=request.user.id,
             require_ready=False,
         )
         if request.method == "PATCH":
@@ -873,8 +876,7 @@ class LensGatewayViewSet(OrgScopedMixin, viewsets.ViewSet):
                 org=self.org,
                 gateway_id=int(pk),
                 path=path,
-                expected_scope=LensGatewayLink.GatewayScope.USER,
-                expected_owner_user_id=request.user.id,
+                expected_scope=LensGatewayLink.GatewayScope.ORGANIZATION,
             )
         except ValidationError as exc:
             return Response(exc.detail, status=status.HTTP_400_BAD_REQUEST)

--- a/src/backend/apps/lens_bridge/migrations/0041_gateway_organization_ownership.py
+++ b/src/backend/apps/lens_bridge/migrations/0041_gateway_organization_ownership.py
@@ -1,0 +1,65 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def backfill_gateway_created_by(apps, schema_editor):
+    LensGatewayLink = apps.get_model("lens_bridge", "LensGatewayLink")
+    LensGatewayLink.objects.filter(
+        created_by_id__isnull=True,
+        owner_user_id__isnull=False,
+    ).update(created_by_id=models.F("owner_user_id"))
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens_bridge", "0040_session_analysis_type"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="lensgatewaylink",
+            name="created_by",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="lens_gateway_links_created",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="lensgatewaylink",
+            name="scope",
+            field=models.CharField(
+                choices=[
+                    ("platform", "Platform"),
+                    ("organization", "Organization"),
+                    ("user", "Legacy organization"),
+                ],
+                db_index=True,
+                default="user",
+                max_length=16,
+            ),
+        ),
+        migrations.RunPython(
+            backfill_gateway_created_by,
+            migrations.RunPython.noop,
+        ),
+        migrations.RemoveConstraint(
+            model_name="lensgatewaylink",
+            name="lens_brgw_scope_owner_ck",
+        ),
+        migrations.AddConstraint(
+            model_name="lensgatewaylink",
+            constraint=models.CheckConstraint(
+                condition=(
+                    models.Q(scope="platform", owner_user_id__isnull=True)
+                    | models.Q(scope="user", owner_user_id__isnull=False)
+                    | models.Q(scope="organization")
+                ),
+                name="lens_brgw_scope_owner_ck",
+            ),
+        ),
+    ]

--- a/src/backend/apps/lens_bridge/models/links.py
+++ b/src/backend/apps/lens_bridge/models/links.py
@@ -159,7 +159,11 @@ class LensGatewayLink(OrganizationScopedModel):
 
     class GatewayScope(models.TextChoices):
         PLATFORM = "platform", "Platform"
-        USER = "user", "User"
+        ORGANIZATION = "organization", "Organization"
+        # Transitional persistence value kept for blue/green compatibility.
+        # New authorization must treat this exactly like ORGANIZATION and must
+        # never infer ownership from the user who installed the gateway.
+        USER = "user", "Legacy organization"
 
     class Origin(models.TextChoices):
         USER = "user", "User"
@@ -187,6 +191,13 @@ class LensGatewayLink(OrganizationScopedModel):
         null=True,
         blank=True,
         related_name="lens_gateway_links_owned",
+    )
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="lens_gateway_links_created",
     )
     origin = models.CharField(
         max_length=16,
@@ -238,6 +249,7 @@ class LensGatewayLink(OrganizationScopedModel):
                 condition=(
                     models.Q(scope="platform", owner_user_id__isnull=True)
                     | models.Q(scope="user", owner_user_id__isnull=False)
+                    | models.Q(scope="organization")
                 ),
                 name="lens_brgw_scope_owner_ck",
             ),

--- a/src/backend/apps/lens_bridge/services/assistants.py
+++ b/src/backend/apps/lens_bridge/services/assistants.py
@@ -352,18 +352,6 @@ def _apply_knowledge_source_payload(
                     )
                 }
             )
-        gateway_link = ks.gateway_link
-        if (
-            gateway_link.scope == LensGatewayLink.GatewayScope.USER
-            and gateway_link.owner_user_id != user.id
-        ):
-            raise ValidationError(
-                {
-                    "knowledge_source_id": (
-                        "Knowledge source data gateway is not owned by the current user."
-                    )
-                }
-            )
     if ks.session_links.exclude(
         lifecycle_status=LensSessionLink.LifecycleStatus.DELETED
     ).exists():
@@ -648,17 +636,18 @@ def _reassign_ks_primary_assistant(org: Organization, ks_id: int) -> None:
 def list_org_lensnodes(
     org: Organization,
     *,
-    owner_user: AbstractBaseUser | None = None,
+    platform_passthrough: bool = False,
 ) -> list[dict[str, Any]]:
+    from apps.lens_bridge.services.gateway_ownership import PRIVATE_GATEWAY_SCOPES
+
     links = LensGatewayLink.objects.filter(
         organization=org,
         sl_lensnode_uuid__isnull=False,
     )
-    if owner_user is not None:
-        links = links.filter(
-            scope=LensGatewayLink.GatewayScope.USER,
-            owner_user=owner_user,
-        )
+    if platform_passthrough:
+        links = links.filter(scope=LensGatewayLink.GatewayScope.PLATFORM)
+    else:
+        links = links.filter(scope__in=PRIVATE_GATEWAY_SCOPES)
     linked = {
         str(link.sl_lensnode_uuid)
         for link in links
@@ -688,12 +677,13 @@ def assistant_form_options(
             raise ValidationError(
                 {"assistant": "Assistant form option owner is required."}
             )
-        links = LensGatewayLink.objects.filter(
-            organization=org,
+        from apps.lens_bridge.services.gateway_ownership import (
+            organization_gateway_links,
+        )
+
+        links = organization_gateway_links(organization=org).filter(
             sl_lensnode_uuid__isnull=False,
-            scope=LensGatewayLink.GatewayScope.USER,
-            owner_user=user,
-        ).select_related("gateway")
+        )
 
     for link in links:
         node = link.gateway
@@ -748,7 +738,7 @@ def assistant_form_options(
     return {
         "lensnodes": list_org_lensnodes(
             ks_org,
-            owner_user=None if platform_passthrough else user,
+            platform_passthrough=platform_passthrough,
         ),
         "gateways": gateway_rows,
         "knowledge_sources": [

--- a/src/backend/apps/lens_bridge/services/chat_binding.py
+++ b/src/backend/apps/lens_bridge/services/chat_binding.py
@@ -18,6 +18,7 @@ from apps.lens_bridge.models import LensChatBinding, LensGatewayLink
 from apps.lens_bridge.services import (
     chat_user_provisioning,
     gateway_readiness,
+    gateway_ownership,
     platform_lens,
     provisioning,
     sl_client,
@@ -179,7 +180,7 @@ def get_active_chat_binding(
 
 
 def list_gateway_options(org: Organization, *, user) -> list[dict[str, Any]]:
-    """List platform and current-user DGs available for explicit Copilot selection."""
+    """List platform and organization DGs available for Copilot selection."""
     rows: list[dict[str, Any]] = []
     seen: set[int] = set()
 
@@ -196,14 +197,18 @@ def list_gateway_options(org: Organization, *, user) -> list[dict[str, Any]]:
         )
         seen.add(link.id)
 
-    for link in platform_lens.user_gateway_links(
-        user=user,
+    for link in gateway_ownership.organization_gateway_links(
         organization=org,
     ).select_related("gateway"):
         if not link.sl_lensnode_uuid or link.id in seen:
             continue
         provisioning.sync_gateway_lensnode_status(link)
-        rows.append(_gateway_option_row(link, scope="user"))
+        rows.append(
+            _gateway_option_row(
+                link,
+                scope=LensGatewayLink.GatewayScope.ORGANIZATION,
+            )
+        )
         seen.add(link.id)
 
     return rows
@@ -242,7 +247,11 @@ def serialize_chat_binding(binding: LensChatBinding) -> dict[str, Any]:
         "source_path": binding.source_path,
         "gateway_link_id": binding.gateway_link_id,
         "gateway_name": gw.name if gw else "",
-        "gateway_scope": binding.gateway_link.scope if binding.gateway_link_id else "",
+        "gateway_scope": (
+            gateway_ownership.external_gateway_scope(binding.gateway_link)
+            if binding.gateway_link_id
+            else ""
+        ),
         "knowledge_source_id": ks.id if ks else None,
         "knowledge_source_status": ks.status if ks else None,
         "sl_assistant_uuid": str(binding.sl_assistant_uuid)

--- a/src/backend/apps/lens_bridge/services/chat_lifecycle.py
+++ b/src/backend/apps/lens_bridge/services/chat_lifecycle.py
@@ -299,12 +299,13 @@ def _configured_gateway_link_for_chat(
 
     if gateway_mode == LensSessionLink.GatewaySelectionMode.AUTO:
         return platform_lens.resolve_auto_gateway_link_for_copilot(user=user)
+    from apps.lens_bridge.services.gateway_ownership import PRIVATE_GATEWAY_SCOPES
+
     return (
         LensGatewayLink.objects.filter(
             pk=gateway_link_id,
             organization=org,
-            owner_user=user,
-            scope=LensGatewayLink.GatewayScope.USER,
+            scope__in=PRIVATE_GATEWAY_SCOPES,
             sl_lensnode_uuid__isnull=False,
             is_deleted=False,
         )
@@ -498,9 +499,6 @@ def create_copilot_chat(
     context_for_gateway_link(
         tenant_organization=org,
         gateway_link=gateway_link,
-        expected_owner_user_id=(
-            user.id if gateway_link.scope == gateway_link.GatewayScope.USER else None
-        ),
         require_ready=False,
     )
     default_model_ref, multimodal_model_ref = (
@@ -1006,9 +1004,6 @@ def _run_copilot_chat_provision(
     context_for_gateway_link(
         tenant_organization=org,
         gateway_link=gateway_link,
-        expected_owner_user_id=(
-            user.id if gateway_link.scope == gateway_link.GatewayScope.USER else None
-        ),
         require_ready=True,
     )
 

--- a/src/backend/apps/lens_bridge/services/chat_selection_preview.py
+++ b/src/backend/apps/lens_bridge/services/chat_selection_preview.py
@@ -353,8 +353,10 @@ def admission_preview(
             ):
                 reasons.append("organization_capacity")
 
+    from apps.lens_bridge.services.gateway_ownership import external_gateway_scope
+
     return {
-        "gateway_scope": str(gateway_link.scope),
+        "gateway_scope": external_gateway_scope(gateway_link),
         "selection": {
             "file_count": int(file_count),
             "size_bytes": int(size_bytes),

--- a/src/backend/apps/lens_bridge/services/conversion_display.py
+++ b/src/backend/apps/lens_bridge/services/conversion_display.py
@@ -232,7 +232,7 @@ def data_context_for_session(
 
     scope = str(gateway_scope or "").strip().lower()
     mode = str(gateway_selection_mode or "").strip().lower()
-    if scope == "private" or mode == "manual":
+    if scope in {"organization", "user", "private"} or mode == "manual":
         processing_location = "private_gateway"
     else:
         processing_location = "public_gateway"

--- a/src/backend/apps/lens_bridge/services/gateway_chat_queue.py
+++ b/src/backend/apps/lens_bridge/services/gateway_chat_queue.py
@@ -172,6 +172,8 @@ def chat_queue_ahead(
 
 
 def chat_workload_payload(*, gateway_link: LensGatewayLink) -> dict[str, Any]:
+    from apps.lens_bridge.services.gateway_ownership import external_gateway_scope
+
     active_count = active_chat_prepare_count(gateway_link_id=gateway_link.id)
     admitted = _admitted_sessions_without_slot(gateway_link.id)
     oldest_at = (
@@ -183,7 +185,7 @@ def chat_workload_payload(*, gateway_link: LensGatewayLink) -> dict[str, Any]:
         "gateway_link_id": gateway_link.id,
         "gateway_id": gateway_link.gateway_id,
         "gateway_name": gateway_link.gateway.name,
-        "gateway_scope": gateway_link.scope,
+        "gateway_scope": external_gateway_scope(gateway_link),
         "chat_prepare_concurrency": int(gateway_link.chat_prepare_concurrency),
         "chat_queue_capacity": int(gateway_link.chat_queue_capacity),
         "active_chat_preparations": active_count,

--- a/src/backend/apps/lens_bridge/services/gateway_execution.py
+++ b/src/backend/apps/lens_bridge/services/gateway_execution.py
@@ -14,6 +14,10 @@ from apps.lens_bridge.models import (
     LensWorkspaceBinding,
 )
 from apps.lens_bridge.services import gateway_readiness
+from apps.lens_bridge.services.gateway_ownership import (
+    PRIVATE_GATEWAY_SCOPES,
+    is_private_gateway,
+)
 
 
 @dataclass(frozen=True)
@@ -49,7 +53,6 @@ def context_for_gateway_link(
     *,
     tenant_organization: Organization,
     gateway_link: LensGatewayLink,
-    expected_owner_user_id: int | None = None,
     require_ready: bool = True,
 ) -> GatewayExecutionContext:
     """Build a trusted execution context from an already-authorized link.
@@ -73,13 +76,9 @@ def context_for_gateway_link(
 
         if link.organization.key != PLATFORM_ORG_KEY or link.owner_user_id is not None:
             raise ValidationError({"gateway_link_id": "Public Data Gateway identity is invalid."})
-    elif link.scope == LensGatewayLink.GatewayScope.USER:
+    elif is_private_gateway(link):
         if link.organization_id != tenant_organization.id:
             raise ValidationError({"gateway_link_id": "Private Data Gateway belongs to another organization."})
-        if link.owner_user_id is None:
-            raise ValidationError({"gateway_link_id": "Private Data Gateway has no owner."})
-        if expected_owner_user_id is not None and link.owner_user_id != expected_owner_user_id:
-            raise ValidationError({"gateway_link_id": "Private Data Gateway belongs to another user."})
     else:
         raise ValidationError({"gateway_link_id": "Unsupported data gateway scope."})
 
@@ -93,15 +92,14 @@ def context_for_gateway_link(
     )
 
 
-def require_user_gateway_link(
+def require_organization_gateway_link(
     *,
     tenant_organization: Organization,
     gateway_id: int,
-    owner_user_id: int,
     require_ready: bool = True,
     lock: bool = False,
 ) -> LensGatewayLink:
-    """Resolve one private Gateway through its organization and user owner."""
+    """Resolve one Private Data Gateway through its organization boundary."""
 
     queryset = LensGatewayLink.objects.select_related("organization", "gateway")
     if lock:
@@ -109,18 +107,16 @@ def require_user_gateway_link(
     link = queryset.filter(
         organization=tenant_organization,
         gateway_id=gateway_id,
-        scope=LensGatewayLink.GatewayScope.USER,
-        owner_user_id=owner_user_id,
+        scope__in=PRIVATE_GATEWAY_SCOPES,
         is_deleted=False,
     ).first()
     if link is None:
         raise ValidationError(
-            {"gateway_id": "Private Data Gateway is not owned by this user."}
+            {"gateway_id": "Private Data Gateway is not available in this organization."}
         )
     context_for_gateway_link(
         tenant_organization=tenant_organization,
         gateway_link=link,
-        expected_owner_user_id=owner_user_id,
         require_ready=require_ready,
     )
     return link
@@ -138,13 +134,9 @@ def context_for_knowledge_source(
         )
     if knowledge_source.gateway_link_id is None:
         raise ValidationError({"gateway_link_id": "Knowledge source has no authoritative data gateway link."})
-    expected_owner_user_id = None
-    if knowledge_source.gateway_link.scope == LensGatewayLink.GatewayScope.USER:
-        expected_owner_user_id = knowledge_source.created_by_id
     context = context_for_gateway_link(
         tenant_organization=tenant_organization,
         gateway_link=knowledge_source.gateway_link,
-        expected_owner_user_id=expected_owner_user_id,
         require_ready=require_ready,
     )
     if context.gateway.id != knowledge_source.gateway_id:

--- a/src/backend/apps/lens_bridge/services/gateway_insights.py
+++ b/src/backend/apps/lens_bridge/services/gateway_insights.py
@@ -6,7 +6,12 @@ from collections.abc import Iterable
 from typing import Any
 
 from apps.lens_bridge.models import LensGatewayLink, LensKnowledgeSource
-from apps.lens_bridge.services import gateway_readiness, provisioning, sl_client
+from apps.lens_bridge.services import (
+    gateway_ownership,
+    gateway_readiness,
+    provisioning,
+    sl_client,
+)
 from apps.node.api.serializers.node import NodeSerializer
 from apps.node.services.internal.agent_upgrade import node_agent_release_status
 from apps.node.services.internal.node_lifecycle import enrich_node_row
@@ -24,15 +29,14 @@ def _lensnode_rows() -> list[dict[str, Any]]:
     return [dict(item) for item in payload if isinstance(item, dict) and item.get("uuid")]
 
 
-def _link_index(*, owner_user=None) -> dict[str, LensGatewayLink]:
+def _link_index(*, organization=None) -> dict[str, LensGatewayLink]:
     links = LensGatewayLink.objects.filter(sl_lensnode_uuid__isnull=False).select_related(
-        "gateway", "organization", "owner_user"
+        "gateway", "organization", "created_by", "owner_user"
     )
-    if owner_user is not None:
+    if organization is not None:
         links = links.filter(
-            owner_user=owner_user,
-            scope=LensGatewayLink.GatewayScope.USER,
-            origin=LensGatewayLink.Origin.USER,
+            organization=organization,
+            scope__in=gateway_ownership.PRIVATE_GATEWAY_SCOPES,
         )
     return {str(link.sl_lensnode_uuid): link for link in links}
 
@@ -71,7 +75,7 @@ def _serialize_row(
         ).data
         knowledge_source_count = LensKnowledgeSource.objects.filter(gateway=node).count()
         origin = link.origin
-        owner_user = link.owner_user
+        created_by = link.created_by or link.owner_user
         workspace_root = str(sl_node.get("workspace_path") or link.resolved_workspace_root())
         sidecar_status = link.sidecar_status
         is_platform_default = bool(link.is_platform_default)
@@ -102,7 +106,7 @@ def _serialize_row(
         }
         knowledge_source_count = 0
         origin = _origin_for_unlinked(sl_node)
-        owner_user = None
+        created_by = None
         workspace_root = str(sl_node.get("workspace_path") or "")
         sidecar_status = LensGatewayLink.SidecarStatus.NOT_DEPLOYED
         is_platform_default = False
@@ -123,13 +127,17 @@ def _serialize_row(
         "knowledge_source_count": knowledge_source_count,
         "workspace_root": workspace_root,
         "sidecar_status": sidecar_status,
-        "scope": link.scope if link else "",
+        "scope": gateway_ownership.external_gateway_scope(link) if link else "",
         "origin": origin,
         "gateway_link_id": gateway_link_id,
         "managed_by_hfl": runtime_state["hfl_managed"],
         **runtime_state,
-        "owner_user_id": owner_user.id if owner_user else None,
-        "owner_username": getattr(owner_user, "username", "") if owner_user else "",
+        # Keep the old response keys during the compatibility window. They now
+        # describe installation audit only and must not be used for access.
+        "owner_user_id": created_by.id if created_by else None,
+        "owner_username": getattr(created_by, "username", "") if created_by else "",
+        "created_by_id": created_by.id if created_by else None,
+        "created_by_username": getattr(created_by, "username", "") if created_by else "",
         "owner_organization_id": link.organization_id if link else None,
         "is_platform_default": is_platform_default,
         "sl_name": str(sl_node.get("name") or ""),
@@ -158,9 +166,12 @@ def list_admin_gateway_insight_rows(*, user=None) -> list[dict[str, Any]]:
     ]
 
 
-def list_user_gateway_insight_rows(*, user) -> list[dict[str, Any]]:
-    """Only DGs owned by the current HFL user, with live SL status."""
-    links = _link_index(owner_user=user)
+def list_organization_gateway_insight_rows(
+    *, organization, user=None
+) -> list[dict[str, Any]]:
+    """Private Data Gateways in one organization, with live SL status."""
+
+    links = _link_index(organization=organization)
     if not links:
         return []
     release_targets: dict[tuple[str, str, str, str], str] = {}

--- a/src/backend/apps/lens_bridge/services/gateway_ownership.py
+++ b/src/backend/apps/lens_bridge/services/gateway_ownership.py
@@ -1,0 +1,43 @@
+"""Organization ownership semantics for Private Data Gateways."""
+
+from __future__ import annotations
+
+from apps.iam.models import Organization
+from apps.lens_bridge.models import LensGatewayLink
+
+
+# ``user`` remains a supported persistence value while blue/green deployments
+# may still run code from before Private Data Gateways became organization
+# resources. Both values have identical authorization semantics in new code.
+PRIVATE_GATEWAY_SCOPES = (
+    LensGatewayLink.GatewayScope.ORGANIZATION,
+    LensGatewayLink.GatewayScope.USER,
+)
+
+
+def is_private_gateway(link: LensGatewayLink) -> bool:
+    return link.scope in PRIVATE_GATEWAY_SCOPES
+
+
+def organization_gateway_links(*, organization: Organization):
+    """Return Private Data Gateways owned by one organization."""
+
+    return LensGatewayLink.objects.filter(
+        organization=organization,
+        scope__in=PRIVATE_GATEWAY_SCOPES,
+        is_deleted=False,
+    ).select_related("gateway", "created_by")
+
+
+def external_gateway_scope(link: LensGatewayLink) -> str:
+    """Return the stable API scope while legacy rows remain in storage."""
+
+    if is_private_gateway(link):
+        return LensGatewayLink.GatewayScope.ORGANIZATION
+    return str(link.scope)
+
+
+def persistence_scope_for_private_gateway() -> str:
+    """Keep new rows readable by the previous blue/green application version."""
+
+    return LensGatewayLink.GatewayScope.USER

--- a/src/backend/apps/lens_bridge/services/platform_lens.py
+++ b/src/backend/apps/lens_bridge/services/platform_lens.py
@@ -10,6 +10,7 @@ from apps.lens_bridge.services.gateway_readiness import (
     gateway_runtime_state,
     require_hfl_usable_gateway,
 )
+from apps.lens_bridge.services.gateway_ownership import organization_gateway_links
 
 PLATFORM_ORG_KEY = "__platform_lens__"
 PLATFORM_ORG_NAME = "Platform Lens"
@@ -32,16 +33,6 @@ def get_or_create_platform_org() -> Organization:
 
         initialize_organization_quota(org)
     return org
-
-
-def user_gateway_links(*, user, organization: Organization | None = None):
-    links = LensGatewayLink.objects.filter(
-        owner_user=user,
-        scope=LensGatewayLink.GatewayScope.USER,
-    ).select_related("gateway")
-    if organization is not None:
-        links = links.filter(organization=organization)
-    return links
 
 
 def platform_gateway_links():
@@ -74,10 +65,12 @@ def resolve_platform_default_gateway_link() -> LensGatewayLink | None:
     )
 
 
-def resolve_user_default_gateway_link(*, user) -> LensGatewayLink | None:
-    """Resolve the first HFL-ready gateway owned by the current HFL user."""
+def resolve_organization_default_gateway_link(
+    *, organization: Organization
+) -> LensGatewayLink | None:
+    """Resolve the first HFL-ready Private Gateway in an organization."""
     return _first_eligible(
-        user_gateway_links(user=user)
+        organization_gateway_links(organization=organization)
         .filter(sl_lensnode_uuid__isnull=False)
         .order_by("created_at", "id")
     )
@@ -108,7 +101,7 @@ def resolve_gateway_link_for_copilot(
         )
         if link is None:
             link = (
-                user_gateway_links(user=user, organization=org)
+                organization_gateway_links(organization=org)
                 .filter(pk=gateway_link_id, sl_lensnode_uuid__isnull=False)
                 .first()
             )

--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -1000,7 +1000,7 @@ def _resolve_gateway_link_identity(
     *,
     org: Organization,
     gateway: Node,
-    owner_user,
+    created_by,
     normalized_scope: str | None,
 ) -> LensGatewayLink:
     """Create or verify an immutable Gateway identity under a row lock."""
@@ -1010,18 +1010,38 @@ def _resolve_gateway_link_identity(
         .filter(organization=org, gateway=gateway)
         .first()
     )
+    from apps.lens_bridge.services.gateway_ownership import (
+        PRIVATE_GATEWAY_SCOPES,
+        is_private_gateway,
+        persistence_scope_for_private_gateway,
+    )
+
+    requested_scope = (
+        normalized_scope
+        if normalized_scope is not None
+        else (
+            existing.scope
+            if existing is not None
+            else persistence_scope_for_private_gateway()
+        )
+    )
+    requested_is_platform = requested_scope == LensGatewayLink.GatewayScope.PLATFORM
     desired_scope = (
         existing.scope
-        if existing is not None and normalized_scope is None
-        else normalized_scope or LensGatewayLink.GatewayScope.USER
+        if existing is not None
+        else (
+            LensGatewayLink.GatewayScope.PLATFORM
+            if requested_is_platform
+            else persistence_scope_for_private_gateway()
+        )
     )
     if (
-        desired_scope == LensGatewayLink.GatewayScope.USER
-        and owner_user is None
+        desired_scope in PRIVATE_GATEWAY_SCOPES
+        and created_by is None
         and existing is None
     ):
         raise ValidationError(
-            {"owner_user": "Private Data Gateway requires an owner."}
+            {"created_by": "Private Data Gateway requires an installer."}
         )
     desired_origin = (
         existing.origin
@@ -1068,7 +1088,11 @@ def _resolve_gateway_link_identity(
                     # their persisted legacy /workspace path through
                     # resolved_workspace_root().
                     "workspace_root": f"/opt/hyperfilelens-agent/workspace/org-{org.id}/data",
-                    "owner_user": None if is_platform else owner_user,
+                    # ``owner_user`` and the legacy ``user`` scope stay
+                    # populated until the blue/green compatibility window
+                    # closes. New authorization uses only organization.
+                    "owner_user": None if is_platform else created_by,
+                    "created_by": None if is_platform else created_by,
                     "scope": desired_scope,
                     "origin": desired_origin,
                     # Infra capacity is set by Platform Ops; unlimited until configured.
@@ -1084,17 +1108,7 @@ def _resolve_gateway_link_identity(
         )
 
     link = existing
-    requested_owner_id = getattr(owner_user, "id", None)
-    if (
-        not is_platform
-        and link.scope == desired_scope
-        and requested_owner_id is not None
-        and link.owner_user_id != requested_owner_id
-    ):
-        raise ValidationError(
-            {"owner_user": "Private Data Gateway belongs to another user."}
-        )
-    if link.scope != desired_scope:
+    if is_private_gateway(link) != (not requested_is_platform):
         raise ValidationError(
             {
                 "scope": (
@@ -1103,6 +1117,9 @@ def _resolve_gateway_link_identity(
                 )
             }
         )
+    if not is_platform and link.created_by_id is None:
+        link.created_by = link.owner_user or created_by
+        link.save(update_fields=["created_by", "updated_at"])
     return link
 
 
@@ -1111,7 +1128,7 @@ def ensure_lensnode_for_gateway(
     org: Organization,
     gateway: Node,
     name: str | None = None,
-    owner_user=None,
+    created_by=None,
     scope: str | None = None,
 ) -> LensGatewayLink:
     """Idempotently associate a SourceLens LensNode with an HFL data gateway."""
@@ -1130,6 +1147,7 @@ def ensure_lensnode_for_gateway(
     if normalized_scope not in {
         None,
         LensGatewayLink.GatewayScope.PLATFORM,
+        LensGatewayLink.GatewayScope.ORGANIZATION,
         LensGatewayLink.GatewayScope.USER,
     }:
         raise ValidationError({"scope": "Data gateway scope is invalid."})
@@ -1139,7 +1157,7 @@ def ensure_lensnode_for_gateway(
     link = _resolve_gateway_link_identity(
         org=org,
         gateway=gateway,
-        owner_user=owner_user,
+        created_by=created_by,
         normalized_scope=normalized_scope,
     )
 
@@ -1188,14 +1206,14 @@ def enable_ai_on_gateway(
     org: Organization,
     gateway: Node,
     name: str | None = None,
-    owner_user=None,
+    created_by=None,
     scope: str | None = None,
 ) -> LensGatewayLink:
     return ensure_lensnode_for_gateway(
         org=org,
         gateway=gateway,
         name=name,
-        owner_user=owner_user,
+        created_by=created_by,
         scope=scope,
     )
 
@@ -1231,7 +1249,7 @@ def provision_gateway_lens_on_register(
     *,
     org: Organization,
     gateway: Node,
-    owner_user=None,
+    created_by=None,
     scope: str | None = None,
 ) -> dict[str, Any] | None:
     """Auto-provision LensNode when a gateway registers; returns enroll config or None."""
@@ -1243,7 +1261,7 @@ def provision_gateway_lens_on_register(
         link = ensure_lensnode_for_gateway(
             org=org,
             gateway=gateway,
-            owner_user=owner_user,
+            created_by=created_by,
             scope=scope,
         )
         return build_lens_enroll_config(link)
@@ -1506,7 +1524,6 @@ def browse_gateway_directory(
     gateway_id: int,
     path: str = "",
     expected_scope: str | None = None,
-    expected_owner_user_id: int | None = None,
     limit: int = 200,
     wait_timeout_seconds: int = 15,
 ) -> dict[str, Any]:
@@ -1521,9 +1538,22 @@ def browse_gateway_directory(
         raise ValidationError({"gateway": "Data gateway must be online to browse directories."})
 
     link = get_gateway_link(org, gateway.id)
-    if expected_scope is not None and link.scope != expected_scope:
-        raise ValidationError({"gateway_id": "Data gateway scope is invalid."})
-    if expected_scope is not None or expected_owner_user_id is not None:
+    if expected_scope is not None:
+        from apps.lens_bridge.services.gateway_ownership import is_private_gateway
+
+        scope_matches = (
+            link.scope == expected_scope
+            or (
+                expected_scope
+                in {
+                    LensGatewayLink.GatewayScope.ORGANIZATION,
+                    LensGatewayLink.GatewayScope.USER,
+                }
+                and is_private_gateway(link)
+            )
+        )
+        if not scope_matches:
+            raise ValidationError({"gateway_id": "Data gateway scope is invalid."})
         from apps.lens_bridge.services.gateway_execution import (
             context_for_gateway_link,
         )
@@ -1531,7 +1561,6 @@ def browse_gateway_directory(
         context_for_gateway_link(
             tenant_organization=org,
             gateway_link=link,
-            expected_owner_user_id=expected_owner_user_id,
             require_ready=False,
         )
 

--- a/src/backend/apps/lens_bridge/services/snapshot_scope_tasks.py
+++ b/src/backend/apps/lens_bridge/services/snapshot_scope_tasks.py
@@ -165,15 +165,9 @@ def _gateway_reader_context(
     )
     if gateway_link is None:
         raise ValidationError({"gateway_link_id": "Data gateway is not available."})
-    expected_owner_user_id = (
-        requesting_user_id
-        if gateway_link.scope == LensGatewayLink.GatewayScope.USER
-        else None
-    )
     context = context_for_gateway_link(
         tenant_organization=tenant_organization,
         gateway_link=gateway_link,
-        expected_owner_user_id=expected_owner_user_id,
         require_ready=False,
     )
     runtime = gateway_readiness.gateway_runtime_state(context.gateway_link)

--- a/src/backend/apps/lens_bridge/tasks/gateway_provisioning.py
+++ b/src/backend/apps/lens_bridge/tasks/gateway_provisioning.py
@@ -35,6 +35,7 @@ def execute_gateway_lensnode_provision_task(*, gateway_link_id: int) -> dict:
         LensGatewayLink.objects.select_related(
             "organization",
             "gateway",
+            "created_by",
             "owner_user",
         )
         .filter(pk=gateway_link_id, is_deleted=False)
@@ -54,11 +55,7 @@ def execute_gateway_lensnode_provision_task(*, gateway_link_id: int) -> dict:
         result = provisioning.ensure_lensnode_for_gateway(
             org=link.organization,
             gateway=link.gateway,
-            owner_user=(
-                link.owner_user
-                if link.scope == LensGatewayLink.GatewayScope.USER
-                else None
-            ),
+            created_by=link.created_by or link.owner_user,
             scope=link.scope,
         )
     return {

--- a/src/backend/apps/lens_bridge/tests/test_assistant_lifecycle_boundary.py
+++ b/src/backend/apps/lens_bridge/tests/test_assistant_lifecycle_boundary.py
@@ -146,7 +146,7 @@ class AssistantLifecycleBoundaryTests(TestCase):
         return_value=[],
     )
     @mock.patch("apps.lens_bridge.services.assistants.sl_client.request_json")
-    def test_tenant_form_options_only_return_owned_private_resources(
+    def test_tenant_form_options_share_gateways_but_not_knowledge_sources(
         self,
         request_json,
         _list_skills,
@@ -167,11 +167,14 @@ class AssistantLifecycleBoundaryTests(TestCase):
 
         self.assertEqual(
             [row["gateway_id"] for row in options["gateways"]],
-            [self.gateway.id],
+            [self.gateway.id, other_link.gateway_id],
         )
         self.assertEqual(
             [row["uuid"] for row in options["lensnodes"]],
-            [str(self.gateway_link.sl_lensnode_uuid)],
+            [
+                str(self.gateway_link.sl_lensnode_uuid),
+                str(other_link.sl_lensnode_uuid),
+            ],
         )
         self.assertEqual(
             [row["id"] for row in options["knowledge_sources"]],

--- a/src/backend/apps/lens_bridge/tests/test_gateway_authorization.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_authorization.py
@@ -1,4 +1,5 @@
 from unittest import mock
+import uuid
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -38,6 +39,7 @@ class PrivateGatewayApiAuthorizationTests(TestCase):
             organization=self.org,
             gateway=self.gateway,
             owner_user=self.owner,
+            created_by=self.owner,
             scope=LensGatewayLink.GatewayScope.USER,
             origin=LensGatewayLink.Origin.USER,
             workspace_root=f"/workspace/org-{self.org.id}/data",
@@ -45,8 +47,9 @@ class PrivateGatewayApiAuthorizationTests(TestCase):
         self.client = APIClient()
         self.client.force_authenticate(user=self.other_admin)
 
-    @mock.patch("apps.lens_bridge.services.provisioning.sl_client.request_json")
-    def test_other_admin_cannot_enable_ai_or_receive_token(self, request_json):
+    @mock.patch("apps.lens_bridge.services.provisioning.enable_ai_on_gateway")
+    def test_other_admin_can_enable_existing_organization_gateway(self, enable_ai):
+        enable_ai.return_value = self.link
         response = self.client.post(
             reverse(
                 "lens-gateway-enable-ai",
@@ -57,10 +60,16 @@ class PrivateGatewayApiAuthorizationTests(TestCase):
             HTTP_X_ORG_KEY=self.org.key,
         )
 
-        self.assertEqual(response.status_code, 400)
-        request_json.assert_not_called()
+        self.assertEqual(response.status_code, 201)
+        enable_ai.assert_called_once_with(
+            org=self.org,
+            gateway=self.gateway,
+            name=None,
+            created_by=self.other_admin,
+            scope=LensGatewayLink.GatewayScope.ORGANIZATION,
+        )
 
-    def test_other_admin_cannot_read_ai_status(self):
+    def test_other_admin_can_read_ai_status(self):
         response = self.client.get(
             reverse(
                 "lens-gateway-ai-status",
@@ -69,9 +78,9 @@ class PrivateGatewayApiAuthorizationTests(TestCase):
             HTTP_X_ORG_KEY=self.org.key,
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
 
-    def test_other_admin_cannot_read_private_gateway_chat_workload(self):
+    def test_other_admin_can_read_private_gateway_chat_workload(self):
         response = self.client.get(
             reverse(
                 "lens-gateway-chat-workload",
@@ -80,7 +89,7 @@ class PrivateGatewayApiAuthorizationTests(TestCase):
             HTTP_X_ORG_KEY=self.org.key,
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
 
     def test_owner_can_update_private_gateway_chat_workload(self):
         self.client.force_authenticate(user=self.owner)
@@ -102,8 +111,9 @@ class PrivateGatewayApiAuthorizationTests(TestCase):
         self.assertEqual(self.link.chat_prepare_concurrency, 2)
         self.assertEqual(self.link.chat_queue_capacity, 20)
 
-    @mock.patch("apps.node.services.interface.run_agent_task_sync")
-    def test_other_admin_cannot_browse_private_gateway(self, run_agent_task):
+    @mock.patch("apps.lens_bridge.services.provisioning.browse_gateway_directory")
+    def test_other_admin_can_browse_private_gateway(self, browse_gateway_directory):
+        browse_gateway_directory.return_value = {"path": "/", "entries": []}
         response = self.client.get(
             reverse(
                 "lens-gateway-browse",
@@ -112,14 +122,36 @@ class PrivateGatewayApiAuthorizationTests(TestCase):
             HTTP_X_ORG_KEY=self.org.key,
         )
 
-        self.assertEqual(response.status_code, 400)
-        run_agent_task.assert_not_called()
+        self.assertEqual(response.status_code, 200)
+        browse_gateway_directory.assert_called_once_with(
+            org=self.org,
+            gateway_id=self.gateway.id,
+            path="",
+            expected_scope=LensGatewayLink.GatewayScope.ORGANIZATION,
+        )
 
-    def test_cross_user_knowledge_source_request_never_persists_row(self):
+    @mock.patch(
+        "apps.lens_bridge.services.knowledge_source_sync.prepare_new_knowledge_source"
+    )
+    @mock.patch(
+        "apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway"
+    )
+    @mock.patch(
+        "apps.lens_bridge.api.serializers.gateway_readiness.require_hfl_usable_gateway"
+    )
+    def test_peer_can_create_knowledge_source_on_organization_gateway(
+        self,
+        _usable,
+        _copilot_ready,
+        prepare_knowledge_source,
+    ):
+        self.link.sl_lensnode_uuid = uuid.uuid4()
+        self.link.save(update_fields=["sl_lensnode_uuid", "updated_at"])
+        prepare_knowledge_source.side_effect = lambda *, org, ks: ks
         response = self.client.post(
             reverse("lens-knowledge-source-list"),
             {
-                "name": "Unauthorized source",
+                "name": "Organization source",
                 "gateway": self.gateway.id,
                 "source_path": self.link.resolved_workspace_root(),
             },
@@ -127,10 +159,11 @@ class PrivateGatewayApiAuthorizationTests(TestCase):
             HTTP_X_ORG_KEY=self.org.key,
         )
 
-        self.assertEqual(response.status_code, 400)
-        self.assertFalse(
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(
             LensKnowledgeSource.objects.filter(
                 organization=self.org,
-                name="Unauthorized source",
+                name="Organization source",
+                created_by=self.other_admin,
             ).exists()
         )

--- a/src/backend/apps/lens_bridge/tests/test_gateway_execution.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_execution.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest import mock
 
 from django.contrib.auth import get_user_model
@@ -14,6 +15,7 @@ from apps.lens_bridge.services import platform_lens
 from apps.lens_bridge.services.gateway_execution import (
     context_for_gateway_link,
     context_for_workspace_binding,
+    require_organization_gateway_link,
 )
 from apps.node.models import Node
 from apps.node.models.base import NodeRole
@@ -66,8 +68,8 @@ class GatewayExecutionContextTests(TestCase):
         link = LensGatewayLink.objects.create(
             organization=other_org,
             gateway=node,
-            owner_user=self.user,
-            scope=LensGatewayLink.GatewayScope.USER,
+            created_by=self.user,
+            scope=LensGatewayLink.GatewayScope.ORGANIZATION,
         )
 
         with self.assertRaises(ValidationError):
@@ -77,7 +79,7 @@ class GatewayExecutionContextTests(TestCase):
             )
 
     @mock.patch("apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway")
-    def test_private_gateway_cannot_cross_user_boundary(self, _ready):
+    def test_private_gateway_is_shared_inside_organization(self, _ready):
         node = Node.objects.create(
             organization=self.tenant,
             name="private-user-gateway",
@@ -90,17 +92,49 @@ class GatewayExecutionContextTests(TestCase):
             owner_user=self.user,
             scope=LensGatewayLink.GatewayScope.USER,
         )
-        another_user = get_user_model().objects.create_user(
-            username="another-gateway-user@example.test",
-            email="another-gateway-user@example.test",
+        context = context_for_gateway_link(
+            tenant_organization=self.tenant,
+            gateway_link=link,
+        )
+        resolved = require_organization_gateway_link(
+            tenant_organization=self.tenant,
+            gateway_id=node.id,
         )
 
-        with self.assertRaises(ValidationError):
-            context_for_gateway_link(
-                tenant_organization=self.tenant,
-                gateway_link=link,
-                expected_owner_user_id=another_user.id,
-            )
+        self.assertEqual(context.gateway_link, link)
+        self.assertEqual(resolved, link)
+
+    @mock.patch(
+        "apps.lens_bridge.services.gateway_execution.gateway_readiness.require_copilot_gateway"
+    )
+    def test_peer_can_select_organization_gateway_for_chat(self, _ready):
+        node = Node.objects.create(
+            organization=self.tenant,
+            name="organization-chat-gateway",
+            role=NodeRole.GATEWAY,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+        )
+        link = LensGatewayLink.objects.create(
+            organization=self.tenant,
+            gateway=node,
+            owner_user=self.user,
+            created_by=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+            sl_lensnode_uuid=uuid.uuid4(),
+        )
+        peer = get_user_model().objects.create_user(
+            username="organization-gateway-peer@example.test",
+            email="organization-gateway-peer@example.test",
+        )
+
+        selected = platform_lens.resolve_gateway_link_for_copilot(
+            self.tenant,
+            user=peer,
+            gateway_link_id=link.id,
+        )
+
+        self.assertEqual(selected, link)
 
     def test_platform_gateway_removal_sees_tenant_knowledge_sources(self):
         platform_org = platform_lens.get_or_create_platform_org()

--- a/src/backend/apps/lens_bridge/tests/test_gateway_insights.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_insights.py
@@ -30,20 +30,24 @@ class GatewayInsightDirectoryTests(SimpleTestCase):
     @patch("apps.lens_bridge.services.gateway_insights._serialize_row")
     @patch("apps.lens_bridge.services.gateway_insights._link_index")
     @patch("apps.lens_bridge.services.gateway_insights._lensnode_rows")
-    def test_user_directory_only_returns_owned_mappings(
+    def test_organization_directory_only_returns_organization_mappings(
         self,
         mock_lensnodes,
         mock_link_index,
         mock_serialize,
     ):
         user = MagicMock()
+        organization = MagicMock()
         link = MagicMock()
         mock_lensnodes.return_value = [{"uuid": "owned"}, {"uuid": "other"}]
         mock_link_index.return_value = {"owned": link}
         mock_serialize.return_value = {"name": "owned"}
 
-        rows = gateway_insights.list_user_gateway_insight_rows(user=user)
+        rows = gateway_insights.list_organization_gateway_insight_rows(
+            organization=organization,
+            user=user,
+        )
 
         self.assertEqual(rows, [{"name": "owned"}])
-        mock_link_index.assert_called_once_with(owner_user=user)
+        mock_link_index.assert_called_once_with(organization=organization)
         mock_serialize.assert_called_once()

--- a/src/backend/apps/lens_bridge/tests/test_gateway_lensnode_provisioning.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_lensnode_provisioning.py
@@ -53,8 +53,8 @@ class DurableGatewayLensNodeProvisioningTests(TestCase):
         result = provisioning.ensure_lensnode_for_gateway(
             org=self.org,
             gateway=self.gateway,
-            owner_user=self.user,
-            scope=LensGatewayLink.GatewayScope.USER,
+            created_by=self.user,
+            scope=LensGatewayLink.GatewayScope.ORGANIZATION,
         )
 
         self.assertEqual(result.sl_lensnode_uuid, remote_uuid)
@@ -96,8 +96,8 @@ class DurableGatewayLensNodeProvisioningTests(TestCase):
         result = provisioning.ensure_lensnode_for_gateway(
             org=self.org,
             gateway=self.gateway,
-            owner_user=self.user,
-            scope=LensGatewayLink.GatewayScope.USER,
+            created_by=self.user,
+            scope=LensGatewayLink.GatewayScope.ORGANIZATION,
         )
 
         self.assertEqual(result.sl_lensnode_uuid, remote_uuid)
@@ -124,8 +124,8 @@ class DurableGatewayLensNodeProvisioningTests(TestCase):
             provisioning.ensure_lensnode_for_gateway(
                 org=self.org,
                 gateway=self.gateway,
-                owner_user=self.user,
-                scope=LensGatewayLink.GatewayScope.USER,
+                created_by=self.user,
+                scope=LensGatewayLink.GatewayScope.ORGANIZATION,
             )
 
         request_json.assert_not_called()
@@ -162,31 +162,51 @@ class DurableGatewayLensNodeProvisioningTests(TestCase):
             provisioning.ensure_lensnode_for_gateway(
                 org=self.org,
                 gateway=self.gateway,
-                owner_user=self.user,
-                scope=LensGatewayLink.GatewayScope.USER,
+                created_by=self.user,
+                scope=LensGatewayLink.GatewayScope.ORGANIZATION,
             )
 
         request_json.assert_called_once()
 
     @mock.patch("apps.lens_bridge.services.provisioning.sl_client.request_json")
-    def test_private_gateway_owner_cannot_be_replaced(self, request_json):
+    def test_private_gateway_installer_is_not_authorization_boundary(
+        self, request_json
+    ):
         another_user = get_user_model().objects.create_user(
             username="other-lensnode-owner@example.test",
             email="other-lensnode-owner@example.test",
         )
 
-        with self.assertRaisesMessage(
-            Exception,
-            "Private Data Gateway belongs to another user.",
-        ):
-            provisioning.ensure_lensnode_for_gateway(
-                org=self.org,
-                gateway=self.gateway,
-                owner_user=another_user,
-                scope=LensGatewayLink.GatewayScope.USER,
-            )
+        self.link.sl_lensnode_uuid = uuid.uuid4()
+        self.link.save(update_fields=["sl_lensnode_uuid", "updated_at"])
+
+        result = provisioning.ensure_lensnode_for_gateway(
+            org=self.org,
+            gateway=self.gateway,
+            created_by=another_user,
+            scope=LensGatewayLink.GatewayScope.ORGANIZATION,
+        )
 
         request_json.assert_not_called()
+        self.assertEqual(result.created_by, self.user)
+
+    def test_new_organization_gateway_uses_rolling_deploy_storage_contract(self):
+        gateway = Node.objects.create(
+            organization=self.org,
+            name="New organization gateway",
+            role=NodeRole.GATEWAY,
+        )
+
+        result = provisioning._resolve_gateway_link_identity(
+            org=self.org,
+            gateway=gateway,
+            created_by=self.user,
+            normalized_scope=LensGatewayLink.GatewayScope.ORGANIZATION,
+        )
+
+        self.assertEqual(result.scope, LensGatewayLink.GatewayScope.USER)
+        self.assertEqual(result.owner_user, self.user)
+        self.assertEqual(result.created_by, self.user)
 
     @mock.patch("apps.lens_bridge.services.provisioning.sl_client.request_json")
     def test_platform_gateway_create_defaults_capacity_bytes(self, request_json):

--- a/src/backend/apps/lens_bridge/tests/test_gateway_organization_ownership_migration.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_organization_ownership_migration.py
@@ -1,0 +1,92 @@
+from django.conf import settings
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+
+class GatewayOrganizationOwnershipMigrationTests(TransactionTestCase):
+    migrate_from = [
+        ("lens_bridge", "0040_session_analysis_type"),
+        ("node", "0020_backfill_upgrade_operation_tasks"),
+    ]
+    migrate_to = [
+        ("lens_bridge", "0041_gateway_organization_ownership"),
+        ("node", "0020_backfill_upgrade_operation_tasks"),
+    ]
+
+    def setUp(self):
+        super().setUp()
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_from)
+        old_apps = executor.loader.project_state(self.migrate_from).apps
+        self._seed_legacy_gateway(old_apps)
+
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_to)
+        self.apps = executor.loader.project_state(self.migrate_to).apps
+
+    def tearDown(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate(executor.loader.graph.leaf_nodes())
+        super().tearDown()
+
+    def _seed_legacy_gateway(self, apps):
+        app_label, model_name = settings.AUTH_USER_MODEL.split(".")
+        User = apps.get_model(app_label, model_name)
+        Organization = apps.get_model("iam", "Organization")
+        Node = apps.get_model("node", "Node")
+        LensGatewayLink = apps.get_model("lens_bridge", "LensGatewayLink")
+
+        creator = User.objects.create(
+            username="legacy-gateway-creator@example.test",
+            email="legacy-gateway-creator@example.test",
+        )
+        organization = Organization.objects.create(
+            key="legacy-gateway-organization",
+            name="Legacy gateway organization",
+        )
+        gateway = Node.objects.create(
+            organization=organization,
+            name="Legacy private gateway",
+            role="gateway",
+        )
+        link = LensGatewayLink.objects.create(
+            organization=organization,
+            gateway=gateway,
+            scope="user",
+            origin="user",
+            owner_user=creator,
+        )
+        self.creator_id = creator.id
+        self.organization_id = organization.id
+        self.gateway_id = gateway.id
+        self.link_id = link.id
+
+    def test_installer_is_backfilled_without_rewriting_legacy_scope(self):
+        LensGatewayLink = self.apps.get_model("lens_bridge", "LensGatewayLink")
+
+        link = LensGatewayLink.objects.get(pk=self.link_id)
+
+        self.assertEqual(link.created_by_id, self.creator_id)
+        self.assertEqual(link.owner_user_id, self.creator_id)
+        self.assertEqual(link.scope, "user")
+
+    def test_schema_accepts_ownerless_organization_scope(self):
+        LensGatewayLink = self.apps.get_model("lens_bridge", "LensGatewayLink")
+        Node = self.apps.get_model("node", "Node")
+        gateway = Node.objects.create(
+            organization_id=self.organization_id,
+            name="Organization-scope private gateway",
+            role="gateway",
+        )
+
+        link = LensGatewayLink.objects.create(
+            organization_id=self.organization_id,
+            gateway_id=gateway.id,
+            scope="organization",
+            origin="user",
+            owner_user_id=None,
+            created_by_id=None,
+        )
+
+        self.assertEqual(link.scope, "organization")

--- a/src/backend/apps/node/api/views/node.py
+++ b/src/backend/apps/node/api/views/node.py
@@ -849,7 +849,7 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
             lens = provisioning.provision_gateway_lens_on_register(
                 org=org,
                 gateway=node,
-                owner_user=token_row.created_by if token_row is not None else None,
+                created_by=token_row.created_by if token_row is not None else None,
                 scope=token_row.gateway_scope if token_row is not None else None,
             )
             if lens:

--- a/src/backend/apps/node/services/internal/local_platform_gateway.py
+++ b/src/backend/apps/node/services/internal/local_platform_gateway.py
@@ -309,6 +309,9 @@ def reconcile_local_platform_gateway_links() -> int:
         if link.owner_user_id is not None:
             link.owner_user = None
             update_fields.append("owner_user")
+        if link.created_by_id is not None:
+            link.created_by = None
+            update_fields.append("created_by")
         if update_fields:
             link.save(update_fields=[*update_fields, "updated_at"])
             changed += 1

--- a/src/backend/apps/node/tests/test_local_platform_gateway.py
+++ b/src/backend/apps/node/tests/test_local_platform_gateway.py
@@ -357,7 +357,7 @@ class LocalPlatformGatewayEnrollmentTests(TestCase):
             provisioning.ensure_lensnode_for_gateway(
                 org=org,
                 gateway=gateway,
-                owner_user=self.user,
+                created_by=self.user,
                 scope=LensGatewayLink.GatewayScope.USER,
             )
 

--- a/src/frontend/src/lib/copilotGatewayTerminology.ts
+++ b/src/frontend/src/lib/copilotGatewayTerminology.ts
@@ -4,7 +4,7 @@ export function copilotGatewayKind(
   gatewayScope: string | null | undefined,
   selectionMode: string | null | undefined,
 ): CopilotGatewayKind {
-  if (gatewayScope === 'user') return 'private'
+  if (gatewayScope === 'organization' || gatewayScope === 'user') return 'private'
   if (gatewayScope === 'platform') return 'public'
   return selectionMode === 'manual' ? 'private' : 'public'
 }

--- a/src/frontend/src/lib/lensApi.ts
+++ b/src/frontend/src/lib/lensApi.ts
@@ -255,6 +255,8 @@ export type LensGatewayInsight = {
   sl_runtime_status?: string
   owner_user_id?: number | null
   owner_username?: string
+  created_by_id?: number | null
+  created_by_username?: string
   owner_organization_id?: number | null
   is_platform_default?: boolean
   organization?: number
@@ -727,7 +729,7 @@ export type GatewayChatWorkload = {
   gateway_link_id: number
   gateway_id: number
   gateway_name: string
-  gateway_scope: 'platform' | 'user' | string
+  gateway_scope: 'platform' | 'organization' | 'user' | string
   chat_prepare_concurrency: number
   chat_queue_capacity: number
   active_chat_preparations: number
@@ -1205,7 +1207,7 @@ export async function cancelCopilotScopePreview(
 }
 
 export type LensAdmissionPreview = {
-  gateway_scope: 'platform' | 'user' | string
+  gateway_scope: 'platform' | 'organization' | 'user' | string
   selection: {
     file_count: number
     size_bytes: number

--- a/src/frontend/src/pages/insight/CopilotGatewayTerminology.test.ts
+++ b/src/frontend/src/pages/insight/CopilotGatewayTerminology.test.ts
@@ -15,6 +15,7 @@ const nodeApi = source('src/lib/nodeApi.ts')
 describe('Copilot Data Gateway product terminology', () => {
   it('uses Gateway scope as the authoritative persisted Chat type', () => {
     expect(copilotGatewayKind('platform', 'manual')).toBe('public')
+    expect(copilotGatewayKind('organization', 'auto')).toBe('private')
     expect(copilotGatewayKind('user', 'auto')).toBe('private')
     expect(copilotGatewayKind(null, 'manual')).toBe('private')
     expect(copilotGatewayKind(null, 'auto')).toBe('public')

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -74,7 +74,9 @@ function newCreateIdempotencyKey(): string {
 const readyGateways = computed(() => gatewayOptions.value.filter(
   (row) => row.online && row.hfl_usable && row.copilot_eligible,
 ))
-const privateGateways = computed(() => readyGateways.value.filter((row) => row.scope === 'user'))
+const privateGateways = computed(() => readyGateways.value.filter(
+  (row) => row.scope === 'organization' || row.scope === 'user',
+))
 const platformGateway = computed(() => {
   const rows = readyGateways.value.filter((row) => row.scope === 'platform')
   return rows.find((row) => row.is_platform_default) ?? rows[0] ?? null


### PR DESCRIPTION
## Summary

- make Private Data Gateways visible, configurable, and selectable by users in the same organization
- separate installer audit metadata from gateway authorization while preserving legacy `scope=user` compatibility for rolling deployments
- keep Chat, Knowledge Source, Assistant, and SourceLens bridge identities user-scoped
- normalize private gateway scope as `organization` in backend and frontend API contracts
- add authorization, provisioning, migration, execution, and frontend compatibility coverage

## Validation

- Lens Bridge and Node backend tests
- restore boundary and related backend tests
- PostgreSQL migration coverage
- frontend unit tests
- Vue type checking and ESLint
- Ruff, Python compile checks, Django migration checks, and `git diff --check`