### PR TITLE
Refine online installation output

### DIFF
--- a/deploy/installer/apply-runtime-config.py
+++ b/deploy/installer/apply-runtime-config.py
@@ -50,6 +50,10 @@ def warn(message: str) -> None:
     print(f"[runtime-config] WARNING: {message}")
 
 
+def info(message: str) -> None:
+    print(f"[runtime-config] INFO: {message}")
+
+
 def require_regular_file(path: pathlib.Path, label: str) -> None:
     try:
         mode = path.lstat().st_mode
@@ -467,7 +471,12 @@ def apply_configuration(
                 f"invalid public URL {public_url!r}; preserving installed URL configuration"
             )
     else:
-        warn("public URL is empty; preserving installed URL configuration")
+        if os.environ.get("HFL_ONLINE_CHILD") == "1":
+            info(
+                "public URL was not specified; existing URL configuration remains unchanged"
+            )
+        else:
+            warn("public URL is empty; preserving installed URL configuration")
 
     admin_public_url = admin_public_url.strip()
     if admin_public_url:

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -1227,6 +1227,7 @@ reload_stable_nginx() {
 }
 
 start_hfl_stack() {
+	local show_sections=${1:-0}
 	local color nginx_generation_before nginx_generation_after
 	ensure_blue_green_state || return 1
 	color="$(read_active_color)" || return 1
@@ -1234,13 +1235,27 @@ start_hfl_stack() {
 		warn "could not inspect the stable Nginx instance before service convergence"
 		return 1
 	fi
+	if [[ "${show_sections}" -eq 1 ]]; then
+		print_section "Core data services"
+	fi
 	compose_in_root up -d --no-build --pull never --no-recreate postgres redis || return 1
 	# Compose v2.27 supports `up --pull` but not `run --pull`. The migration
 	# service inherits `pull_policy: never` from the release Compose model, so
 	# this remains offline without relying on a version-sensitive CLI flag.
+	if [[ "${show_sections}" -eq 1 ]]; then
+		print_section "Database initialization"
+		step "Applying backend database migrations and initial data"
+	fi
 	compose_in_root --profile tools run --rm --no-deps migration || return 1
+	if [[ "${show_sections}" -eq 1 ]]; then
+		ok "Database migrations and initial data are ready"
+		print_section "Application services"
+	fi
 	compose_in_root up -d --no-build --pull never worker scheduler || return 1
 	compose_color "${color}" up -d --no-build --pull never "api-${color}" "web-${color}" || return 1
+	if [[ "${show_sections}" -eq 1 ]]; then
+		print_section "Health checks"
+	fi
 	wait_for_color_health "${color}" || return 1
 	compose_in_root up -d --no-build --pull never nginx || return 1
 	if ! nginx_generation_after="$(stable_nginx_running_generation)"; then
@@ -2500,6 +2515,7 @@ with (root / "MANIFEST.json").open(encoding="utf-8") as fh:
     manifest = json.load(fh)
 delivery = manifest.get("delivery") or {"mode": "offline"}
 delivery_mode = str(delivery.get("mode") or "offline")
+online_child = os.environ.get("HFL_ONLINE_CHILD") == "1"
 
 
 def sha256_file(path: pathlib.Path) -> str:
@@ -2584,13 +2600,25 @@ if delivery_mode == "registry":
         ]
         pulled = ""
         errors = []
-        print(
-            f"[....] Resolving registry image ({index}/{len(registry_images)}): "
-            f"{local_ref}@{digest}"
-        )
+        if online_child:
+            print(
+                f"[....] Verifying prepared runtime image "
+                f"({index}/{len(registry_images)}): {local_ref}@{digest}"
+            )
+        else:
+            print(
+                f"[....] Resolving registry image ({index}/{len(registry_images)}): "
+                f"{local_ref}@{digest}"
+            )
         if has_expected_digest(local_ref, digest):
             verify_revision(local_ref, str(image.get("role") or ""))
-            print(f"[ OK ] Reusing registry image: {local_ref}@{digest}")
+            if online_child:
+                print(
+                    f"[ OK ] Runtime image {index}/{len(registry_images)} "
+                    f"verified · {local_ref}@{digest}"
+                )
+            else:
+                print(f"[ OK ] Reusing registry image: {local_ref}@{digest}")
             continue
         for source in sources:
             source_ref = str(source.get("ref") or "")
@@ -2619,8 +2647,17 @@ if delivery_mode == "registry":
         if not has_expected_digest(local_ref, digest):
             raise SystemExit(f"registry image digest was not retained locally: {local_ref}")
         verify_revision(local_ref, str(image.get("role") or ""))
-        print(f"[ OK ] Verified registry image: {local_ref}@{digest}")
-    print(f"[ OK ] Processed {len(registry_images)} registry image(s)")
+        if online_child:
+            print(
+                f"[ OK ] Runtime image {index}/{len(registry_images)} "
+                f"verified · {local_ref}@{digest}"
+            )
+        else:
+            print(f"[ OK ] Verified registry image: {local_ref}@{digest}")
+    if online_child:
+        print(f"[ OK ] All {len(registry_images)} prepared runtime images are verified")
+    else:
+        print(f"[ OK ] Processed {len(registry_images)} registry image(s)")
     raise SystemExit(0)
 if delivery_mode != "offline":
     raise SystemExit(f"unsupported release delivery mode: {delivery_mode}")
@@ -3645,15 +3682,37 @@ PY
 	printf '%s' "<host>"
 }
 
+print_nested_value() {
+	local label=$1 value=${2:-}
+	[[ -n "${value}" ]] || return 0
+	printf '    %-14s %s\n' "${label}" "${value}"
+}
+
+installation_platform_display() {
+	local platform_name="Linux" machine
+	if [[ -r /etc/os-release ]]; then
+		platform_name="$(
+			awk -F= '$1 == "PRETTY_NAME" {value=substr($0, index($0, "=") + 1); gsub(/^"|"$/, "", value); print value; exit}' \
+				/etc/os-release
+		)"
+		[[ -n "${platform_name}" ]] || platform_name="Linux"
+	fi
+	machine="$(uname -m)"
+	case "${machine}" in
+	x86_64) machine=amd64 ;;
+	aarch64) machine=arm64 ;;
+	esac
+	printf '%s · linux/%s' "${platform_name}" "${machine}"
+}
+
 print_console_access_summary() {
 	local summary_title=${1:-"Installation summary"}
 	local show_deployment=${2:-1}
 	local env_file="${ROOT}/.env"
 	[[ -f "${env_file}" ]] || return 0
-
 	local host seed seed_email seed_pass seed_org sourcelens_mode sourcelens_console_port
 	local website_bind website_port tenant_bind tenant_port admin_bind admin_port sourcelens_console_bind
-	local sl_env sl_user sl_email sl_pass show_credentials=0
+	local sl_env sl_user sl_email sl_pass show_credentials=0 credentials_note
 	host="$(resolve_console_host)"
 	seed="$(read_env_value SEED_INITIAL_DATA)"
 	seed_email="$(read_env_value SEED_ADMIN_EMAIL)"
@@ -3678,28 +3737,6 @@ print_console_access_summary() {
 	sourcelens_console_port="$(read_env_value SOURCELENS_CONSOLE_PORT)"
 	[[ -n "${sourcelens_console_port}" ]] || sourcelens_console_port="11445"
 
-	if [[ "${show_deployment}" -eq 1 ]]; then
-		print_section "${summary_title}"
-		print_value "Version" "$(read_version)"
-		print_value "Edition" "$(display_edition_from_dir "${ROOT}")"
-		print_value "Install path" "${ROOT}"
-		print_value "Config file" "${env_file}"
-		print_value "Log file" "${LOG_FILE}"
-		print_section "Access"
-	else
-		print_section "${summary_title}"
-	fi
-	print_value "Website" "https://${host}:${website_port}/en/  (${website_bind})"
-	print_value "Tenant" "https://${host}:${tenant_port}/  (${tenant_bind})"
-	print_value "Platform Ops" "https://${host}:${admin_port}/  (${admin_bind})"
-	print_value "Django Admin" "https://${host}:${admin_port}/admin/"
-	print_value "API / Swagger" "https://${host}:${tenant_port}/swagger"
-	if [[ "${sourcelens_mode}" == "bundled" ]] && sourcelens_installed; then
-		print_value "Insight Console" "https://${host}:${sourcelens_console_port}/  (${sourcelens_console_bind})"
-	elif [[ "${sourcelens_mode}" == "external" ]]; then
-		print_value "Insight Console" "$(read_env_value LENS_BASE_URL) (external)"
-	fi
-
 	if [[ "${seed}" == "1" ]]; then
 		[[ -n "${seed_email}" ]] || seed_email="admin@hyperfilelens.com"
 		[[ -n "${seed_pass}" ]] || seed_pass="Admin@123"
@@ -3710,39 +3747,139 @@ print_console_access_summary() {
 		auto) [[ "${INTERACTIVE_SESSION}" -eq 1 ]] && show_credentials=1 || true ;;
 		*) die "invalid HFL_SHOW_GENERATED_CREDENTIALS=${SHOW_GENERATED_CREDENTIALS}" ;;
 		esac
-		print_section "Login credentials"
-		printf '  HyperFileLens\n'
-		if [[ "${show_credentials}" -eq 1 ]]; then
-			print_value "  Email" "${seed_email}"
-			print_value "  Password" "${seed_pass}"
-			print_value "  Applies to" "Tenant, Platform Ops and Django Admin"
-		else
-			print_value "  Credentials" "stored in ${env_file}; values are hidden in non-interactive logs"
+		credentials_note="stored in ${env_file}; values are hidden in non-interactive logs"
+	fi
+	if [[ "${sourcelens_mode}" == "bundled" ]] && sourcelens_installed; then
+		sl_env="${ROOT}/data/sourcelens/config/.env"
+		sl_user="$(grep -E '^DJANGO_SUPERUSER_USERNAME=' "${sl_env}" 2>/dev/null | head -1 | cut -d= -f2- | tr -d ' "' || true)"
+		sl_email="$(grep -E '^DJANGO_SUPERUSER_EMAIL=' "${sl_env}" 2>/dev/null | head -1 | cut -d= -f2- | tr -d ' "' || true)"
+		sl_pass="$(grep -E '^DJANGO_SUPERUSER_PASSWORD=' "${sl_env}" 2>/dev/null | head -1 | cut -d= -f2- | tr -d ' "' || true)"
+		[[ -n "${sl_user}" ]] || sl_user="admin"
+		[[ -n "${sl_email}" ]] || sl_email="admin@example.com"
+		[[ -n "${sl_pass}" ]] || sl_pass="adminpassword"
+	fi
+
+	if [[ "${show_deployment}" -eq 1 ]]; then
+		print_section "${summary_title}"
+		print_value "Version" "$(read_version)"
+		print_value "Edition" "$(display_edition_from_dir "${ROOT}")"
+		if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+			print_value "Platform" "$(installation_platform_display)"
 		fi
-		print_value "  Organization" "${seed_org}"
+		print_value "Install path" "${ROOT}"
+		print_value "Config file" "${env_file}"
+		print_value "Log file" "${LOG_FILE}"
+		print_section "Access"
+	else
+		print_section "${summary_title}"
+	fi
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		printf '  Website · %s\n' "${website_port}"
+		print_nested_value "URL" "https://${host}:${website_port}/en/"
+		print_nested_value "Bind" "${website_bind}"
+
+		printf '\n  Tenant · %s\n' "${tenant_port}"
+		print_nested_value "URL" "https://${host}:${tenant_port}/"
+		if [[ "${seed}" == "1" ]]; then
+			if [[ "${show_credentials}" -eq 1 ]]; then
+				print_nested_value "Email" "${seed_email}"
+				print_nested_value "Password" "${seed_pass}"
+			else
+				print_nested_value "Credentials" "${credentials_note}"
+			fi
+			print_nested_value "Organization" "${seed_org}"
+		fi
+
+		printf '\n  Platform Ops · %s\n' "${admin_port}"
+		print_nested_value "URL" "https://${host}:${admin_port}/"
+		if [[ "${seed}" == "1" ]]; then
+			if [[ "${show_credentials}" -eq 1 ]]; then
+				print_nested_value "Email" "${seed_email}"
+				print_nested_value "Password" "${seed_pass}"
+			else
+				print_nested_value "Credentials" "${credentials_note}"
+			fi
+		fi
+
+		printf '\n  Django Admin · %s\n' "${admin_port}"
+		print_nested_value "URL" "https://${host}:${admin_port}/admin/"
+		if [[ "${seed}" == "1" ]]; then
+			if [[ "${show_credentials}" -eq 1 ]]; then
+				print_nested_value "Email" "${seed_email}"
+				print_nested_value "Password" "${seed_pass}"
+			else
+				print_nested_value "Credentials" "${credentials_note}"
+			fi
+		fi
 
 		if [[ "${sourcelens_mode}" == "bundled" ]] && sourcelens_installed; then
-			sl_env="${ROOT}/data/sourcelens/config/.env"
-			sl_user="$(grep -E '^DJANGO_SUPERUSER_USERNAME=' "${sl_env}" 2>/dev/null | head -1 | cut -d= -f2- | tr -d ' "' || true)"
-			sl_email="$(grep -E '^DJANGO_SUPERUSER_EMAIL=' "${sl_env}" 2>/dev/null | head -1 | cut -d= -f2- | tr -d ' "' || true)"
-			sl_pass="$(grep -E '^DJANGO_SUPERUSER_PASSWORD=' "${sl_env}" 2>/dev/null | head -1 | cut -d= -f2- | tr -d ' "' || true)"
-			[[ -n "${sl_user}" ]] || sl_user="admin"
-			[[ -n "${sl_email}" ]] || sl_email="admin@example.com"
-			[[ -n "${sl_pass}" ]] || sl_pass="adminpassword"
+			printf '\n  Insight Console · %s\n' "${sourcelens_console_port}"
+			print_nested_value "URL" "https://${host}:${sourcelens_console_port}/"
+			print_nested_value "Bind" "${sourcelens_console_bind}"
+			if [[ "${seed}" == "1" ]]; then
+				if [[ "${show_credentials}" -eq 1 ]]; then
+					print_nested_value "Username" "${sl_user}"
+					print_nested_value "Email" "${sl_email}"
+					print_nested_value "Password" "${sl_pass}"
+				else
+					print_nested_value "Credentials" "stored in ${sl_env}; values are hidden in non-interactive logs"
+				fi
+			fi
+			print_nested_value "API" "https://${host}:${tenant_port}/sourcelens/api/"
+			print_nested_value "WebSocket" "wss://${host}:${tenant_port}/sourcelens/ws/lens/lensnodes/"
+			print_nested_value "Network" "${HFL_BRIDGE_NETWORK} (private)"
+		elif [[ "${sourcelens_mode}" == "external" ]]; then
 			printf '\n  Insight Console\n'
+			print_nested_value "URL" "$(read_env_value LENS_BASE_URL)"
+			print_nested_value "Mode" "external"
+		fi
+
+		printf '\n  API / Swagger · %s\n' "${tenant_port}"
+		print_nested_value "URL" "https://${host}:${tenant_port}/swagger"
+		print_nested_value "Authentication" "HyperFileLens account"
+	else
+		print_value "Website" "https://${host}:${website_port}/en/  (${website_bind})"
+		print_value "Tenant" "https://${host}:${tenant_port}/  (${tenant_bind})"
+		print_value "Platform Ops" "https://${host}:${admin_port}/  (${admin_bind})"
+		print_value "Django Admin" "https://${host}:${admin_port}/admin/"
+		print_value "API / Swagger" "https://${host}:${tenant_port}/swagger"
+		if [[ "${sourcelens_mode}" == "bundled" ]] && sourcelens_installed; then
+			print_value "Insight Console" "https://${host}:${sourcelens_console_port}/  (${sourcelens_console_bind})"
+		elif [[ "${sourcelens_mode}" == "external" ]]; then
+			print_value "Insight Console" "$(read_env_value LENS_BASE_URL) (external)"
+		fi
+	fi
+
+	if [[ "${seed}" == "1" ]]; then
+		if [[ "${HFL_ONLINE_CHILD:-0}" != "1" ]]; then
+			print_section "Login credentials"
+			printf '  HyperFileLens\n'
 			if [[ "${show_credentials}" -eq 1 ]]; then
-				print_value "  Username" "${sl_user}"
-				print_value "  Email" "${sl_email}"
-				print_value "  Password" "${sl_pass}"
+				print_value "  Email" "${seed_email}"
+				print_value "  Password" "${seed_pass}"
+				print_value "  Applies to" "Tenant, Platform Ops and Django Admin"
 			else
-				print_value "  Credentials" "stored in ${sl_env}; values are hidden in non-interactive logs"
+				print_value "  Credentials" "${credentials_note}"
+			fi
+			print_value "  Organization" "${seed_org}"
+
+			if [[ "${sourcelens_mode}" == "bundled" ]] && sourcelens_installed; then
+				printf '\n  Insight Console\n'
+				if [[ "${show_credentials}" -eq 1 ]]; then
+					print_value "  Username" "${sl_user}"
+					print_value "  Email" "${sl_email}"
+					print_value "  Password" "${sl_pass}"
+				else
+					print_value "  Credentials" "stored in ${sl_env}; values are hidden in non-interactive logs"
+				fi
 			fi
 		fi
 	else
 		warn "Initial seeding is disabled (SEED_INITIAL_DATA=${seed:-0}); no default admin account will be created automatically."
 	fi
 
-	if [[ "${sourcelens_mode}" == "bundled" ]] && sourcelens_installed; then
+	if [[ "${HFL_ONLINE_CHILD:-0}" != "1" \
+		&& "${sourcelens_mode}" == "bundled" ]] && sourcelens_installed; then
 		print_section "Service endpoints"
 		print_value "Insight API" "https://${host}:${tenant_port}/sourcelens/api/"
 		print_value "Insight WSS" "wss://${host}:${tenant_port}/sourcelens/ws/lens/lensnodes/"
@@ -3767,12 +3904,19 @@ print_console_access_summary() {
 
 	print_section "Management commands"
 	print_value "Status" "sudo ${ROOT}/install.sh status"
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		print_value "Logs" "sudo docker compose -f ${ROOT}/docker-compose.yml logs -f"
+	fi
 	print_value "Start" "sudo ${ROOT}/install.sh start"
 	print_value "Stop" "sudo ${ROOT}/install.sh stop"
 	print_value "Restart" "sudo ${ROOT}/install.sh restart"
 	print_value "Backup" "sudo ${ROOT}/install.sh backup"
 	print_value "Upgrade" "sudo ${ROOT}/install.sh upgrade --from /path/to/new-release.tar.gz"
 	print_value "Uninstall" "sudo ${ROOT}/install.sh uninstall"
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]] \
+		&& local_platform_gateway_agent_is_managed; then
+		print_value "Gateway status" "sudo ${LOCAL_PLATFORM_AGENT_INSTALL_DIR}/install.sh status"
+	fi
 }
 
 print_platform_gateway_summary() {
@@ -3801,7 +3945,7 @@ print_platform_gateway_summary() {
 	[[ "${LOCAL_PLATFORM_GATEWAY_VERIFIED}" -eq 0 ]] || console_state="online"
 
 	print_section "Platform Data Gateway"
-	print_value "Role" "Private Data Gateway"
+	print_value "Role" "Platform Data Gateway"
 	print_value "Organization" "${organization:-platform_lens}"
 	print_value "Node ID" "${node_id:-unknown}"
 	print_value "Agent version" "${version:-unknown}"
@@ -3815,6 +3959,48 @@ print_platform_gateway_summary() {
 	print_value "Data" "${LOCAL_PLATFORM_AGENT_DATA_DIR}/data"
 	print_value "Logs" "${LOCAL_PLATFORM_AGENT_DATA_DIR}/logs"
 	print_value "Install log" "${LOCAL_PLATFORM_AGENT_DATA_DIR}/logs/install.log"
+}
+
+print_online_installation_verification() {
+	local sourcelens_mode=$1
+	local service container_id ai_engine
+	print_section "HyperFileLens services"
+	compose_all_profiles ps
+	ok "HyperFileLens services are healthy"
+
+	if [[ "${sourcelens_mode}" -ne 0 \
+		&& "$(configured_sourcelens_mode)" == "bundled" ]] \
+		&& sourcelens_installed; then
+		print_section "Insight services"
+		sourcelens_compose ps \
+			|| warn "Could not display the current Insight service status table"
+		ok "Insight services are healthy"
+	fi
+
+	local_platform_gateway_agent_is_managed || return 0
+	service="$(systemctl is-active hyperfilelens-agent.service 2>/dev/null || true)"
+	[[ -n "${service}" ]] || service="unknown"
+	container_id="$(docker ps -aq --no-trunc \
+		--filter 'label=com.hyperfilelens.managed=true' \
+		--filter 'label=com.hyperfilelens.component=gateway-lensnode' \
+		--filter 'label=com.docker.compose.project=hyperfilelens-gateway' \
+		--filter 'label=com.docker.compose.service=lensnode' 2>/dev/null | head -1)" \
+		|| container_id=""
+	ai_engine="unknown"
+	if [[ -n "${container_id}" ]]; then
+		ai_engine="$(docker inspect --format '{{.State.Status}}' "${container_id}" 2>/dev/null || true)"
+		[[ -n "${ai_engine}" ]] || ai_engine="unknown"
+	fi
+	print_section "Platform Data Gateway"
+	print_value "Agent service" "${service}"
+	print_value "AI engine" "${ai_engine}"
+	if [[ "${LOCAL_PLATFORM_GATEWAY_VERIFIED}" -eq 1 ]]; then
+		print_value "Console" "online"
+		ok "Platform Data Gateway is ready"
+	else
+		print_value "Console" "not verified by this installation"
+		skip "Platform Data Gateway readiness was not verified"
+	fi
 }
 
 package_has_sourcelens() {
@@ -4360,7 +4546,11 @@ install_bundled_sourcelens() {
 	console_port="$(read_env_value SOURCELENS_CONSOLE_PORT)"
 	[[ -n "${console_port}" ]] || console_port="11445"
 	stop_bundled_sourcelens
-	step "Installing bundled SourceLens ..."
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		step "Preparing bundled Insight services"
+	else
+		step "Installing bundled SourceLens ..."
+	fi
 	SOURCELENS_INSTALL_DIR="${ROOT}/sourcelens" \
 		SOURCELENS_DATA_DIR="${ROOT}/data/sourcelens" \
 		SOURCELENS_CONFIG_DIR="${ROOT}/data/sourcelens/config" \
@@ -4579,7 +4769,7 @@ wait_for_local_platform_gateway_readiness() {
 	while true; do
 		if local_platform_gateway_readiness_once; then
 			LOCAL_PLATFORM_GATEWAY_VERIFIED=1
-			ok "Installer-managed platform Gateway is online and usable"
+			ok "Platform Data Gateway is online and usable"
 			return 0
 		fi
 		if ((SECONDS >= deadline)); then
@@ -4699,7 +4889,9 @@ converge_local_platform_gateway_lensnode() {
 		fi
 	fi
 	if [[ "${current_id}" == "${desired_id}" && "${layout_migration}" -eq 0 ]]; then
-		skip "Platform Data Gateway AI engine already uses the desired image"
+		if [[ "${HFL_ONLINE_CHILD:-0}" != "1" ]]; then
+			skip "Platform Data Gateway AI engine already uses the desired image"
+		fi
 	else
 		script="${ROOT}/data/media/gateway-bootstrap/gateway-install-lensnode-sidecar.sh"
 		[[ -f "${script}" && ! -L "${script}" ]] \
@@ -4729,6 +4921,9 @@ converge_local_platform_gateway_lensnode() {
 	running="$(docker inspect --format '{{.State.Running}}' "${container_id}" 2>/dev/null || true)"
 	[[ "${running}" == "true" ]] \
 		|| die "installer-managed Platform Data Gateway AI engine is not running"
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		ok "Platform Data Gateway AI engine is running with the desired image"
+	fi
 }
 
 ensure_local_platform_gateway() {
@@ -4838,6 +5033,55 @@ print("\t".join([*(str(payload[key]).strip() for key in required), node_ids]))
 	fi
 }
 
+persist_captured_command_output() {
+	local output=$1
+	[[ -n "${output}" && -n "${LOG_FILE:-}" && -f "${LOG_FILE}" \
+		&& ! -L "${LOG_FILE}" ]] || return 0
+	printf '%s\n' "${output}" | timestamp_log_stream "${LOG_FILE}"
+}
+
+render_deployment_command_output() {
+	local output=$1 line value
+	RENDERED_DEPLOYMENT_WARNINGS=0
+	persist_captured_command_output "${output}"
+	while IFS= read -r line || [[ -n "${line}" ]]; do
+		line="${line#"${line%%[![:space:]]*}"}"
+		[[ -n "${line}" ]] || continue
+		if [[ "${line}" =~ ^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[^]]+Z\][[:space:]]+\[[A-Z]+\].*\][[:space:]]+-[[:space:]]+(.*)$ ]]; then
+			line="${BASH_REMATCH[1]}"
+		fi
+		case "${line}" in
+		*Django\ Admin:\ auto-registered\ *|*QuotaProvider\ registered\ *|*AuthzProvider\ registered\ *)
+			# Framework/plugin startup records remain in the durable log. They are
+			# not results of the deployment operation itself.
+			continue
+			;;
+		Email\ sign-up:*)
+			value="${line#Email sign-up: }"
+			log "Email sign-up ${value}"
+			;;
+		Google\ OAuth:*)
+			value="${line#Google OAuth: }"
+			log "Google OAuth ${value}"
+			;;
+		Deployment-managed\ SMTP\ is\ unavailable\;*)
+			skip "SMTP synchronization skipped because SMTP is not configured"
+			;;
+		HFL_IDENTITY_STATUS=*|HFL_GOOGLE_OAUTH_STATUS=*|HFL_AI_MODEL_REPAIRED=*)
+			# Internal machine-readable result markers are represented by the
+			# surrounding structured status lines.
+			;;
+		*WARNING*|*Warning*|*warning*|*preserved*|*failed*|*Failed*)
+			RENDERED_DEPLOYMENT_WARNINGS=$((RENDERED_DEPLOYMENT_WARNINGS + 1))
+			warn "${line}"
+			;;
+		*)
+			printf '%s\n' "${line}"
+			;;
+		esac
+	done <<<"${output}"
+}
+
 sync_optional_identity_settings() {
 	step "Synchronizing optional identity and email settings"
 	local output command_status
@@ -4849,14 +5093,26 @@ sync_optional_identity_settings() {
 	command_status=$?
 	set -e
 	if [[ -n "${output}" ]]; then
-		printf '%s\n' "${output}"
+		if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+			render_deployment_command_output "${output}"
+		else
+			printf '%s\n' "${output}"
+		fi
 	fi
 	if [[ "${command_status}" -ne 0 ]]; then
 		warn "Optional identity or email settings could not be synchronized; core services remain available"
 		return 0
 	fi
 	if grep -F 'HFL_IDENTITY_STATUS=warning' <<<"${output}" >/dev/null; then
-		warn "Invalid optional identity or email settings were preserved"
+		if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+			if [[ "${RENDERED_DEPLOYMENT_WARNINGS:-0}" -eq 0 ]]; then
+				ok "Optional identity and email settings synchronized"
+			else
+				log "Optional identity and email synchronization completed with warnings"
+			fi
+		else
+			warn "Invalid optional identity or email settings were preserved"
+		fi
 	else
 		ok "Optional identity and email settings synchronized"
 	fi
@@ -4869,7 +5125,11 @@ sync_optional_identity_settings() {
 	command_status=$?
 	set -e
 	if [[ -n "${output}" ]]; then
-		printf '%s\n' "${output}"
+		if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+			render_deployment_command_output "${output}"
+		else
+			printf '%s\n' "${output}"
+		fi
 	fi
 	if [[ "${command_status}" -ne 0 ]]; then
 		warn "Google OAuth local route or generated callback is not ready; core services remain available"
@@ -4888,7 +5148,11 @@ repair_existing_multimodal_model() {
 	command_status=$?
 	set -e
 	if [[ -n "${output}" ]]; then
-		printf '%s\n' "${output}"
+		if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+			render_deployment_command_output "${output}"
+		else
+			printf '%s\n' "${output}"
+		fi
 	fi
 	if [[ "${command_status}" -ne 0 ]]; then
 		warn "Existing multimodal model capability could not be reconciled; core services remain available"
@@ -4976,14 +5240,24 @@ cmd_install() {
 	sync_runtime_media
 	ok "Configuration, TLS, runtime directories, and published media are ready"
 
-	print_section "[4/8] Loading container images"
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		print_section "[4/8] Verifying prepared container images"
+	else
+		print_section "[4/8] Loading container images"
+	fi
 	load_images_from_manifest "$([[ "${sourcelens_mode}" -eq 0 ]] && echo 1 || echo 0)"
-	ok "Required container images are available"
+	if [[ "${HFL_ONLINE_CHILD:-0}" != "1" ]]; then
+		ok "Required container images are available"
+	fi
 
 	print_section "[5/8] Installing insight services"
 	if should_install_sourcelens "${sourcelens_mode}"; then
 		install_bundled_sourcelens
-		ok "Insight services are installed"
+		if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+			ok "Insight services are ready"
+		else
+			ok "Insight services are installed"
+		fi
 	else
 		skip "Bundled insight service installation was not requested"
 	fi
@@ -4993,8 +5267,12 @@ cmd_install() {
 	fi
 
 	print_section "[6/8] Installing and starting HyperFileLens"
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		print_section "Runtime policy"
+	fi
 	log "Log rotation: built into nginx container (hourly; daily or 500M; keep 30)"
-	start_hfl_stack || die "HyperFileLens active color failed to start"
+	start_hfl_stack "$([[ "${HFL_ONLINE_CHILD:-0}" == "1" ]] && echo 1 || echo 0)" \
+		|| die "HyperFileLens active color failed to start"
 	wait_for_hfl_health || die "HyperFileLens failed its post-install health gate"
 	ok "HyperFileLens data, application, worker, scheduler, and web services are healthy"
 	if [[ "${sourcelens_mode}" -eq 0 ]]; then
@@ -5007,14 +5285,27 @@ cmd_install() {
 		fi
 	fi
 	print_section "[7/8] Preparing platform services"
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		print_section "Identity and email"
+	fi
 	sync_optional_identity_settings
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		print_section "Multimodal model"
+	fi
 	repair_existing_multimodal_model
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		print_section "Platform Data Gateway"
+	fi
 	ensure_local_platform_gateway
 	prune_agent_release_media
 	ok "Platform configuration and managed services are ready"
 
 	print_section "[8/8] Verifying installation"
-	compose_all_profiles ps
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		print_online_installation_verification "${sourcelens_mode}"
+	else
+		compose_all_profiles ps
+	fi
 	print_result "Installation completed successfully"
 	print_console_access_summary
 }

--- a/deploy/installer/sourcelens/install.sh
+++ b/deploy/installer/sourcelens/install.sh
@@ -187,7 +187,11 @@ materialize_install_dir() {
 	source_abs="$(cd "${source}" && pwd)"
 	target_abs="$(readlink -m "${target}")"
 	if [[ "${source_abs}" == "${target_abs}" ]]; then
-		log "already installed at ${target}"
+		if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+			log "Using bundled SourceLens files from ${target}"
+		else
+			log "already installed at ${target}"
+		fi
 		return 0
 	fi
 	log "Copying SourceLens bundle ${source} -> ${target}"

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -1105,6 +1105,8 @@ PY
 	TAG="${values[0]}"
 	RELEASE_VERSION="${values[1]}"
 	RELEASE_COMMIT="${values[2]}"
+	printf '[ OK ] Community release resolved · %s · commit %s\n' \
+		"${TAG}" "${RELEASE_COMMIT:0:12}"
 }
 
 confirm_installation() {
@@ -1122,6 +1124,7 @@ download_source_archive() {
 	global) url="https://codeload.github.com/oneprolabs/hyperfilelens/tar.gz/${RELEASE_COMMIT}" ;;
 	cn) url="https://gitee.com/oneprolabs/hyperfilelens/repository/archive/${RELEASE_COMMIT}.tar.gz" ;;
 	esac
+	printf '\nRelease contract\n'
 	printf '[....] Downloading %s installation contract from %s (commit %s)\n' \
 		"${TAG}" "${SOURCE_NAME}" "${RELEASE_COMMIT:0:12}"
 	if ! download_file "${url}" "${SESSION_DIR}/source.tar.gz" 300; then
@@ -1218,8 +1221,6 @@ if [[ "${DOCKER_RUNTIME_ACTION}" == reuse ]]; then
 fi
 ensure_online_docker_runtime
 
-printf '\n[....] Preparing release images and installation assets\n'
-
 export HFL_GLOBAL_REGISTRY_PREFIX="${GLOBAL_REGISTRY_PREFIX}"
 export HFL_CN_REGISTRY_PREFIX="${CN_REGISTRY_PREFIX}"
 export HFL_REGISTRY_REGION="${REGION}"
@@ -1235,7 +1236,7 @@ fi
 if ! verify_candidate_release; then
 	fail_with_tag_guidance "Community tag ${TAG} failed release identity validation"
 fi
-printf '[ OK ] Release images and installation assets are ready\n'
+printf '[ OK ] Release package and installation assets are ready\n'
 
 if [[ "${INSTALL_ACTION}" == Upgrade ]]; then
 	printf '[....] Upgrading the existing installation to %s\n' "${TAG}"

--- a/deploy/online/prepare.py
+++ b/deploy/online/prepare.py
@@ -399,7 +399,11 @@ def resolve_image(
             continue
         digest = image_digest(source_ref)
         run(["docker", "tag", source_ref, spec.local_ref])
-        print(f"[ OK ] {image_kind.title()} ready: {spec.local_ref}@{digest}", flush=True)
+        print(
+            f"[ OK ] {image_kind.capitalize()} {position}/{total} ready · "
+            f"{spec.local_ref}@{digest}",
+            flush=True,
+        )
         return ResolvedImage(spec=spec, digest=digest)
     raise RuntimeError(
         f"neither public registry could provide {spec.local_ref}: "
@@ -722,11 +726,13 @@ def main() -> int:
         )
         for kind in ("agent", "gateway", "language")
     ]
+    print("\nRuntime images", flush=True)
     runtime = [
         resolve_image(spec, args.region, position, len(runtime_specs))
         for position, spec in enumerate(runtime_specs, start=1)
     ]
-    print(f"[ OK ] Runtime images are ready: {len(runtime)} images", flush=True)
+    print(f"[ OK ] All {len(runtime)} runtime images are ready", flush=True)
+    print("\nRelease assets", flush=True)
     assets = [
         resolve_image(spec, args.region, position, len(asset_specs))
         for position, spec in enumerate(asset_specs, start=1)
@@ -740,6 +746,7 @@ def main() -> int:
         "gateway": "Data Gateway packages",
         "language": "Language packs",
     }
+    print("\nRelease package", flush=True)
     for asset in assets:
         label = asset_labels[asset.spec.asset_kind]
         print(f"[....] Preparing {label}", flush=True)
@@ -750,7 +757,7 @@ def main() -> int:
         print(f"[ OK ] {label} are ready", flush=True)
     sourcelens = write_sourcelens_build_info(source, target, runtime)
     write_manifest(target, version, revision, runtime, assets, sourcelens)
-    print(f"[ OK ] Prepared Community package: {target}")
+    print(f"[ OK ] Community release package prepared · {target}")
     return 0
 
 

--- a/src/agent/internal/enroll/download_progress.go
+++ b/src/agent/internal/enroll/download_progress.go
@@ -277,7 +277,10 @@ func roleDisplayName(role model.Role, gatewayScope ...string) string {
 	case model.RoleGateway:
 		scope := ""
 		if len(gatewayScope) > 0 {
-			scope = gatewayScope[0]
+			scope = strings.ToLower(strings.TrimSpace(gatewayScope[0]))
+		}
+		if scope == "platform" {
+			return "Platform Data Gateway"
 		}
 		if isPublicGatewayScope(scope) {
 			return "Public Data Gateway"

--- a/src/agent/internal/enroll/download_progress_test.go
+++ b/src/agent/internal/enroll/download_progress_test.go
@@ -52,7 +52,7 @@ func TestRoleDownloadLabels(t *testing.T) {
 			t.Fatalf("role %q label=%q, want %q", role, got, expected)
 		}
 	}
-	if got := agentPackageLabel(model.RoleGateway, "platform"); got != "Public Data Gateway Agent package" {
+	if got := agentPackageLabel(model.RoleGateway, "platform"); got != "Platform Data Gateway Agent package" {
 		t.Fatalf("platform gateway label=%q", got)
 	}
 	if got := agentPackageLabel(model.RoleGateway, "public"); got != "Public Data Gateway Agent package" {
@@ -71,10 +71,10 @@ func TestIsPublicGatewayScope(t *testing.T) {
 			t.Fatalf("expected private scope %q", scope)
 		}
 	}
-	if got := roleDisplayName(model.RoleGateway, "platform"); got != "Public Data Gateway" {
+	if got := roleDisplayName(model.RoleGateway, "platform"); got != "Platform Data Gateway" {
 		t.Fatalf("platform display=%q", got)
 	}
-	if got := gatewayDisplayName("platform"); got != "Public Data Gateway" {
+	if got := gatewayDisplayName("platform"); got != "Platform Data Gateway" {
 		t.Fatalf("gatewayDisplayName(platform)=%q", got)
 	}
 	if got := gatewayDisplayName("user"); got != "Private Data Gateway" {

--- a/src/agent/internal/enroll/gateway_install.go
+++ b/src/agent/internal/enroll/gateway_install.go
@@ -351,6 +351,9 @@ func printGatewayInstallSuccess(info SummaryInfo, lens LensSidecarConfig) {
 }
 
 func gatewayDisplayName(scope string) string {
+	if strings.EqualFold(strings.TrimSpace(scope), "platform") {
+		return "Platform Data Gateway"
+	}
 	if isPublicGatewayScope(scope) {
 		return "Public Data Gateway"
 	}

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -948,7 +948,8 @@ hfl_role_display_name() {
 	proxy) printf '%s' "Proxy Host" ;;
 	gateway)
 		case "${scope}" in
-		public | platform) printf '%s' "Public Data Gateway" ;;
+		platform) printf '%s' "Platform Data Gateway" ;;
+		public) printf '%s' "Public Data Gateway" ;;
 		*) printf '%s' "Private Data Gateway" ;;
 		esac
 		;;

--- a/tools/quality/test-agent-installer-output.sh
+++ b/tools/quality/test-agent-installer-output.sh
@@ -27,6 +27,18 @@ grep -F 'HyperFileLens Source Host Installer' "${tmp}/success.out" >/dev/null
 grep -F 'Installation completed successfully' "${tmp}/success.out" >/dev/null
 grep -F 'HyperFileLens Source Host Installer' "${success_log}" >/dev/null
 grep -F 'Installation completed successfully' "${success_log}" >/dev/null
+
+role_labels="$({
+	# shellcheck disable=SC1090
+	source <(sed '/^bundle_agent()/,$d' "${installer}")
+	printf '%s\n' \
+		"$(hfl_role_display_name gateway platform)" \
+		"$(hfl_role_display_name gateway public)" \
+		"$(hfl_role_display_name gateway private)"
+})"
+grep -Fx 'Platform Data Gateway' <<<"${role_labels}" >/dev/null
+grep -Fx 'Public Data Gateway' <<<"${role_labels}" >/dev/null
+grep -Fx 'Private Data Gateway' <<<"${role_labels}" >/dev/null
 if awk 'NF && $0 !~ /^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z\] / { exit 1 }' \
 	"${success_log}"; then
 	:

--- a/tools/quality/test-lifecycle-output-contract.sh
+++ b/tools/quality/test-lifecycle-output-contract.sh
@@ -41,6 +41,7 @@ read_edition_from_dir() { printf 'Enterprise'; }
 resolve_console_host() { printf '192.0.2.10'; }
 package_has_sourcelens() { return 0; }
 sourcelens_installed() { return 0; }
+local_platform_gateway_agent_is_managed() { return 1; }
 
 output="$({
 	print_banner 'HyperFileLens Installer'
@@ -59,6 +60,65 @@ grep -F 'adminpassword' <<<"${output}" >/dev/null
 grep -F 'install.sh upgrade --from /path/to/new-release.tar.gz' <<<"${output}" >/dev/null
 grep -F 'install.sh uninstall' <<<"${output}" >/dev/null
 
+# The online installer groups each login with its endpoint while preserving
+# the same credential visibility policy as the standalone installer.
+SESSION_WARNINGS=()
+HFL_ONLINE_CHILD=1
+online_output="$(print_console_access_summary 2>&1)"
+unset HFL_ONLINE_CHILD
+for heading in \
+	'Website · 11442' \
+	'Tenant · 11443' \
+	'Platform Ops · 11444' \
+	'Django Admin · 11444' \
+	'Insight Console · 11445' \
+	'API / Swagger · 11443'; do
+	grep -F "${heading}" <<<"${online_output}" >/dev/null
+done
+grep -F 'linux/amd64' <<<"${online_output}" >/dev/null
+grep -F 'Email          admin@hyperfilelens.com' <<<"${online_output}" >/dev/null
+grep -F 'Password       Admin@123' <<<"${online_output}" >/dev/null
+grep -F 'Username       admin' <<<"${online_output}" >/dev/null
+grep -F 'sudo docker compose -f' <<<"${online_output}" >/dev/null
+if grep -F 'Login credentials' <<<"${online_output}" >/dev/null; then
+	echo 'Online summary split credentials away from their access endpoints' >&2
+	exit 1
+fi
+
+INTERACTIVE_SESSION=0
+SESSION_WARNINGS=()
+HFL_ONLINE_CHILD=1
+noninteractive_online_output="$(print_console_access_summary 2>&1)"
+unset HFL_ONLINE_CHILD
+INTERACTIVE_SESSION=1
+grep -F 'values are hidden in non-interactive logs' \
+	<<<"${noninteractive_online_output}" >/dev/null
+if grep -F 'Admin@123' <<<"${noninteractive_online_output}" >/dev/null \
+	|| grep -F 'adminpassword' <<<"${noninteractive_online_output}" >/dev/null; then
+	echo 'Online non-interactive summary exposed generated credentials' >&2
+	exit 1
+fi
+
+# Online child output keeps framework startup noise in the durable log while
+# presenting only the meaningful deployment result in the terminal.
+identity_raw=$'[2026-08-23T04:53:45.921Z] [INFO] [test:1] [-] [-/-] [server-python(apps.py:23)] - Django Admin: auto-registered 51 project model(s)\nEmail sign-up: disabled\nGoogle OAuth: disabled\nDeployment-managed SMTP is unavailable; preserved the installed email settings.\nHFL_IDENTITY_STATUS=warning'
+touch "${LOG_FILE}"
+identity_output="$({
+	HFL_ONLINE_CHILD=1
+	render_deployment_command_output "${identity_raw}"
+} 2>&1)"
+grep -F '[INFO ] Email sign-up disabled.' <<<"${identity_output}" >/dev/null
+grep -F '[INFO ] Google OAuth disabled.' <<<"${identity_output}" >/dev/null
+grep -F '[SKIP] SMTP synchronization skipped because SMTP is not configured.' \
+	<<<"${identity_output}" >/dev/null
+if grep -F 'auto-registered' <<<"${identity_output}" >/dev/null \
+	|| grep -F 'HFL_IDENTITY_STATUS=' <<<"${identity_output}" >/dev/null; then
+	echo 'Online identity output leaked framework or machine-readable noise' >&2
+	exit 1
+fi
+grep -F 'Django Admin: auto-registered 51 project model(s)' "${LOG_FILE}" >/dev/null
+grep -F 'HFL_IDENTITY_STATUS=warning' "${LOG_FILE}" >/dev/null
+
 # A bundled package is not the same as a running Insight installation. The
 # --hfl-only summary must not advertise an unavailable console or credentials.
 sourcelens_installed() { return 1; }
@@ -68,6 +128,20 @@ if grep -F 'Insight Console' <<<"${hfl_only_output}" >/dev/null; then
 	exit 1
 fi
 sourcelens_installed() { return 0; }
+
+# The online status table is diagnostic output, not a new installation gate.
+# A transient Compose inspection failure must remain visible without turning a
+# successfully health-checked installation into a failure.
+compose_all_profiles() { printf 'HyperFileLens fixture status\n'; }
+sourcelens_compose() {
+	printf 'Insight fixture status unavailable\n' >&2
+	return 1
+}
+SESSION_WARNINGS=()
+verification_output="$(print_online_installation_verification 1 2>&1)"
+grep -F 'Could not display the current Insight service status table' \
+	<<<"${verification_output}" >/dev/null
+grep -F 'Insight services are healthy' <<<"${verification_output}" >/dev/null
 
 grep -F 'hfl_print_banner "${title}"' "${ROOT_REPO}/dev/stack.sh" >/dev/null
 grep -F 'HFL_PARENT_SESSION=1 "${ROOT}/dev/sourcelens.sh"' \

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -62,7 +62,7 @@ if grep -Eq 'def parse\([^)]*\)[[:space:]]*->[[:space:]]*(tuple|list|dict)\[' \
 	printf 'ERROR: online installer uses a Python annotation unsupported by Ubuntu 20.04\n' >&2
 	exit 1
 fi
-grep -Fq -- '--yes                   Non-interactive compatibility flag' \
+grep -Fq -- '--yes                       Non-interactive compatibility option' \
 	"${ROOT}/deploy/installer/install.sh"
 
 grep -Fq 'name: HFL - Publish Images & Upgrade SaaS' "${workflow}"
@@ -75,7 +75,7 @@ grep -Fq 'hyperfilelens-gateway-assets:${{ needs.prepare.outputs.version }}' "${
 grep -Fq 'hyperfilelens-language-assets:${{ needs.prepare.outputs.version }}' "${workflow}"
 
 installer="${ROOT}/deploy/installer/install.sh"
-[[ "$(grep -Fc 'if [[ "${HFL_ONLINE_CHILD:-0}" != "1" ]]; then' "${installer}")" -eq 2 ]]
+[[ "$(grep -Fc 'if [[ "${HFL_ONLINE_CHILD:-0}" != "1" ]]; then' "${installer}")" -ge 2 ]]
 for summary_contract in \
 	'print_section "Platform Data Gateway"' \
 	'print_section "Published resources"' \
@@ -87,6 +87,21 @@ for summary_contract in \
 	'print_value "Install log"'; do
 	grep -Fq "${summary_contract}" "${installer}"
 done
+for online_output_contract in \
+	'[4/8] Verifying prepared container images' \
+	'Verifying prepared runtime image' \
+	'Core data services' \
+	'Database initialization' \
+	'Application services' \
+	'Health checks' \
+	'Identity and email' \
+	'Multimodal model' \
+	'print_online_installation_verification'; do
+	grep -Fq "${online_output_contract}" "${installer}"
+done
+grep -Fq 'Preparing bundled Insight services' "${installer}"
+grep -Fq 'Using bundled SourceLens files from' \
+	"${ROOT}/deploy/installer/sourcelens/install.sh"
 if grep -Eq 'publish-community-channel|community-channel|git push origin HEAD:main' "${workflow}"; then
 	printf 'ERROR: SaaS workflow must not manage a separate Community channel branch\n' >&2
 	exit 1
@@ -1247,6 +1262,8 @@ latest_session_log="$(find "${test_install_root}/logs" -maxdepth 1 -type f \
 [[ -n "${latest_session_log}" ]]
 grep -Fq 'HyperFileLens Community Online Installer' "${latest_session_log}"
 grep -Fq 'Resolving Community tags from GitHub' "${latest_session_log}"
+grep -Fq 'Community release resolved · v1.2.12 · commit cccccccccccc' "${latest_session_log}"
+grep -Fq 'Release contract' "${latest_session_log}"
 grep -Fq "Log file       ${latest_session_log}" "${latest_log}"
 grep -Fq 'recent fallback tags: v1.2.11, v1.2.10, v1.2.9, v1.2.8, v1.2.7, v1.2.6, v1.2.5, v1.2.4, v1.2.3, v1.2.2' \
 	"${latest_log}"
@@ -1355,6 +1372,13 @@ PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 		--region global \
 		--output "${candidate}" >"${prepare_log}" 2>&1
 grep -F 'Docker native pull progress:' "${prepare_log}" >/dev/null
+for heading in 'Runtime images' 'Release assets' 'Release package'; do
+	grep -Fx "${heading}" "${prepare_log}" >/dev/null
+done
+grep -F '[ OK ] Runtime image 1/8 ready ·' "${prepare_log}" >/dev/null
+grep -F '[ OK ] Release asset image 3/3 ready ·' "${prepare_log}" >/dev/null
+grep -F '[ OK ] All 8 runtime images are ready' "${prepare_log}" >/dev/null
+grep -F '[ OK ] Community release package prepared ·' "${prepare_log}" >/dev/null
 if grep -F 'Untagged:' "${prepare_log}" >/dev/null; then
 	printf 'ERROR: temporary asset image cleanup leaked into online output\n' >&2
 	exit 1

--- a/tools/quality/test-platform-gateway-auto-deploy.sh
+++ b/tools/quality/test-platform-gateway-auto-deploy.sh
@@ -13,6 +13,8 @@ source <(sed -n '/^read_env_value()/,/^resolve_console_host()/p' "${installer}" 
 # shellcheck disable=SC1090
 source <(sed -n '/^platform_gateway_auto_deploy_enabled()/,/^# --- Commands ---/p' "${installer}" | sed '$d')
 
+[[ "$(grep -Fc 'ok "Platform Data Gateway is online and usable"' "${installer}")" -eq 1 ]]
+
 ROOT="${tmp}/install"
 LOCAL_PLATFORM_AGENT_INSTALL_DIR="${tmp}/agent-install"
 LOCAL_PLATFORM_AGENT_DATA_DIR="${tmp}/agent-data"

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -304,6 +304,16 @@ HFL_TEST_FAIL_REGION=cn HFL_REGISTRY_REGION=cn \
 [[ "$(sed -n '2p' "${pull_marker}")" == docker.io/* ]]
 HFL_REGISTRY_REGION=cn load_images_from_manifest 0 "${package_root}"
 [[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
+online_registry_output="$(
+	HFL_ONLINE_CHILD=1 HFL_REGISTRY_REGION=cn \
+		load_images_from_manifest 0 "${package_root}"
+)"
+grep -F '[....] Verifying prepared runtime image (1/1):' \
+	<<<"${online_registry_output}" >/dev/null
+grep -F '[ OK ] Runtime image 1/1 verified ·' \
+	<<<"${online_registry_output}" >/dev/null
+grep -F '[ OK ] All 1 prepared runtime images are verified' \
+	<<<"${online_registry_output}" >/dev/null
 
 rm -f "${tag_marker}"
 : >"${pull_marker}"


### PR DESCRIPTION
## Summary

- organize the Community online installer into clear release, runtime, service, and verification sections
- preserve native Docker, Compose, migration, and Gateway output while reducing duplicated framework noise
- group access URLs with their credentials and report the installer-managed Platform Data Gateway consistently
- keep offline and standard lifecycle output behavior unchanged

## Validation

- online Community installer and SaaS registry delivery contract tests
- lifecycle, Agent installer, and Platform Gateway output tests
- release contract, image refresh, SourceLens, Gateway uninstall, and Gateway upgrade tests
- Agent Go test suite
- Bash syntax, Ruff, gofmt, and git diff checks