### PR TITLE
Fix detached Agent upgrade recovery

### DIFF
--- a/src/agent/internal/app/agent.go
+++ b/src/agent/internal/app/agent.go
@@ -26,6 +26,8 @@ const controlPlanePollInterval = 5 * time.Second
 const gatewayObservabilityRefreshInterval = 10 * time.Minute
 const heartbeatCollectionInterval = 30 * time.Second
 const durableRegistrationRetryInterval = 5 * time.Minute
+const lifecycleRepairInterval = 10 * time.Second
+const lifecycleRepairTimeout = 10 * time.Minute
 
 // Agent is the runtime composition root coordinating module startup and shutdown.
 type Agent struct {
@@ -39,10 +41,12 @@ type Agent struct {
 	taskFixer *controller.TaskFixer
 	monitor   *monitor.Collector
 
-	heartbeatMu      sync.RWMutex
-	storageInventory map[string]any
-	monitorMetrics   map[string]any
-	registrationOnce sync.Once
+	heartbeatMu           sync.RWMutex
+	storageInventory      map[string]any
+	monitorMetrics        map[string]any
+	registrationOnce      sync.Once
+	lifecycleRepairMu     sync.Mutex
+	lifecycleRepairActive bool
 
 	idleLogged bool
 }
@@ -96,7 +100,7 @@ func (a *Agent) Startup(ctx context.Context) error {
 	)
 	a.taskFixer = controller.NewTaskFixer(repo, a.tracker, dataRoot, logDir)
 
-	if _, err := a.taskFixer.RepairRunning(ctx); err != nil {
+	if _, err := a.repairRunning(ctx); err != nil {
 		return err
 	}
 
@@ -155,6 +159,7 @@ func (a *Agent) Run(ctx context.Context) error {
 			slog.Warn("node registration before websocket failed", "err", err)
 		}
 
+		rootCtx := ctx
 		err := a.connector.Run(ctx,
 			func(ctx context.Context, msg []byte) error {
 				return a.wire.Handle(ctx, msg, a.connector)
@@ -162,7 +167,7 @@ func (a *Agent) Run(ctx context.Context) error {
 			func(ctx context.Context) error {
 				a.wire.SetTaskResultAckEnabled(a.connector.TaskResultAckEnabled())
 				if a.taskFixer != nil {
-					if _, err := a.taskFixer.RepairRunning(ctx); err != nil {
+					if _, err := a.repairRunning(ctx); err != nil {
 						slog.Warn("connect lifecycle repair failed", "err", err)
 					}
 				}
@@ -183,7 +188,7 @@ func (a *Agent) Run(ctx context.Context) error {
 				); err != nil {
 					return err
 				}
-				go a.deferredLifecycleRepair(context.WithoutCancel(ctx))
+				a.startDeferredLifecycleRepair(rootCtx)
 				if a.store.Current().Role == model.RoleGateway {
 					go a.gatewayObservabilityLoop(ctx)
 				}
@@ -435,30 +440,60 @@ func (a *Agent) waitControlPlaneConfig(ctx context.Context) {
 }
 
 // deferredLifecycleRepair re-checks detached upgrade/uninstall tasks after reconnect.
-// Startup repair can run while install.ps1 is still executing; this flushes success once logs exist.
+// Startup repair can run while the installer is still executing; this persists
+// the terminal result for the existing task-result outbox once evidence exists.
 func (a *Agent) deferredLifecycleRepair(ctx context.Context) {
-	delays := []time.Duration{10 * time.Second, 25 * time.Second}
-	for _, delay := range delays {
+	defer func() {
+		a.lifecycleRepairMu.Lock()
+		a.lifecycleRepairActive = false
+		a.lifecycleRepairMu.Unlock()
+	}()
+	ticker := time.NewTicker(lifecycleRepairInterval)
+	defer ticker.Stop()
+	for {
+		if a.taskFixer == nil {
+			return
+		}
+		startedAt, err := a.taskFixer.PendingLifecycleStartedAt(ctx)
+		if err != nil {
+			slog.Warn("deferred lifecycle repair lookup failed", "err", err)
+		} else if startedAt == nil {
+			return
+		} else if time.Since(*startedAt) >= lifecycleRepairTimeout {
+			slog.Warn("deferred lifecycle repair timed out", "started_at", startedAt)
+			return
+		}
+
+		if _, err := a.repairRunning(ctx); err != nil {
+			slog.Warn("deferred lifecycle repair failed", "err", err)
+		}
+
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(delay):
-		}
-		if a.taskFixer == nil || a.wire == nil || a.connector == nil {
-			return
-		}
-		repaired, err := a.taskFixer.RepairRunning(ctx)
-		if err != nil {
-			slog.Warn("deferred lifecycle repair failed", "err", err)
-			continue
-		}
-		if len(repaired) == 0 {
-			continue
-		}
-		if err := a.wire.FlushUnreportedResults(ctx, a.connector); err != nil {
-			slog.Warn("flush deferred lifecycle repair failed", "err", err)
+		case <-ticker.C:
 		}
 	}
+}
+
+func (a *Agent) startDeferredLifecycleRepair(ctx context.Context) {
+	a.lifecycleRepairMu.Lock()
+	if a.lifecycleRepairActive {
+		a.lifecycleRepairMu.Unlock()
+		return
+	}
+	a.lifecycleRepairActive = true
+	a.lifecycleRepairMu.Unlock()
+	go a.deferredLifecycleRepair(ctx)
+}
+
+func (a *Agent) repairRunning(ctx context.Context) ([]model.Task, error) {
+	a.lifecycleRepairMu.Lock()
+	defer a.lifecycleRepairMu.Unlock()
+	if a.taskFixer == nil {
+		return nil, nil
+	}
+	return a.taskFixer.RepairRunning(ctx)
 }
 
 // Shutdown stops active tasks and releases resources.

--- a/src/agent/internal/controller/taskfixer.go
+++ b/src/agent/internal/controller/taskfixer.go
@@ -3,9 +3,11 @@ package controller
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"hyperfilelens/agent/internal/infra/database"
 	"hyperfilelens/agent/internal/model"
+	"hyperfilelens/agent/internal/platform/install"
 )
 
 // TaskFixer repairs stale "running" task rows after an Agent restart.
@@ -48,4 +50,35 @@ func (f *TaskFixer) RepairRunning(ctx context.Context) ([]model.Task, error) {
 		)
 	}
 	return repaired, nil
+}
+
+// PendingLifecycleStartedAt returns the oldest detached lifecycle task start
+// time. It is intentionally limited to lifecycle tasks so the periodic repair
+// loop never keeps ordinary work alive.
+func (f *TaskFixer) PendingLifecycleStartedAt(ctx context.Context) (*time.Time, error) {
+	if f.tasks == nil {
+		return nil, nil
+	}
+	tasks, err := f.tasks.List(ctx, database.ListFilter{Status: string(model.TaskStatusRunning)})
+	if err != nil {
+		return nil, err
+	}
+	var oldest *time.Time
+	for _, task := range tasks {
+		if !install.IsLifecycleRepairKind(task.Kind) {
+			continue
+		}
+		startedAt := task.StartedAt
+		if raw, ok := task.Result["detached_started_at"].(string); ok {
+			if parsed, parseErr := time.Parse(time.RFC3339Nano, raw); parseErr == nil {
+				started := parsed
+				startedAt = &started
+			}
+		}
+		if startedAt != nil && (oldest == nil || startedAt.Before(*oldest)) {
+			started := *startedAt
+			oldest = &started
+		}
+	}
+	return oldest, nil
 }

--- a/src/agent/internal/controller/taskfixer_test.go
+++ b/src/agent/internal/controller/taskfixer_test.go
@@ -1,0 +1,54 @@
+package controller
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"hyperfilelens/agent/internal/infra/database"
+)
+
+func TestPendingLifecycleStartedAtIgnoresOrdinaryTasks(t *testing.T) {
+	ctx := t.Context()
+	db, err := database.Open(ctx, filepath.Join(t.TempDir(), "agent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	repo := database.NewTaskRepo(db)
+	started := time.Now().UTC().Add(-2 * time.Minute)
+	for _, input := range []database.RecordInput{
+		{TaskID: "ordinary", Kind: "backup.run", StartedAt: &started},
+		{TaskID: "lifecycle", Kind: "agent.upgrade", StartedAt: &started},
+	} {
+		if err := repo.RecordCommand(ctx, input); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fixer := NewTaskFixer(repo, nil, "", "")
+	got, err := fixer.PendingLifecycleStartedAt(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Sub(started).Abs() > time.Second {
+		t.Fatalf("started_at = %v, want %v", got, started)
+	}
+}
+
+func TestPendingLifecycleStartedAtReturnsNilWhenEmpty(t *testing.T) {
+	ctx := t.Context()
+	db, err := database.Open(ctx, filepath.Join(t.TempDir(), "agent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	got, err := NewTaskFixer(database.NewTaskRepo(db), nil, "", "").PendingLifecycleStartedAt(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("started_at = %v, want nil", got)
+	}
+}

--- a/src/agent/internal/engine/lifecycle.go
+++ b/src/agent/internal/engine/lifecycle.go
@@ -103,10 +103,11 @@ func (e *Engine) runAgentUpgrade(ctx context.Context, rep ReporterSink, taskID s
 	slog.Info("detached upgrade scheduled", "install_dir", installDir, "archive", stagedArchive, "upgrade_log", upgradeLog)
 	// Keep task running: service stop + WS drop are expected while detached install.sh runs.
 	return "running", map[string]any{
-		"previous_version": selfupdate.Version,
-		"target_version":   targetVersion,
-		"mode":             "local_detached",
-		"upgrade_log":      upgradeLog,
+		"previous_version":    selfupdate.Version,
+		"target_version":      targetVersion,
+		"mode":                "local_detached",
+		"detached_started_at": time.Now().UTC().Format(time.RFC3339Nano),
+		"upgrade_log":         upgradeLog,
 	}, ""
 }
 
@@ -169,9 +170,10 @@ func (e *Engine) runAgentUninstall(ctx context.Context, rep ReporterSink, taskID
 	}
 	slog.Info("detached uninstall scheduled", "install_dir", installDir, "data_dir", dataDir, "uninstall_log", uninstallLog)
 	return "running", map[string]any{
-		"keep_data":     keepData,
-		"mode":          "local_detached",
-		"uninstall_log": uninstallLog,
+		"keep_data":           keepData,
+		"mode":                "local_detached",
+		"detached_started_at": time.Now().UTC().Format(time.RFC3339Nano),
+		"uninstall_log":       uninstallLog,
 	}, ""
 }
 

--- a/src/backend/apps/node/services/internal/node_lifecycle.py
+++ b/src/backend/apps/node/services/internal/node_lifecycle.py
@@ -193,6 +193,23 @@ def _node_installed_commit(node: Node) -> str:
     return str(meta.get("agent_commit") or "").strip().lower()
 
 
+def _stale_failed_upgrade_is_current(*, node: Node, task: NodeTask) -> bool:
+    """Return whether a failed projection is superseded by the installed build."""
+    if task.status not in {
+        NodeTask.Status.FAILED,
+        NodeTask.Status.TIMEOUT,
+    } or node.status != Node.Status.ACTIVE:
+        return False
+    target_version = _target_version_from_task(task)
+    target_commit = _target_commit_from_task(task)
+    if not target_version or not target_commit:
+        return False
+    return (
+        _node_installed_version(node) == target_version
+        and _node_installed_commit(node) == target_commit
+    )
+
+
 def _node_capabilities(node: Node) -> set[str]:
     meta = node.metadata if isinstance(node.metadata, dict) else {}
     inv = meta.get("inventory") if isinstance(meta.get("inventory"), dict) else meta
@@ -977,6 +994,18 @@ def _upgrade_lifecycle_payload(
     if task is None:
         return None
 
+    # A detached upgrade can finish on the Agent after its final result frame
+    # is lost.  If the node is now Active and reports the exact requested
+    # build, do not keep projecting the obsolete timeout/failure banner.  The
+    # original task and audit record remain unchanged for troubleshooting.
+    if _stale_failed_upgrade_is_current(node=node, task=task):
+        logger.info(
+            "suppressing stale upgrade failure projection node_id=%s task_id=%s",
+            node.id,
+            task.id,
+        )
+        return None
+
     target_version = _target_version_from_task(task)
     if not target_version and task.status in _ACTIVE_TASK_STATUSES:
         try:
@@ -1348,6 +1377,25 @@ def start_node_upgrade(
         from apps.node.services.internal.task import _update_node_lifecycle_status
 
         _update_node_lifecycle_status(node_id=node.id, status=Node.Status.ACTIVE)
+        write_audit_log(
+            organization=node.organization,
+            user=user,
+            action="node.lifecycle.upgrade.already_current",
+            target_type="node",
+            target_id=str(node.id),
+            resource_type="node",
+            resource_id=str(node.id),
+            resource_name=node.name,
+            result=AuditResult.SUCCESS,
+            metadata={
+                "kind": LIFECYCLE_KIND_UPGRADE,
+                "role": node.role,
+                "outcome": "no_op",
+                "target_version": target_version,
+                "target_commit": target_commit,
+                "current_version": current_version,
+            },
+        )
         return {
             "operation_id": None,
             "task_id": None,

--- a/src/backend/apps/node/tests/test_node_lifecycle.py
+++ b/src/backend/apps/node/tests/test_node_lifecycle.py
@@ -570,6 +570,45 @@ class NodeLifecycleTests(TestCase):
         )
         self.assertEqual(lifecycle["source_version"], "1.0.0")
 
+    def test_stale_failed_upgrade_is_hidden_when_exact_build_is_active(self):
+        self.node.status = Node.Status.ACTIVE
+        self.node.version = "1.2.0"
+        self.node.metadata = {"inventory": {"agent_commit": "a" * 40}}
+        self.node.save(update_fields=["status", "version", "metadata", "updated_at"])
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.FAILED,
+            payload={"target_version": "1.2.0", "target_commit": "A" * 40},
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        self.assertIsNone(
+            _upgrade_lifecycle_payload(org=self.org, node=self.node, task=task)
+        )
+
+    def test_failed_upgrade_remains_visible_when_build_does_not_match(self):
+        task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="agent.upgrade",
+            status=NodeTask.Status.FAILED,
+            payload={"target_version": "1.2.0", "target_commit": "b" * 40},
+            watchdog_deadline_at=timezone.now(),
+            correlation_type=node_conf.LIFECYCLE_CORRELATION_TYPE,
+            correlation_id=f"upgrade:{self.node.id}",
+        )
+
+        lifecycle = _upgrade_lifecycle_payload(
+            org=self.org,
+            node=self.node,
+            task=task,
+        )
+        self.assertEqual(lifecycle["state"], "failed")
+
     @patch(
         "apps.node.services.internal.node_lifecycle.agent_release_commit",
         return_value="a" * 40,

--- a/src/frontend/src/components/NodeBasicInfoPanel.vue
+++ b/src/frontend/src/components/NodeBasicInfoPanel.vue
@@ -141,13 +141,15 @@ function resolveNodeDisplayStatus(node: ApiNode): NodeDisplayStatus {
   }
   // Status is the lifecycle state. Connectivity is rendered separately from availability.
   const status = node.status === 'online' || node.status === 'offline' ? 'active' : node.status
+  const visibleStatus = status === 'verification_pending' ? 'upgrading' : status
   const display = {
-    labelKey: `nodeLifecycle.state.${status}`,
+    labelKey: `nodeLifecycle.state.${visibleStatus}`,
     tagType: status === 'active'
       ? 'success'
       : status === 'failed' || status === 'upgrade_failed' || status === 'deregistration_failed'
         ? 'danger'
         : 'info',
+    spinning: ['upgrading', 'restarting', 'verification_pending', 'verifying'].includes(status),
   }
   return props.useBackupSourceTerminology ? backupSourceLifecycleDisplay(display) : display
 }

--- a/src/frontend/src/composables/useNodeLifecycleOps.test.ts
+++ b/src/frontend/src/composables/useNodeLifecycleOps.test.ts
@@ -264,4 +264,31 @@ describe('useNodeLifecycleOps persisted queue', () => {
       wrapper.unmount()
     }
   })
+
+  it('presents verification pending as an in-progress upgrade', () => {
+    const { lifecycle, wrapper } = mountLifecycle()
+
+    try {
+      const display = lifecycle.resolveDisplayStatus({
+        id: 1,
+        organization: 1,
+        name: 'gateway-1',
+        role: 'agent',
+        status: 'active',
+        availability: 'online',
+        version: '1.0.0',
+        lifecycle: {
+          kind: 'upgrade',
+          state: 'verification_pending',
+          target_version: '1.0.1',
+        },
+      })
+
+      expect(display.labelKey).toBe('nodeLifecycle.state.upgrading')
+      expect(display.tagType).toBe('info')
+      expect(display.spinning).toBe(true)
+    } finally {
+      wrapper.unmount()
+    }
+  })
 })

--- a/src/frontend/src/composables/useNodeLifecycleOps.ts
+++ b/src/frontend/src/composables/useNodeLifecycleOps.ts
@@ -77,10 +77,17 @@ function savePersisted(snapshot: PersistedQueue | null) {
 }
 
 const LIFECYCLE_FAILED_CONFIRM_POLLS = 2
-const UPGRADE_ACTIVE_STATES = ['upgrading', 'restarting', 'verifying', 'queued'] as const
+const UPGRADE_ACTIVE_STATES = [
+  'upgrading',
+  'restarting',
+  'verification_pending',
+  'verifying',
+  'queued',
+] as const
 const LIFECYCLE_SPINNING_STATES = [
   'upgrading',
   'restarting',
+  'verification_pending',
   'verifying',
   'removing',
   'cleaning_up',
@@ -89,6 +96,10 @@ const LIFECYCLE_SPINNING_STATES = [
 
 function isUpgradeLifecycleState(state: string | undefined | null): boolean {
   return !!state && UPGRADE_ACTIVE_STATES.includes(state as (typeof UPGRADE_ACTIVE_STATES)[number])
+}
+
+function userVisibleLifecycleState(state: string): string {
+  return state === 'verification_pending' ? 'upgrading' : state
 }
 
 function versionReachedTarget(node: ApiNode, targetVersion: string | undefined): boolean {
@@ -779,18 +790,16 @@ export function useNodeLifecycleOps(options: {
           spinning: true,
         }
       }
+      const visibleState = userVisibleLifecycleState(lc.state)
       const key = lc.state === 'failed'
         ? lc.kind === 'upgrade'
           ? 'nodeLifecycle.state.upgrade_failed'
           : 'nodeLifecycle.state.deregistration_failed'
-        : `nodeLifecycle.state.${lc.state}`
+        : `nodeLifecycle.state.${visibleState}`
       const spinning = LIFECYCLE_SPINNING_STATES.includes(
         lc.state as (typeof LIFECYCLE_SPINNING_STATES)[number],
       )
-      const tagType =
-        lc.state === 'failed' || lc.state === 'verification_pending'
-          ? 'danger'
-          : 'info'
+      const tagType = lc.state === 'failed' ? 'danger' : 'info'
       return {
         labelKey: key,
         tagType,

--- a/src/frontend/src/pages/protection/ProductionSitesAvailability.test.ts
+++ b/src/frontend/src/pages/protection/ProductionSitesAvailability.test.ts
@@ -100,7 +100,8 @@ describe('Production Sites availability presentation', () => {
 
   it('keeps node lifecycle status and connectivity polling separate', () => {
     const basicPanel = source('components/NodeBasicInfoPanel.vue')
-    expect(basicPanel).toContain('`nodeLifecycle.state.${status}`')
+    expect(basicPanel).toContain('`nodeLifecycle.state.${visibleStatus}`')
+    expect(basicPanel).toContain("status === 'verification_pending' ? 'upgrading' : status")
     expect(basicPanel).toContain('props.node.availability')
 
     for (const relativePath of [

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -966,6 +966,7 @@ function flowSourceLifecycleStatusLabel(status: FlowSourceRow['status']) {
     probing: 'protection.sourceResources.capacitySyncing',
     removing: 'protection.backupsPage.sourcePendingDeleting',
     remove_failed: 'protection.backupsPage.sourcePendingDeleteFailed',
+    verification_pending: 'nodeLifecycle.state.upgrading',
   }[status] || `nodeLifecycle.state.${status}`
   return t(labelKey)
 }


### PR DESCRIPTION
## Summary

- replace fixed detached lifecycle checks with a bounded, single recovery loop
- preserve detached execution timestamps and prevent duplicate repair attempts
- suppress stale upgrade failure projections only when the exact target build is active
- present verification-in-progress states as a normal upgrade in the UI
- add lifecycle recovery and projection coverage

## Validation

- Go unit tests for Agent, controller, database, and lifecycle paths
- Go race detector for Agent/controller/database packages
- Go vet
- Python compileall and Ruff
- Vue TypeScript check
- git diff --check

Some full Django and frontend test commands remain environment-limited by unavailable PostgreSQL/frontend dependencies.