### PR TITLE
Tune control-plane resource limits and concurrency

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -43,8 +43,8 @@ x-api: &api
       condition: service_healthy
   command: api
   stop_grace_period: 90s
-  mem_limit: 512m
-  cpus: 0.50
+  mem_limit: 1g
+  cpus: 1.00
   healthcheck:
     test:
       [
@@ -80,8 +80,8 @@ x-web: &web
     - ./data/lang-packs/versions/${HFL_PRODUCT_VERSION:-latest}:/opt/hyperfilelens/lang-packs:ro
   networks:
     - default
-  mem_limit: 128m
-  cpus: 0.125
+  mem_limit: 512m
+  cpus: 0.50
   healthcheck:
     test:
       [
@@ -147,8 +147,8 @@ services:
         condition: service_healthy
     command: scheduler
     stop_grace_period: 60s
-    mem_limit: 256m
-    cpus: 0.25
+    mem_limit: 512m
+    cpus: 0.50
     healthcheck:
       test:
         [
@@ -300,8 +300,8 @@ services:
       options:
         max-size: "10m"
         max-file: "10"
-    mem_limit: 128m
-    cpus: 0.125
+    mem_limit: 512m
+    cpus: 0.50
 
 networks:
   bridge:

--- a/deploy/installer/sourcelens/docker-compose.template.yml
+++ b/deploy/installer/sourcelens/docker-compose.template.yml
@@ -11,7 +11,7 @@ services:
     env_file:
       - ./.env
     environment:
-      API_WORKERS: "1"
+      API_WORKERS: "2"
       UVICORN_WS_PING_INTERVAL: "45"
       UVICORN_WS_PING_TIMEOUT: "180"
       SENTRY_COMPONENT: sourcelens-backend
@@ -58,7 +58,7 @@ services:
     env_file:
       - ./.env
     environment:
-      CELERY_CONCURRENCY: "1"
+      CELERY_CONCURRENCY: "2"
       SENTRY_COMPONENT: sourcelens-backend
       SENTRY_RELEASE: ${SENTRY_RELEASE:-}
       SENTRY_SERVICE: worker
@@ -75,8 +75,8 @@ services:
       api:
         condition: service_healthy
     command: celery
-    mem_limit: 512m
-    cpus: 0.50
+    mem_limit: 2g
+    cpus: 1.00
 
   scheduler:
     image: __SOURCELENS_BACKEND_IMAGE__
@@ -98,8 +98,8 @@ services:
       api:
         condition: service_healthy
     command: celery-beat
-    mem_limit: 256m
-    cpus: 0.25
+    mem_limit: 512m
+    cpus: 0.50
 
   web:
     image: __SOURCELENS_FRONTEND_IMAGE__
@@ -111,8 +111,8 @@ services:
       sourcelens_network:
         aliases:
           - frontend
-    mem_limit: 128m
-    cpus: 0.125
+    mem_limit: 512m
+    cpus: 0.50
 
 # HFL_EMBED_LENSNODE_SERVICE_BEGIN
   local-lensnode:
@@ -174,8 +174,8 @@ services:
         condition: service_healthy
       web:
         condition: service_started
-    mem_limit: 128m
-    cpus: 0.125
+    mem_limit: 512m
+    cpus: 0.50
 
   postgres:
     image: hyperfilelens-postgres:17
@@ -228,8 +228,8 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
-    mem_limit: 256m
-    cpus: 0.25
+    mem_limit: 512m
+    cpus: 0.50
 
 networks:
   sourcelens_network:

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1632,11 +1632,14 @@ grep -E '^[[:space:]]*11444[[:space:]]+ops;' \
 grep -F 'proxy_set_header X-HFL-Site-Role $hfl_site;' \
 	"${ROOT}/deploy/nginx/snippets/hfl-backend-proxy-headers.inc" >/dev/null
 for resource in \
-	'mem_limit: 128m' 'mem_limit: 256m' 'mem_limit: 512m' \
-	'cpus: 0.125' 'cpus: 0.25' 'cpus: 0.50' 'cpus: 1.00'; do
+	'mem_limit: 512m' 'mem_limit: 1g' 'cpus: 0.50' 'cpus: 1.00'; do
 	grep -F "${resource}" "${ROOT}/deploy/docker-compose.yml" \
 		"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null
 done
+hfl_api_contract="$(sed -n '/^x-api: &api$/,/^x-web: &web$/p' \
+	"${ROOT}/deploy/docker-compose.yml")"
+grep -F '  mem_limit: 1g' <<<"${hfl_api_contract}" >/dev/null
+grep -F '  cpus: 1.00' <<<"${hfl_api_contract}" >/dev/null
 grep -F '    mem_limit: ${HFL_WORKER_MEMORY_LIMIT:-2g}' \
 	"${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F '    cpus: ${HFL_WORKER_CPU_LIMIT:-1.0}' \
@@ -1648,10 +1651,12 @@ grep -F 'HFL_WORKER_CPU_LIMIT=1.0' "${ROOT}/.env.example" >/dev/null
 	"${ROOT}/deploy/docker/backend-entrypoint.sh" || true)" -eq 2 ]] \
 	|| { printf 'ERROR: production and development Workers must default to two processes\n' >&2; exit 1; }
 sourcelens_compose_template="${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml"
-[[ "$(grep -Fc '    mem_limit: 2g' "${sourcelens_compose_template}" || true)" -eq 2 ]] \
-	|| { printf 'ERROR: bundled SourceLens API and LensNode must both use a 2 GiB limit\n' >&2; exit 1; }
-[[ "$(grep -Fc '    cpus: 1.00' "${sourcelens_compose_template}" || true)" -eq 2 ]] \
-	|| { printf 'ERROR: bundled SourceLens API and LensNode must both use a 1 CPU limit\n' >&2; exit 1; }
+grep -F '      API_WORKERS: "2"' "${sourcelens_compose_template}" >/dev/null
+grep -F '      CELERY_CONCURRENCY: "2"' "${sourcelens_compose_template}" >/dev/null
+[[ "$(grep -Fc '    mem_limit: 2g' "${sourcelens_compose_template}" || true)" -eq 3 ]] \
+	|| { printf 'ERROR: bundled SourceLens API, Worker, and LensNode must use a 2 GiB limit\n' >&2; exit 1; }
+[[ "$(grep -Fc '    cpus: 1.00' "${sourcelens_compose_template}" || true)" -eq 3 ]] \
+	|| { printf 'ERROR: bundled SourceLens API, Worker, and LensNode must use a 1 CPU limit\n' >&2; exit 1; }
 grep -F '      UVICORN_WS_PING_INTERVAL: "45"' \
 	"${sourcelens_compose_template}" >/dev/null
 grep -F '      UVICORN_WS_PING_TIMEOUT: "180"' \
@@ -1660,11 +1665,15 @@ grep -F '    mem_limit: 2g' \
 	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
 grep -F '    cpus: 1.00' \
 	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null
-if grep -E 'mem_limit: (64|320|384|448)m|cpus: (0\.05|0\.10|0\.15|0\.20|0\.30)' \
+if grep -E 'mem_limit: (64|128|256|320|384|448)m|cpus: (0\.05|0\.10|0\.125|0\.15|0\.20|0\.25|0\.30)' \
 	"${ROOT}/deploy/docker-compose.yml" \
-	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" \
+	"${ROOT}/deploy/installer/sourcelens/docker-compose.template.yml" >/dev/null; then
+	printf 'ERROR: control-plane services must use at least 0.5 CPU and 512 MiB memory\n' >&2
+	exit 1
+fi
+if grep -E 'mem_limit: (64|320|384|448)m|cpus: (0\.05|0\.10|0\.15|0\.20|0\.30)' \
 	"${ROOT}/deploy/bootstrap/gateway-install-lensnode-sidecar.sh" >/dev/null; then
-	printf 'ERROR: deployment resources must use the normalized human-readable limits\n' >&2
+	printf 'ERROR: gateway resources must use the normalized human-readable limits\n' >&2
 	exit 1
 fi
 grep -F 'MemoryHigh=512M' "${ROOT}/src/agent/packaging/install/install.sh" >/dev/null


### PR DESCRIPTION
## Summary

- raise HFL API, web, scheduler, and gateway resource limits while leaving the one-shot migration service unrestricted
- run the bundled SourceLens API and Celery worker with two processes and allocate 1 CPU and 2 GiB to each container
- normalize remaining bundled SourceLens control-plane services to at least 0.5 CPU and 512 MiB
- strengthen release contract checks for the new deployment defaults

## Validation

- Docker Compose rendering for HFL blue/green and migration profiles
- release contract checks
- online Community installer tests
- synthetic CI release assembly
- blue/green recovery tests
- SourceLens runtime contract tests
- git diff checks