### PR TITLE
Disable offline Agent upgrades

### DIFF
--- a/language-packs/packs/es/frontend/messages.json
+++ b/language-packs/packs/es/frontend/messages.json
@@ -4026,6 +4026,7 @@
     "upgradeFailedNoIp": "Falló la actualización de {entity} {name}: {error}",
     "batchSkipped": "Se omitieron {n}; no se iniciaron.",
     "nothingEligible": "No hay nodos seleccionados son elegibles para esta operación.",
+    "nothingEligibleOffline": "La actualización remota requiere que los nodos seleccionados estén en línea. Restablece la conexión o selecciona un nodo y usa Mantenimiento para obtener un comando de actualización local.",
     "nothingEligibleProxyBound": "{n} proxy node(s) todavía tiene recursos consolidados y no se puede eliminar.",
     "nothingEligibleWorkload": "{n} node(s) están bloqueados por ejecutar tareas de copia de seguridad o restauración.",
     "nothingEligibleInProgress": "{n} node(s) ya tiene una operación de ciclo de vida en curso.",

--- a/language-packs/packs/es/frontend/source-lock.json
+++ b/language-packs/packs/es/frontend/source-lock.json
@@ -3841,6 +3841,7 @@
   "nodeLifecycle.upgradeFailedNoIp": "12d822eae53582eb75fe4675046734364556a6055348e9c657dc43a8f7195980",
   "nodeLifecycle.batchSkipped": "62bf6ffe80487e712e11cd5f41f04654c5b6687e4bf1f99ff80a8cdf7c6b0826",
   "nodeLifecycle.nothingEligible": "e19f58921c06e4f349e3fb46e89f7d16751396273229ce48e015545e6497e5d6",
+  "nodeLifecycle.nothingEligibleOffline": "fb9a952fd97b49ccbe94fe5d340611bce911a86734d98207f04e10d9d1d54bcc",
   "nodeLifecycle.nothingEligibleProxyBound": "3870f57189cf75afeddcdaae57f7eb61c5d94caddc6a0828e4348b4f710b3084",
   "nodeLifecycle.nothingEligibleWorkload": "201f69bf71a51286de830f655b354384fa95041e53162f5414baef0ad55988d9",
   "nodeLifecycle.nothingEligibleInProgress": "299632f87a747fa885c6fc607869b12ee4f87aca23161aebf2c6ced73ff1c788",

--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -3995,6 +3995,7 @@
     "upgradeFailedNoIp": "{entity} {name} 升级失败: {error}",
     "batchSkipped": "已跳过 {n} 台（未开始）。",
     "nothingEligible": "所选节点均不符合操作条件。",
+    "nothingEligibleOffline": "远程升级要求所选节点在线。请恢复连接，或选择一个节点并通过“维护”获取本地升级命令。",
     "nothingEligibleProxyBound": "有 {n} 个 Proxy 仍绑定资源，无法删除。",
     "nothingEligibleWorkload": "有 {n} 个节点正在执行备份/恢复任务，无法操作。",
     "nothingEligibleInProgress": "有 {n} 个节点已有进行中的生命周期操作。",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -3826,6 +3826,7 @@
   "nodeLifecycle.upgradeFailedNoIp": "12d822eae53582eb75fe4675046734364556a6055348e9c657dc43a8f7195980",
   "nodeLifecycle.batchSkipped": "62bf6ffe80487e712e11cd5f41f04654c5b6687e4bf1f99ff80a8cdf7c6b0826",
   "nodeLifecycle.nothingEligible": "e19f58921c06e4f349e3fb46e89f7d16751396273229ce48e015545e6497e5d6",
+  "nodeLifecycle.nothingEligibleOffline": "fb9a952fd97b49ccbe94fe5d340611bce911a86734d98207f04e10d9d1d54bcc",
   "nodeLifecycle.nothingEligibleProxyBound": "3870f57189cf75afeddcdaae57f7eb61c5d94caddc6a0828e4348b4f710b3084",
   "nodeLifecycle.nothingEligibleWorkload": "201f69bf71a51286de830f655b354384fa95041e53162f5414baef0ad55988d9",
   "nodeLifecycle.nothingEligibleInProgress": "299632f87a747fa885c6fc607869b12ee4f87aca23161aebf2c6ced73ff1c788",

--- a/src/frontend/src/composables/useNodeLifecycleOps.test.ts
+++ b/src/frontend/src/composables/useNodeLifecycleOps.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, nextTick } from 'vue'
 import { mount } from '@vue/test-utils'
+import { ElMessage } from 'element-plus'
 import { fetchLifecycleWatch, previewNodeOperationsBatch, startNodeOperationsBatch } from '../lib/nodeApi'
 import type { ApiNode } from '../types/node'
 import { useNodeLifecycleOps } from './useNodeLifecycleOps'
@@ -163,6 +164,110 @@ describe('useNodeLifecycleOps batch start', () => {
       expect(lifecycle.completed.value).toEqual([
         expect.objectContaining({ nodeId: startedNode.id }),
       ])
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('explains an offline-only upgrade preview after connectivity becomes stale', async () => {
+    const node = {
+      id: 33,
+      organization: 1,
+      name: 'stale-source',
+      role: 'agent',
+      status: 'active',
+      availability: 'online',
+      routable: true,
+    } as ApiNode
+    vi.mocked(previewNodeOperationsBatch).mockResolvedValue({
+      kind: 'upgrade',
+      requested: 1,
+      eligible: [],
+      skipped_offline: [{ node_id: node.id, name: node.name, reason: 'offline' }],
+      skipped_workload: [],
+      skipped_in_progress: [],
+      skipped_not_upgradeable: [],
+      skipped_proxy_bound: [],
+      missing_node_ids: [],
+      max_concurrent: 5,
+    })
+    const warning = vi.spyOn(ElMessage, 'warning').mockImplementation(() => undefined as never)
+    let lifecycle!: ReturnType<typeof useNodeLifecycleOps>
+    const wrapper = mount(defineComponent({
+      setup() {
+        lifecycle = useNodeLifecycleOps({
+          role: 'agent',
+          t: ((key: string) => key) as never,
+        })
+        return () => h('div')
+      },
+    }))
+
+    try {
+      await expect(lifecycle.runBatch('upgrade', [node])).resolves.toBe(false)
+      expect(warning).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'nodeLifecycle.nothingEligibleOffline',
+      }))
+    } finally {
+      warning.mockRestore()
+      wrapper.unmount()
+    }
+  })
+})
+
+describe('useNodeLifecycleOps remote upgrade eligibility', () => {
+  function mountLifecycle() {
+    let lifecycle!: ReturnType<typeof useNodeLifecycleOps>
+    const wrapper = mount(defineComponent({
+      setup() {
+        lifecycle = useNodeLifecycleOps({
+          role: 'agent',
+          t: ((key: string) => key) as never,
+        })
+        return () => h('div')
+      },
+    }))
+    return { lifecycle, wrapper }
+  }
+
+  function node(overrides: Partial<ApiNode> = {}): ApiNode {
+    return {
+      id: 41,
+      organization: 1,
+      name: 'source-host',
+      role: 'agent',
+      status: 'active',
+      availability: 'online',
+      routable: true,
+      version: '1.0.0',
+      ...overrides,
+    }
+  }
+
+  it('requires the node to be online and routable', () => {
+    const { lifecycle, wrapper } = mountLifecycle()
+    const versionEligible = vi.fn(() => true)
+
+    try {
+      expect(lifecycle.canUpgradeNode(node(), versionEligible)).toBe(true)
+      expect(lifecycle.canUpgradeNode(node({ availability: 'offline' }), versionEligible)).toBe(false)
+      expect(lifecycle.canUpgradeNode(node({ routable: false }), versionEligible)).toBe(false)
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('still rejects busy, workload-blocked, and version-ineligible nodes', () => {
+    const { lifecycle, wrapper } = mountLifecycle()
+
+    try {
+      expect(lifecycle.canUpgradeNode(node({
+        lifecycle: { kind: 'upgrade', state: 'upgrading' },
+      }), () => true)).toBe(false)
+      expect(lifecycle.canUpgradeNode(node({
+        workload: { blocked: true, reasons: [] },
+      }), () => true)).toBe(false)
+      expect(lifecycle.canUpgradeNode(node(), () => false)).toBe(false)
     } finally {
       wrapper.unmount()
     }

--- a/src/frontend/src/composables/useNodeLifecycleOps.ts
+++ b/src/frontend/src/composables/useNodeLifecycleOps.ts
@@ -498,6 +498,9 @@ export function useNodeLifecycleOps(options: {
     if (preview.skipped_in_progress.length) {
       return t('nodeLifecycle.nothingEligibleInProgress', { n: preview.skipped_in_progress.length })
     }
+    if (preview.skipped_offline.length) {
+      return t('nodeLifecycle.nothingEligibleOffline')
+    }
     return t('nodeLifecycle.nothingEligible')
   }
 
@@ -881,6 +884,7 @@ export function useNodeLifecycleOps(options: {
   }
 
   function canUpgradeNode(node: ApiNode, canUpgradeFn: (node: ApiNode) => boolean): boolean {
+    if (node.availability !== 'online' || node.routable === false) return false
     if (isNodeBusy(node)) return false
     if (node.workload?.blocked) return false
     return canUpgradeFn(node)

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -1763,6 +1763,8 @@ export const en = {
     upgradeFailedNoIp: '{entity} {name} upgrade failed: {error}',
     batchSkipped: '{n} skipped (not started).',
     nothingEligible: 'No selected nodes are eligible for this operation.',
+    nothingEligibleOffline:
+      'Remote upgrade requires selected nodes to be online. Restore their connection, or select one node and use Maintenance for a local upgrade command.',
     nothingEligibleProxyBound: '{n} proxy node(s) still have bound resources and cannot be removed.',
     nothingEligibleWorkload: '{n} node(s) are blocked by running backup or restore tasks.',
     nothingEligibleInProgress: '{n} node(s) already have a lifecycle operation in progress.',

--- a/src/frontend/src/pages/protection/BackupSources.vue
+++ b/src/frontend/src/pages/protection/BackupSources.vue
@@ -4,7 +4,7 @@ import { computed, nextTick, onMounted, onUnmounted, reactive, ref, toRef, watch
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ArrowLeft, Plus, RefreshCw, Search, ChevronDown, Pencil, Trash2, TriangleAlert, ArrowUpCircle, Link2, Wrench } from 'lucide-vue-next'
-import { ElMessage, type ElTable } from 'element-plus'
+import { ElMessage, ElTooltip, type ElTable } from 'element-plus'
 import ModulePage from '../../components/ModulePage.vue'
 import BackupSourceDeleteDialog from '../../components/BackupSourceDeleteDialog.vue'
 import NodeLifecycleStatusCell from '../../components/node-lifecycle/NodeLifecycleStatusCell.vue'
@@ -880,14 +880,23 @@ function openRowDetail(row: SourceResource) {
 
 
 async function onUpgradeSelectedHosts() {
-  const targets = selectedHostAgents.value.filter((node) =>
+  const selected = [...selectedHostAgents.value]
+  const targets = selected.filter((node) =>
     lifecycleOps.canUpgradeNode(node, agentCanUpgrade),
   )
   if (targets.length === 0) {
-    ElMessage.warning({ message: t('nodeLifecycle.nothingEligible'), grouping: true })
+    const allDisconnected = selected.length > 0 && selected.every(
+      (node) => node.availability !== 'online' || node.routable === false,
+    )
+    ElMessage.warning({
+      message: t(allDisconnected
+        ? 'nodeLifecycle.nothingEligibleOffline'
+        : 'nodeLifecycle.nothingEligible'),
+      grouping: true,
+    })
     return
   }
-  const started = await lifecycleOps.runBatch('upgrade', targets)
+  const started = await lifecycleOps.runBatch('upgrade', selected)
   if (started) {
     clearHostTableSelection()
   }
@@ -1473,6 +1482,13 @@ const hostUpgradeDisabled = computed(() => {
     lifecycleOps.canUpgradeNode(node, agentCanUpgrade),
   )
   return upgradable.length === 0
+})
+const hostUpgradeDisabledReason = computed(() => {
+  if (!hostUpgradeDisabled.value || selectedHostAgents.value.length === 0) return ''
+  const allDisconnected = selectedHostAgents.value.every(
+    (node) => node.availability !== 'online' || node.routable === false,
+  )
+  return allDisconnected ? t('nodeLifecycle.nothingEligibleOffline') : ''
 })
 const nasBatchDisabled = computed(() => selectedNas.value.length === 0)
 const nasDeleteDisabled = computed(
@@ -2074,13 +2090,28 @@ onUnmounted(() => {
                   :disabled="hostUpgradeDisabled"
                   @click="onUpgradeSelectedHosts"
                 >
-                  <span class="el-dropdown-menu__item-content">
-                    <ArrowUpCircle
-                      :size="14"
-                      class="shrink-0"
-                    />
-                    <span>{{ t('nodesPage.actionUpgrade') }}</span>
-                  </span>
+                  <ElTooltip
+                    :disabled="!hostUpgradeDisabledReason"
+                    :content="hostUpgradeDisabledReason"
+                    placement="right"
+                    :fallback-placements="['left', 'top', 'bottom']"
+                    popper-class="hfl-tooltip--medium"
+                    :show-after="300"
+                  >
+                    <span
+                      class="el-dropdown-menu__item-content source-host-upgrade-action__trigger"
+                      :tabindex="hostUpgradeDisabledReason ? 0 : undefined"
+                      :aria-label="hostUpgradeDisabledReason
+                        ? `${t('nodesPage.actionUpgrade')}. ${hostUpgradeDisabledReason}`
+                        : t('nodesPage.actionUpgrade')"
+                    >
+                      <ArrowUpCircle
+                        :size="14"
+                        class="shrink-0"
+                      />
+                      <span>{{ t('nodesPage.actionUpgrade') }}</span>
+                    </span>
+                  </ElTooltip>
                 </ElDropdownItem>
                 <ElDropdownItem
                   :disabled="hostRenameDisabled"

--- a/src/frontend/src/pages/protection/BackupSourcesOfflineUpgrade.test.ts
+++ b/src/frontend/src/pages/protection/BackupSourcesOfflineUpgrade.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function source(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), 'src', relativePath), 'utf8')
+}
+
+describe('Source Hosts offline upgrade action', () => {
+  const page = source('pages/protection/BackupSources.vue')
+
+  it('disables remote upgrade with a hover and focus explanation', () => {
+    expect(page).toContain("node.availability !== 'online' || node.routable === false")
+    expect(page).toContain(':disabled="hostUpgradeDisabled"')
+    expect(page).toContain('<ElTooltip')
+    expect(page).toContain(':content="hostUpgradeDisabledReason"')
+    expect(page).toContain(':disabled="!hostUpgradeDisabledReason"')
+    expect(page).toContain('popper-class="hfl-tooltip--medium"')
+    expect(page).toContain(`:fallback-placements="['left', 'top', 'bottom']"`)
+    expect(page).toContain(':tabindex="hostUpgradeDisabledReason ? 0 : undefined"')
+    expect(page).toContain(':aria-label="hostUpgradeDisabledReason')
+    expect(page).not.toContain('class="source-host-upgrade-action__reason"')
+    expect(page).toContain("t('nodeLifecycle.nothingEligibleOffline')")
+  })
+
+  it('uses the shared viewport-safe explanatory tooltip width', () => {
+    const popperStyles = source('styles/element-plus-popper.css')
+    expect(popperStyles).toMatch(/\.el-popper\.hfl-tooltip--medium\s*\{[\s\S]*?width:\s*min\(360px, calc\(100vw - 32px\)\)/)
+    expect(popperStyles).toMatch(/\.el-popper\.hfl-tooltip--medium\s*\{[\s\S]*?white-space:\s*normal/)
+    expect(popperStyles).toMatch(/\.el-popper\.hfl-tooltip--medium\s*\{[\s\S]*?overflow-wrap:\s*anywhere/)
+  })
+
+  it('sends the complete selection to preflight so mixed selections report skipped hosts', () => {
+    expect(page).toContain("lifecycleOps.runBatch('upgrade', selected)")
+    expect(page).not.toContain("lifecycleOps.runBatch('upgrade', targets)")
+  })
+})

--- a/src/frontend/src/styles/element-plus-popper.css
+++ b/src/frontend/src/styles/element-plus-popper.css
@@ -27,6 +27,17 @@
   overflow: visible;
 }
 
+/* Standard width for explanatory tooltips. Match the established 360px
+   information-popper measure while preserving a 16px viewport gutter. */
+.el-popper.hfl-tooltip--medium {
+  box-sizing: border-box;
+  width: min(360px, calc(100vw - 32px));
+  max-width: min(360px, calc(100vw - 32px));
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
 /* Keep Element Plus' bordered arrow geometry, but clip the rotated square to
    the half that belongs outside the popper. Negative insets preserve its tip. */
 .el-popper[data-popper-placement^='bottom'] > .el-popper__arrow {

--- a/src/frontend/src/styles/source-list-ui.css
+++ b/src/frontend/src/styles/source-list-ui.css
@@ -2,6 +2,11 @@
    Source / protection list UI
    ============================================ */
 
+.hfl-actions-dropdown .source-host-upgrade-action__trigger {
+  width: 100%;
+  outline: none;
+}
+
 .hfl-list-table .source-version-cell,
 .hfl-list-table .nodes-version-cell {
   display: inline-flex;


### PR DESCRIPTION
## Summary

- disable remote Agent upgrades when selected nodes are offline or unroutable
- preserve complete mixed selections so server preflight reports skipped offline nodes
- explain the disabled Source Hosts action with a viewport-safe tooltip
- synchronize English, Simplified Chinese, and Spanish copy

## Testing

- `npm test -- --run src/composables/useNodeLifecycleOps.test.ts src/pages/protection/BackupSourcesOfflineUpgrade.test.ts src/lib/nodeLifecycleUpgradeConfirm.test.ts`
- `npm run build`
- `npm run lint`
- `./language-packs/tooling/build-all.sh --version 0.1.0`
- `git diff --check`

Closes #1041