### PR TITLE
Canonicalize English website routes and responsive login layout

### DIFF
--- a/.github/actions/deploy-saas/action.yml
+++ b/.github/actions/deploy-saas/action.yml
@@ -162,7 +162,7 @@ runs:
             -o ConnectTimeout=20 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
             -o TCPKeepAlive=yes -p "$DEPLOY_SSH_PORT" \
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
-            'curl -kfsS https://127.0.0.1:11442/en/ >/dev/null &&
+            'curl -kfsS https://127.0.0.1:11442/ >/dev/null &&
              curl -kfsS https://127.0.0.1:11443/health/ready >/dev/null &&
              curl -kfsS https://127.0.0.1:11444/ >/dev/null &&
              curl -kfsS https://127.0.0.1:11445/ >/dev/null'

--- a/.github/workflows/deploy_target.yml
+++ b/.github/workflows/deploy_target.yml
@@ -586,7 +586,7 @@ jobs:
             -o TCPKeepAlive=yes \
             -p "$DEPLOY_SSH_PORT" \
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
-            'curl -kfsS https://127.0.0.1:11442/en/ >/dev/null && curl -kfsS https://127.0.0.1:11443/health/ready >/dev/null && curl -kfsS https://127.0.0.1:11444/ >/dev/null && curl -kfsS https://127.0.0.1:11445/ >/dev/null'
+            'curl -kfsS https://127.0.0.1:11442/ >/dev/null && curl -kfsS https://127.0.0.1:11443/health/ready >/dev/null && curl -kfsS https://127.0.0.1:11444/ >/dev/null && curl -kfsS https://127.0.0.1:11445/ >/dev/null'
 
       - name: Ensure Platform Gateway
         if: ${{ inputs.platform_gateway_auto_deploy }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ English | [中文](README.zh-CN.md)
 
 Open-source backup and recovery with AI-powered Insights from protected snapshots.
 
-[Website](https://hyperfilelens.com/en/) · [Documentation](https://hyperfilelens.com/en/docs/) · [Try Free](https://app.hyperfilelens.com/) · [Releases](https://github.com/oneprolabs/hyperfilelens/releases)
+[Website](https://hyperfilelens.com/) · [Documentation](https://hyperfilelens.com/docs/) · [Try Free](https://app.hyperfilelens.com/) · [Releases](https://github.com/oneprolabs/hyperfilelens/releases)
 
 </div>
 
@@ -75,9 +75,9 @@ Insights answers questions using the snapshot data selected for the session and 
 
 The official HyperFileLens SaaS is provided and operated by OnePro Cloud. There is no control plane to install or maintain.
 
-- Visit the [HyperFileLens product website](https://hyperfilelens.com/en/) to learn more.
+- Visit the [HyperFileLens product website](https://hyperfilelens.com/) to learn more.
 - Open the [SaaS console](https://app.hyperfilelens.com/) to start using the product.
-- Follow the [first-use guide](https://hyperfilelens.com/en/docs/) to complete your first backup, restore, and Insights workflow.
+- Follow the [first-use guide](https://hyperfilelens.com/docs/) to complete your first backup, restore, and Insights workflow.
 
 When using SaaS, install an Agent on the host whose files you want to protect and prepare object storage that both the SaaS and the backup host can reach.
 
@@ -101,20 +101,20 @@ curl -fsSL https://raw.githubusercontent.com/oneprolabs/hyperfilelens/main/deplo
 
 When installation finishes, find the complete address marked `Tenant` in the installation result and open it in a browser to enter the HyperFileLens console.
 
-See [Install Community](https://hyperfilelens.com/en/docs/getting-started/install) for detailed system requirements, network conditions, and installation checks.
+See [Install Community](https://hyperfilelens.com/docs/getting-started/install) for detailed system requirements, network conditions, and installation checks.
 
 ## Complete Your First Workflow
 
 Follow the first-use guide with a set of test files to walk through the complete path from data access to backup, restore, and Insights:
 
-1. [Sign in to the console](https://hyperfilelens.com/en/docs/getting-started/sign-in).
-2. [Add a backup source](https://hyperfilelens.com/en/docs/getting-started/add-source) and install the Agent on the backup host.
-3. [Configure the backup source](https://hyperfilelens.com/en/docs/getting-started/configure-source) and select the files or folders to protect.
-4. [Add target storage](https://hyperfilelens.com/en/docs/getting-started/add-target).
-5. [Create and run the first backup](https://hyperfilelens.com/en/docs/getting-started/first-backup).
-6. [Check the job and snapshot](https://hyperfilelens.com/en/docs/getting-started/verify-backup).
-7. [Restore a test file](https://hyperfilelens.com/en/docs/getting-started/first-restore).
-8. [Create an Insights session](https://hyperfilelens.com/en/docs/getting-started/first-insight).
+1. [Sign in to the console](https://hyperfilelens.com/docs/getting-started/sign-in).
+2. [Add a backup source](https://hyperfilelens.com/docs/getting-started/add-source) and install the Agent on the backup host.
+3. [Configure the backup source](https://hyperfilelens.com/docs/getting-started/configure-source) and select the files or folders to protect.
+4. [Add target storage](https://hyperfilelens.com/docs/getting-started/add-target).
+5. [Create and run the first backup](https://hyperfilelens.com/docs/getting-started/first-backup).
+6. [Check the job and snapshot](https://hyperfilelens.com/docs/getting-started/verify-backup).
+7. [Restore a test file](https://hyperfilelens.com/docs/getting-started/first-restore).
+8. [Create an Insights session](https://hyperfilelens.com/docs/getting-started/first-insight).
 
 ## How the Product Works
 
@@ -149,16 +149,16 @@ By default, the official SaaS provides a Public Data Gateway, and Community depl
 - Docker Engine 24.0.0 or later
 - Docker Compose V2 2.20.0 or later
 
-See [Supported Configurations](https://hyperfilelens.com/en/docs/reference/support-matrix) and [Limitations and Security Recommendations](https://hyperfilelens.com/en/docs/reference/limitations-security) for product boundaries.
+See [Supported Configurations](https://hyperfilelens.com/docs/reference/support-matrix) and [Limitations and Security Recommendations](https://hyperfilelens.com/docs/reference/limitations-security) for product boundaries.
 
 ## Documentation
 
-- [Quick Start](https://hyperfilelens.com/en/docs/)
-- [Product Usage](https://hyperfilelens.com/en/docs/product/)
-- [Backup and Restore](https://hyperfilelens.com/en/docs/backup-restore/)
-- [Insights](https://hyperfilelens.com/en/docs/insights/)
-- [Deployment and Operations](https://hyperfilelens.com/en/docs/deployment/)
-- [Help Center](https://hyperfilelens.com/en/docs/help/)
+- [Quick Start](https://hyperfilelens.com/docs/)
+- [Product Usage](https://hyperfilelens.com/docs/product/)
+- [Backup and Restore](https://hyperfilelens.com/docs/backup-restore/)
+- [Insights](https://hyperfilelens.com/docs/insights/)
+- [Deployment and Operations](https://hyperfilelens.com/docs/deployment/)
+- [Help Center](https://hyperfilelens.com/docs/help/)
 
 ## Project Status
 

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -1322,7 +1322,7 @@ wait_for_public_endpoints() {
 	[[ -n "${tenant_port}" ]] || tenant_port=11443
 	deadline=$((SECONDS + timeout_seconds))
 	while ((SECONDS < deadline)); do
-		if curl -kfsS "https://127.0.0.1:${website_port}/en/" >/dev/null 2>&1 \
+		if curl -kfsS "https://127.0.0.1:${website_port}/" >/dev/null 2>&1 \
 			&& curl -kfsS "https://127.0.0.1:${tenant_port}/health/ready" >/dev/null 2>&1; then
 			return 0
 		fi
@@ -3777,7 +3777,7 @@ print_console_access_summary() {
 	fi
 	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
 		printf '  Website · %s\n' "${website_port}"
-		print_nested_value "URL" "https://${host}:${website_port}/en/"
+		print_nested_value "URL" "https://${host}:${website_port}/"
 		print_nested_value "Bind" "${website_bind}"
 
 		printf '\n  Tenant · %s\n' "${tenant_port}"
@@ -3840,7 +3840,7 @@ print_console_access_summary() {
 		print_nested_value "URL" "https://${host}:${tenant_port}/swagger"
 		print_nested_value "Authentication" "HyperFileLens account"
 	else
-		print_value "Website" "https://${host}:${website_port}/en/  (${website_bind})"
+		print_value "Website" "https://${host}:${website_port}/  (${website_bind})"
 		print_value "Tenant" "https://${host}:${tenant_port}/  (${tenant_bind})"
 		print_value "Platform Ops" "https://${host}:${admin_port}/  (${admin_bind})"
 		print_value "Django Admin" "https://${host}:${admin_port}/admin/"

--- a/deploy/nginx/development-web.conf
+++ b/deploy/nginx/development-web.conf
@@ -65,7 +65,6 @@ http {
             try_files /website-runtime-config.js =404;
             add_header Cache-Control "no-store";
         }
-        location = / { return 302 /en/; }
         location ^~ /assets/ {
             try_files $uri =404;
             expires 1y;

--- a/deploy/nginx/web.conf
+++ b/deploy/nginx/web.conf
@@ -52,6 +52,5 @@ server {
         try_files /website-runtime-config.js =404;
         add_header Cache-Control "no-store";
     }
-    location = / { return 302 /en/; }
     location / { try_files $uri $uri/ $uri.html =404; }
 }

--- a/dev/stack.sh
+++ b/dev/stack.sh
@@ -725,7 +725,7 @@ prepare_website_static() {
 	WEBSITE_ARTIFACT_REBUILT=0
 	fingerprint="$(cache_fingerprint website -- "npm=${OPT_NPM_REGISTRY}" \
 		"platform=linux/amd64" "base=${HFL_WEBSITE_BASE_IMAGE}")"
-	if [[ "${force}" -eq 1 ]] || [[ ! -f "${WEBSITE_OUTPUT}/public/en/index.html" ]] \
+	if [[ "${force}" -eq 1 ]] || [[ ! -f "${WEBSITE_OUTPUT}/public/index.html" ]] \
 		|| ! cache_matches website-static "${fingerprint}"; then
 		[[ "${DEV_OFFLINE}" -eq 0 ]] \
 			|| die "Website static artifact is missing or stale in offline mode"
@@ -1212,7 +1212,7 @@ Development stack is ready
 User access
 
   Website
-    URL              https://localhost:${website_port}/en/
+    URL              https://localhost:${website_port}/
     Purpose          Main HyperFileLens website
     Listen           ${website_bind}:${website_port}
 
@@ -1875,7 +1875,7 @@ cmd_status() {
 	else
 		log "SourceLens runtime has not been prepared"
 	fi
-	if [[ -f "${WEBSITE_OUTPUT}/public/en/index.html" ]]; then
+	if [[ -f "${WEBSITE_OUTPUT}/public/index.html" ]]; then
 		printf 'ok      Website static artifact %s\n' "${WEBSITE_OUTPUT}"
 	else
 		printf 'pending Website static artifact (created by up)\n'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,7 +263,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "nginx -t >/dev/null 2>&1 && wget --no-check-certificate -qO- https://127.0.0.1:11443/health >/dev/null && sh /etc/nginx/snippets/check-language-packs.sh && wget --no-check-certificate -qO- https://127.0.0.1:11443/ >/dev/null && wget --no-check-certificate -qO- https://127.0.0.1:11442/en/ >/dev/null",
+          "nginx -t >/dev/null 2>&1 && wget --no-check-certificate -qO- https://127.0.0.1:11443/health >/dev/null && sh /etc/nginx/snippets/check-language-packs.sh && wget --no-check-certificate -qO- https://127.0.0.1:11443/ >/dev/null && wget --no-check-certificate -qO- https://127.0.0.1:11442/ >/dev/null",
         ]
       interval: 5s
       timeout: 3s

--- a/src/frontend/src/pages/auth/Login.vue
+++ b/src/frontend/src/pages/auth/Login.vue
@@ -1168,20 +1168,21 @@ onMounted(async () => {
   box-sizing: border-box;
   width: 100%;
   min-height: var(--app-viewport-height);
-  padding: 64px 48px;
+  padding: 64px max(48px, calc((100vw - 1440px) / 2));
   background-color: #08090c;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(420px, 2fr);
   align-items: center;
-  justify-content: center;
   overflow-x: hidden;
   overflow-y: auto;
   position: relative;
 }
 
 .left-logo {
-  width: min(540px, 44vw);
-  min-width: 480px;
-  margin-right: clamp(64px, 7vw, 96px);
+  width: min(540px, 100%);
+  min-width: 0;
+  margin: 0;
+  justify-self: center;
   z-index: 10;
   display: flex;
   align-items: center;
@@ -1191,6 +1192,7 @@ onMounted(async () => {
   box-sizing: border-box;
   min-width: 420px;
   width: 420px;
+  justify-self: center;
   padding: 30px;
   background: linear-gradient(180deg, rgba(30, 26, 40, 0.92), rgba(20, 17, 28, 0.94));
   border-radius: 18px;
@@ -1715,6 +1717,7 @@ onMounted(async () => {
   .login-container {
     min-height: var(--app-viewport-height);
     height: auto;
+    display: flex;
     flex-direction: column;
     justify-content: flex-start;
     gap: 18px;

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1362,7 +1362,7 @@ platform_gateway_verify_line="$(grep -nF 'platform-gateway verify --required --t
 }
 grep -F 'https://127.0.0.1:11443/health/ready' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
-grep -F 'https://127.0.0.1:11442/en/' \
+grep -F 'https://127.0.0.1:11442/' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
 grep -F 'run: ./.github/scripts/check-public-endpoint.sh' \
 	"${ROOT}/.github/workflows/deploy_target.yml" >/dev/null
@@ -1635,8 +1635,7 @@ if grep -F -- '--network host' "${smoke_runner}" >/dev/null; then
 fi
 grep -F 'image: hyperfilelens-postgres:17' "${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F 'absolute_redirect off;' "${ROOT}/deploy/nginx/default.conf" >/dev/null
-# Website pool (:8082) must keep / → /en/ relative; absolute redirects leak the
-# unpublished internal listen port through the public :11442 gateway.
+# Website pool (:8082) serves the default English homepage directly at /.
 grep -F 'absolute_redirect off;' "${ROOT}/deploy/nginx/web.conf" >/dev/null
 grep -F 'map $server_port $hfl_site {' \
 	"${ROOT}/deploy/nginx/snippets/hfl-log-format.conf" >/dev/null

--- a/tools/quality/test-lifecycle-output-contract.sh
+++ b/tools/quality/test-lifecycle-output-contract.sh
@@ -50,7 +50,7 @@ output="$({
 } 2>&1)"
 
 [[ "$(grep -c 'INSTALLER' <<<"${output}")" -eq 1 ]]
-grep -F 'https://192.0.2.10:11442/en/' <<<"${output}" >/dev/null
+grep -F 'https://192.0.2.10:11442/' <<<"${output}" >/dev/null
 grep -F 'https://192.0.2.10:11443/' <<<"${output}" >/dev/null
 grep -F 'https://192.0.2.10:11444/admin/' <<<"${output}" >/dev/null
 grep -F 'https://192.0.2.10:11445/' <<<"${output}" >/dev/null

--- a/tools/quality/test-website-runtime-config.sh
+++ b/tools/quality/test-website-runtime-config.sh
@@ -40,6 +40,24 @@ for nginx_config in \
 	"${ROOT}/deploy/nginx/web.conf" \
 	"${ROOT}/deploy/nginx/development-web.conf"; do
 	grep -F 'try_files $uri $uri/ $uri.html =404;' "${nginx_config}" >/dev/null
+	if grep -F 'return 302 /en/' "${nginx_config}" >/dev/null; then
+		printf 'ERROR: Website root must serve the default English homepage directly\n' >&2
+		exit 1
+	fi
 done
+
+grep -F "rewrites: (id) => id.startsWith('en/') ? id.slice(3) : id" \
+	"${ROOT}/website/.vitepress/config.mts" >/dev/null
+grep -F '<a class="brand" href="/" aria-label="HyperFileLens home">' \
+	"${ROOT}/website/.vitepress/theme/HomeLanding.vue" >/dev/null
+grep -F '<a href="/docs/" target="_blank" rel="noopener noreferrer">Documentation</a>' \
+	"${ROOT}/website/.vitepress/theme/HomeLanding.vue" >/dev/null
+if grep -R -F '/en/docs' --exclude-dir=dist --exclude-dir=cache \
+	"${ROOT}/website/en" >/dev/null \
+	|| grep -F '/en/docs' "${ROOT}/website/.vitepress/config.mts" \
+		"${ROOT}/website/.vitepress/theme/HomeLanding.vue" >/dev/null; then
+	printf 'ERROR: English Website links must use the default /docs route\n' >&2
+	exit 1
+fi
 
 printf 'Website runtime URL configuration checks passed.\n'

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -5,21 +5,21 @@ const enQuickStart = [
   {
     text: 'Quick start',
     items: [
-      { text: 'Install HyperFileLens Community', link: '/en/docs/getting-started/install' },
+      { text: 'Install HyperFileLens Community', link: '/docs/getting-started/install' },
     ],
   },
   {
     text: 'First use',
     items: [
-      { text: 'Sign in to the console', link: '/en/docs/getting-started/sign-in' },
-      { text: 'Add a backup source', link: '/en/docs/getting-started/add-source' },
-      { text: 'Configure the backup source', link: '/en/docs/getting-started/configure-source' },
-      { text: 'Add target storage', link: '/en/docs/getting-started/add-target' },
-      { text: 'Create and run the first backup', link: '/en/docs/getting-started/first-backup' },
-      { text: 'Check tasks and snapshots', link: '/en/docs/getting-started/verify-backup' },
-      { text: 'Restore a test file', link: '/en/docs/getting-started/first-restore' },
-      { text: 'Configure an AI model for Insights', link: '/en/docs/getting-started/configure-insights-model' },
-      { text: 'Create an Insights session', link: '/en/docs/getting-started/first-insight' },
+      { text: 'Sign in to the console', link: '/docs/getting-started/sign-in' },
+      { text: 'Add a backup source', link: '/docs/getting-started/add-source' },
+      { text: 'Configure the backup source', link: '/docs/getting-started/configure-source' },
+      { text: 'Add target storage', link: '/docs/getting-started/add-target' },
+      { text: 'Create and run the first backup', link: '/docs/getting-started/first-backup' },
+      { text: 'Check tasks and snapshots', link: '/docs/getting-started/verify-backup' },
+      { text: 'Restore a test file', link: '/docs/getting-started/first-restore' },
+      { text: 'Configure an AI model for Insights', link: '/docs/getting-started/configure-insights-model' },
+      { text: 'Create an Insights session', link: '/docs/getting-started/first-insight' },
     ],
   },
 ]
@@ -28,30 +28,30 @@ const enProduct = [
   {
     text: 'Product guide',
     items: [
-      { text: 'Product workflow', link: '/en/docs/product/' },
+      { text: 'Product workflow', link: '/docs/product/' },
     ],
   },
   {
     text: 'Backup and restore',
     items: [
-      { text: 'Workflow', link: '/en/docs/backup-restore/' },
-      { text: 'Manage backup sources', link: '/en/docs/backup-restore/sources' },
-      { text: 'Manage target storage', link: '/en/docs/backup-restore/targets' },
-      { text: 'Create and run backups', link: '/en/docs/backup-restore/create-backup' },
-      { text: 'Policies and retention', link: '/en/docs/backup-restore/policies' },
-      { text: 'View tasks and snapshots', link: '/en/docs/backup-restore/snapshots' },
-      { text: 'Restore files and directories', link: '/en/docs/backup-restore/restore' },
+      { text: 'Workflow', link: '/docs/backup-restore/' },
+      { text: 'Manage backup sources', link: '/docs/backup-restore/sources' },
+      { text: 'Manage target storage', link: '/docs/backup-restore/targets' },
+      { text: 'Create and run backups', link: '/docs/backup-restore/create-backup' },
+      { text: 'Policies and retention', link: '/docs/backup-restore/policies' },
+      { text: 'View tasks and snapshots', link: '/docs/backup-restore/snapshots' },
+      { text: 'Restore files and directories', link: '/docs/backup-restore/restore' },
     ],
   },
   {
     text: 'Insights',
     items: [
-      { text: 'Workflow', link: '/en/docs/insights/' },
-      { text: 'Prepare a snapshot', link: '/en/docs/insights/prepare' },
-      { text: 'Create an Insights session', link: '/en/docs/insights/copilot' },
-      { text: 'Configure AI models', link: '/en/docs/insights/models' },
-      { text: 'Use a Private Data Gateway', link: '/en/docs/insights/data-gateway' },
-      { text: 'Session and data scope', link: '/en/docs/insights/privacy' },
+      { text: 'Workflow', link: '/docs/insights/' },
+      { text: 'Prepare a snapshot', link: '/docs/insights/prepare' },
+      { text: 'Create an Insights session', link: '/docs/insights/copilot' },
+      { text: 'Configure AI models', link: '/docs/insights/models' },
+      { text: 'Use a Private Data Gateway', link: '/docs/insights/data-gateway' },
+      { text: 'Session and data scope', link: '/docs/insights/privacy' },
     ],
   },
 ]
@@ -60,30 +60,30 @@ const enOperations = [
   {
     text: 'Deployment and operations',
     items: [
-      { text: 'Deployment guide', link: '/en/docs/deployment/' },
+      { text: 'Deployment guide', link: '/docs/deployment/' },
     ],
   },
   {
     text: 'Deploy HyperFileLens Community',
     items: [
-      { text: 'System requirements', link: '/en/docs/deployment/requirements' },
-      { text: 'Network and ports', link: '/en/docs/deployment/network' },
-      { text: 'Post-installation checks', link: '/en/docs/deployment/post-install' },
+      { text: 'System requirements', link: '/docs/deployment/requirements' },
+      { text: 'Network and ports', link: '/docs/deployment/network' },
+      { text: 'Post-installation checks', link: '/docs/deployment/post-install' },
     ],
   },
   {
     text: 'Component deployment',
     items: [
-      { text: 'Deploy an Agent', link: '/en/docs/deployment/agent' },
-      { text: 'Deploy a Proxy', link: '/en/docs/deployment/proxy' },
-      { text: 'Deploy a Private Data Gateway', link: '/en/docs/deployment/data-gateway' },
+      { text: 'Deploy an Agent', link: '/docs/deployment/agent' },
+      { text: 'Deploy a Proxy', link: '/docs/deployment/proxy' },
+      { text: 'Deploy a Private Data Gateway', link: '/docs/deployment/data-gateway' },
     ],
   },
   {
     text: 'Operations',
     items: [
-      { text: 'Upgrade and recovery', link: '/en/docs/deployment/lifecycle' },
-      { text: 'Jobs, alerts, and audit logs', link: '/en/docs/deployment/operations' },
+      { text: 'Upgrade and recovery', link: '/docs/deployment/lifecycle' },
+      { text: 'Jobs, alerts, and audit logs', link: '/docs/deployment/operations' },
     ],
   },
 ]
@@ -96,19 +96,19 @@ const enHelp = [
   {
     text: 'Product reference',
     items: [
-      { text: 'Core concepts', link: '/en/docs/reference/' },
-      { text: 'Supported configurations', link: '/en/docs/reference/support-matrix' },
-      { text: 'Security and limits', link: '/en/docs/reference/limitations-security' },
+      { text: 'Core concepts', link: '/docs/reference/' },
+      { text: 'Supported configurations', link: '/docs/reference/support-matrix' },
+      { text: 'Security and limits', link: '/docs/reference/limitations-security' },
     ],
   },
   {
     text: 'Troubleshooting',
     items: [
-      { text: 'Troubleshooting guide', link: '/en/docs/troubleshooting/' },
-      { text: 'Accounts and sign-in', link: '/en/docs/troubleshooting/account-sign-in' },
-      { text: 'Installation and nodes', link: '/en/docs/troubleshooting/installation-nodes' },
-      { text: 'Backup, storage, and restore', link: '/en/docs/troubleshooting/protection' },
-      { text: 'Insights and Data Gateway', link: '/en/docs/troubleshooting/insights' },
+      { text: 'Troubleshooting guide', link: '/docs/troubleshooting/' },
+      { text: 'Accounts and sign-in', link: '/docs/troubleshooting/account-sign-in' },
+      { text: 'Installation and nodes', link: '/docs/troubleshooting/installation-nodes' },
+      { text: 'Backup, storage, and restore', link: '/docs/troubleshooting/protection' },
+      { text: 'Insights and Data Gateway', link: '/docs/troubleshooting/insights' },
     ],
   },
 ]
@@ -118,6 +118,7 @@ export default defineConfig({
   title: 'HyperFileLens',
   description: 'Open source backup with agentic AI insight — protect your files without touching production, then ask deep questions, no pre-built index required.',
   cleanUrls: true,
+  rewrites: (id) => id.startsWith('en/') ? id.slice(3) : id,
   head: [
     ['link', { rel: 'icon', type: 'image/x-icon', href: '/brand/icons/favicon.ico' }],
     ['meta', { name: 'theme-color', content: '#07111f' }],
@@ -139,31 +140,31 @@ export default defineConfig({
     nav: [
       {
         text: 'Quick start',
-        link: '/en/docs/getting-started/install',
-        activeMatch: '^/en/docs/(?:$|getting-started/)',
+        link: '/docs/getting-started/install',
+        activeMatch: '^/docs/(?:$|getting-started/)',
       },
       {
         text: 'Product guide',
-        link: '/en/docs/product/',
-        activeMatch: '^/en/docs/(product|backup-restore|insights)/',
+        link: '/docs/product/',
+        activeMatch: '^/docs/(product|backup-restore|insights)/',
       },
-      { text: 'Deployment and operations', link: '/en/docs/deployment/' },
+      { text: 'Deployment and operations', link: '/docs/deployment/' },
       {
         text: 'Help center',
-        link: '/en/docs/help/',
-        activeMatch: '^/en/docs/(help|reference|troubleshooting)/',
+        link: '/docs/help/',
+        activeMatch: '^/docs/(help|reference|troubleshooting)/',
       },
     ],
     sidebar: {
-      '/en/docs/product/': enProduct,
-      '/en/docs/backup-restore/': enProduct,
-      '/en/docs/insights/': enProduct,
-      '/en/docs/deployment/': enOperations,
-      '/en/docs/help/': enHelp,
-      '/en/docs/reference/': enHelp,
-      '/en/docs/troubleshooting/': enHelp,
-      '/en/docs/': enQuickStart,
-      '/en/docs/getting-started/': enQuickStart,
+      '/docs/product/': enProduct,
+      '/docs/backup-restore/': enProduct,
+      '/docs/insights/': enProduct,
+      '/docs/deployment/': enOperations,
+      '/docs/help/': enHelp,
+      '/docs/reference/': enHelp,
+      '/docs/troubleshooting/': enHelp,
+      '/docs/': enQuickStart,
+      '/docs/getting-started/': enQuickStart,
     },
     socialLinks: [
       { icon: 'github', link: 'https://github.com/oneprolabs/hyperfilelens' },
@@ -187,10 +188,10 @@ export default defineConfig({
     },
   },
   locales: {
-    en: {
+    root: {
       label: 'English',
       lang: 'en-US',
-      link: '/en/',
+      link: '/',
       title: 'HyperFileLens',
       description: 'Open source backup with agentic AI insight — protect your files without touching production, then ask deep questions, no pre-built index required.',
       head: [

--- a/website/.vitepress/theme/DocTrialLink.vue
+++ b/website/.vitepress/theme/DocTrialLink.vue
@@ -10,7 +10,11 @@ const props = defineProps<{
 
 const route = useRoute()
 const appOrigin = ref('')
-const isDocs = computed(() => route.path.startsWith('/zh/docs') || route.path.startsWith('/en/docs'))
+const isDocs = computed(() =>
+  route.path.startsWith('/zh/docs')
+  || route.path.startsWith('/docs')
+  || route.path.startsWith('/en/docs'),
+)
 const label = computed(() => route.path.startsWith('/zh/docs') ? siteTrialLabels.zh : siteTrialLabels.en)
 
 function validOrigin(value: string): string {

--- a/website/.vitepress/theme/HomeLanding.vue
+++ b/website/.vitepress/theme/HomeLanding.vue
@@ -130,13 +130,13 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
 
     <header class="site-header-wrap">
       <div class="site-header">
-        <a class="brand" href="/en/" aria-label="HyperFileLens home">
+        <a class="brand" href="/" aria-label="HyperFileLens home">
           <img class="brand-lockup" src="/brand/images/hyperfilelens-lockup-on-light.png" alt="HyperFileLens" />
         </a>
         <nav aria-label="Main navigation">
           <a href="#use-cases">Use Cases</a>
           <a href="#how-it-works">How It Works</a>
-          <a href="/en/docs/" target="_blank" rel="noopener noreferrer">Documentation</a>
+          <a href="/docs/" target="_blank" rel="noopener noreferrer">Documentation</a>
           <a href="#open-source">Open Source</a>
           <a href="#contact">Contact</a>
         </nav>
@@ -342,7 +342,7 @@ function openApp(event: MouseEvent, placement: WebsiteOpenAppPlacement) {
 
     <footer>
       <div class="footer-brand">
-        <a class="brand" href="/en/"><img class="brand-lockup" src="/brand/images/hyperfilelens-lockup-on-light.png" alt="HyperFileLens" /></a>
+        <a class="brand" href="/"><img class="brand-lockup" src="/brand/images/hyperfilelens-lockup-on-light.png" alt="HyperFileLens" /></a>
         <p>Open source backup with agentic AI insight, by OneProLabs.</p>
         <a class="footer-social" :href="githubUrl" aria-label="HyperFileLens on GitHub"><svg aria-hidden="true"><use href="#icon-github" /></svg></a>
       </div>

--- a/website/.vitepress/theme/analytics.ts
+++ b/website/.vitepress/theme/analytics.ts
@@ -27,9 +27,9 @@ let activePagePath = '/'
 let lastTrackedPagePath = ''
 
 function websitePageMetadata(path: string) {
-  const isDocs = /^\/(?:en|zh)(?:-[^/]+)?\/docs(?:\/|$)/.test(path)
+  const isDocs = /^\/(?:zh\/)?docs(?:\/|$)/.test(path)
   const locale = path.startsWith('/zh') ? 'zh' : 'en'
-  const relative = path.replace(/^\/(?:en|zh)(?:-[^/]+)?\//, '').replace(/^docs\/?/, '')
+  const relative = path.replace(/^\/zh\//, '').replace(/^\//, '').replace(/^docs\/?/, '')
   const slug = relative.replace(/\/$/, '').replace(/[^a-zA-Z0-9/_-]+/g, '_') || 'home'
   let pageGroup = 'home'
   if (isDocs) {
@@ -60,7 +60,9 @@ function websitePageTitle(path: string, isDocs: boolean): string {
 function sanitizedPath(value: string): string {
   try {
     const parsed = new URL(value, window.location.origin)
-    return parsed.pathname || '/'
+    const path = parsed.pathname || '/'
+    if (path === '/en' || path === '/en/') return '/'
+    return path.replace(/^\/en(?=\/docs(?:\/|$))/, '')
   } catch {
     return '/'
   }

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -10,7 +10,7 @@ import { enDocA11yLabels, zhDocA11yLabels } from './languages'
 function localizeDocCopyButtons(path: string) {
   const labels = path.startsWith('/zh/docs')
     ? zhDocA11yLabels
-    : path.startsWith('/en/docs')
+    : path.startsWith('/docs')
       ? enDocA11yLabels
       : null
   if (!labels) return
@@ -35,7 +35,7 @@ function localizeDocCopyButtons(path: string) {
 function localizeDocLabels(path: string) {
   const labels = path.startsWith('/zh/docs')
     ? zhDocA11yLabels
-    : path.startsWith('/en/docs')
+    : path.startsWith('/docs')
       ? enDocA11yLabels
       : null
   if (!labels) return
@@ -122,16 +122,18 @@ function englishDocFallback(route: string) {
 }
 
 function updateDocLanguageLinks(path: string) {
-  const match = path.match(/^\/(en|zh)(\/docs(?:\/.*)?$)/)
-  if (!match) return
+  const chineseMatch = path.match(/^\/zh(\/docs(?:\/.*)?$)/)
+  const englishMatch = path.match(/^(\/docs(?:\/.*)?$)/)
+  if (!chineseMatch && !englishMatch) return
 
-  const [, currentLocale, rawRoute] = match
+  const currentLocale = chineseMatch ? 'zh' : 'en'
+  const rawRoute = chineseMatch?.[1] ?? englishMatch?.[1] ?? '/docs'
   const route = normalizeDocRoute(rawRoute)
   const targetLocale = currentLocale === 'en' ? 'zh' : 'en'
   const targetRoute = targetLocale === 'en' && !englishDocRoutes.has(route)
     ? englishDocFallback(route)
     : route
-  const target = `/${targetLocale}${targetRoute}`
+  const target = targetLocale === 'zh' ? `/zh${targetRoute}` : targetRoute
 
   document
     .querySelectorAll<HTMLAnchorElement>('.VPNavBarTranslations a, .VPNavScreenTranslations a')
@@ -141,7 +143,7 @@ function updateDocLanguageLinks(path: string) {
 }
 
 function decorateDocSidebar(path: string) {
-  if (!/^\/(?:en|zh)\/docs(?:\/|$)/.test(path)) return
+  if (!/^\/(?:zh\/)?docs(?:\/|$)/.test(path)) return
 
   const iconSets = {
     quickStart: [
@@ -166,7 +168,7 @@ function decorateDocSidebar(path: string) {
     ],
   } as const
 
-  const docsPath = path.replace(/^\/(?:en|zh)/, '')
+  const docsPath = path.replace(/^\/zh/, '')
   const section = docsPath.startsWith('/docs/deployment/')
     ? 'operations'
     : docsPath.startsWith('/docs/product/') ||
@@ -188,7 +190,7 @@ function decorateDocSidebar(path: string) {
     document.querySelectorAll<HTMLElement>('.VPSidebarItem.level-0 > .item .text').forEach((title, index) => {
       const icon = icons[index]
       const group = title.closest<HTMLElement>('.VPSidebarItem.level-0')
-      if (group && section === 'help' && index === 0 && /^\/(?:en|zh)\/docs\/help\/?$/.test(path)) {
+      if (group && section === 'help' && index === 0 && /^\/(?:zh\/)?docs\/help\/?$/.test(path)) {
         group.classList.add('hfl-sidebar-current')
       }
       if (group && section === 'help' && index === 0 && !group.querySelector(':scope > .items')) {
@@ -208,7 +210,7 @@ function decorateDocSidebar(path: string) {
 }
 
 function revealActiveSidebarItem(path: string) {
-  if (!/^\/(?:en|zh)\/docs(?:\/|$)/.test(path)) return
+  if (!/^\/(?:zh\/)?docs(?:\/|$)/.test(path)) return
 
   const sidebar = document.querySelector<HTMLElement>('.VPSidebar')
   const activeItem = sidebar?.querySelector<HTMLElement>('.VPSidebarItem.is-active')
@@ -227,14 +229,19 @@ function revealActiveSidebarItem(path: string) {
   sidebar.scrollTop = activeTop - (sidebar.clientHeight - activeRect.height) / 2
 }
 
+function publishedPath(path: string) {
+  return path.replace(/^\/en(?=\/docs(?:\/|$))/, '')
+}
+
 function enhanceDocPage(path: string) {
+  const pathForPublication = publishedPath(path)
   window.requestAnimationFrame(() => {
-    localizeDocCopyButtons(path)
-    localizeDocLabels(path)
-    decorateDocSidebar(path)
-    revealActiveSidebarItem(path)
-    updateDocLanguageLinks(path)
-    window.setTimeout(() => updateDocLanguageLinks(path), 80)
+    localizeDocCopyButtons(pathForPublication)
+    localizeDocLabels(pathForPublication)
+    decorateDocSidebar(pathForPublication)
+    revealActiveSidebarItem(pathForPublication)
+    updateDocLanguageLinks(pathForPublication)
+    window.setTimeout(() => updateDocLanguageLinks(pathForPublication), 80)
   })
 }
 

--- a/website/.vitepress/theme/languages.ts
+++ b/website/.vitepress/theme/languages.ts
@@ -6,7 +6,7 @@ export interface SiteLanguage {
 
 // Add new locales here — every LanguageSwitcher instance picks it up automatically.
 export const siteLanguages: SiteLanguage[] = [
-  { code: 'en', label: 'English', path: '/en/' },
+  { code: 'en', label: 'English', path: '/' },
   { code: 'zh', label: '简体中文', path: '/zh/' },
 ]
 

--- a/website/build.sh
+++ b/website/build.sh
@@ -83,8 +83,8 @@ docker rm -f "${container_id}" >/dev/null
 container_id=""
 install -m 0755 "${SCRIPT_DIR}/runtime-config.sh" "${temporary}/runtime-config.sh"
 
-[[ -f "${temporary}/public/en/index.html" ]] \
-	|| { printf 'ERROR: Website artifact is missing en/index.html\n' >&2; exit 1; }
+[[ -f "${temporary}/public/index.html" ]] \
+	|| { printf 'ERROR: Website artifact is missing index.html\n' >&2; exit 1; }
 [[ -f "${temporary}/public/website-runtime-config.js" ]] \
 	|| { printf 'ERROR: Website artifact is missing website-runtime-config.js\n' >&2; exit 1; }
 printf 'schema=1\n' >"${temporary}/.hfl-website-artifact"

--- a/website/en/docs/backup-restore/create-backup.md
+++ b/website/en/docs/backup-restore/create-backup.md
@@ -51,4 +51,4 @@ Back on **Start Backup**, confirm that repository **Connectivity** is **Online**
 
 ![Backup configuration ready to run with Connectivity Online and account and host information blurred](/docs/getting-started/backup-ready-to-run.png)
 
-Do not stop the Agent, unmount a NAS, or change storage credentials while the task is running. Continue with [View tasks and snapshots](/en/docs/backup-restore/snapshots) after the task finishes.
+Do not stop the Agent, unmount a NAS, or change storage credentials while the task is running. Continue with [View tasks and snapshots](/docs/backup-restore/snapshots) after the task finishes.

--- a/website/en/docs/backup-restore/index.md
+++ b/website/en/docs/backup-restore/index.md
@@ -9,12 +9,12 @@ The HyperFileLens data-protection workflow starts with an accessible backup sour
 
 ## Workflow
 
-1. [Manage backup sources](/en/docs/backup-restore/sources) and confirm that the Agent or Proxy is online and the intended folders can be browsed.
-2. [Manage target storage](/en/docs/backup-restore/targets), create a dedicated repository, and validate its connection.
-3. [Create and run a backup](/en/docs/backup-restore/create-backup), selecting its scope, repository, and run options.
-4. [View tasks and snapshots](/en/docs/backup-restore/snapshots) to check both the task result and the files in the snapshot.
-5. [Restore files and directories](/en/docs/backup-restore/restore) to an independent location and inspect the restored content.
-6. After validating the basic path, configure [policies and retention](/en/docs/backup-restore/policies) to meet the recovery point objective.
+1. [Manage backup sources](/docs/backup-restore/sources) and confirm that the Agent or Proxy is online and the intended folders can be browsed.
+2. [Manage target storage](/docs/backup-restore/targets), create a dedicated repository, and validate its connection.
+3. [Create and run a backup](/docs/backup-restore/create-backup), selecting its scope, repository, and run options.
+4. [View tasks and snapshots](/docs/backup-restore/snapshots) to check both the task result and the files in the snapshot.
+5. [Restore files and directories](/docs/backup-restore/restore) to an independent location and inspect the restored content.
+6. After validating the basic path, configure [policies and retention](/docs/backup-restore/policies) to meet the recovery point objective.
 
 ## Three checks that matter
 

--- a/website/en/docs/backup-restore/restore.md
+++ b/website/en/docs/backup-restore/restore.md
@@ -53,4 +53,4 @@ Confirm that **Restore Task** is **Succeeded** on **Start Backup**, then open **
 
 ![Successful single-file restore in Restore Records with host and IP information blurred while Record, Task, and Snapshot identifiers and times remain visible](/docs/getting-started/restore-record-succeeded.png)
 
-For failures, record the failed path, destination node, error code, and task time, then see [Backup, Storage, and Restore troubleshooting](/en/docs/troubleshooting/protection).
+For failures, record the failed path, destination node, error code, and task time, then see [Backup, Storage, and Restore troubleshooting](/docs/troubleshooting/protection).

--- a/website/en/docs/deployment/agent.md
+++ b/website/en/docs/deployment/agent.md
@@ -9,8 +9,8 @@ Install an Agent on each Windows, Linux, or macOS host whose local files you wan
 
 ## Before deployment
 
-- Confirm that the host meets the [system requirements](/en/docs/deployment/requirements).
-- Confirm that it can reach the HyperFileLens control plane and the target storage you plan to use. See [Network and ports](/en/docs/deployment/network).
+- Confirm that the host meets the [system requirements](/docs/deployment/requirements).
+- Confirm that it can reach the HyperFileLens control plane and the target storage you plan to use. See [Network and ports](/docs/deployment/network).
 - Use an account with access to the files you want to protect. The installer determines how the Agent runs from the identity used to execute the command.
 
 ## Install the Agent
@@ -29,4 +29,4 @@ In the console, confirm that:
 - You can browse the required folders and select the intended backup paths.
 - For a persistent installation, the Agent reconnects automatically after the host or service restarts.
 
-If registration fails or the Agent remains offline, see [Installation and nodes](/en/docs/troubleshooting/installation-nodes).
+If registration fails or the Agent remains offline, see [Installation and nodes](/docs/troubleshooting/installation-nodes).

--- a/website/en/docs/deployment/data-gateway.md
+++ b/website/en/docs/deployment/data-gateway.md
@@ -17,7 +17,7 @@ If the Public Data Gateway can reach the repository, you normally do not need to
 ## Before deployment
 
 - Prepare an Ubuntu 20.04, 22.04, or 24.04 amd64 host with at least 2 CPU cores, 4 GiB of memory, and 50 GiB of free space.
-- Confirm that the host can reach both the HyperFileLens control plane and the required backup repositories. See [Network and ports](/en/docs/deployment/network).
+- Confirm that the host can reach both the HyperFileLens control plane and the required backup repositories. See [Network and ports](/docs/deployment/network).
 - If Docker is not installed, the installer adds the runtime included with the release. If Docker is already present, use Docker Engine 24.0.0 or later and Compose V2 2.20.0 or later.
 
 ## Deploy the gateway
@@ -36,4 +36,4 @@ In the console, confirm that:
 - The gateway can reach the repositories that will be used by Insights.
 - A test session can select the gateway and prepare data from the selected snapshot.
 
-If installation fails, the gateway remains offline, or the AI engine is unhealthy, see [Installation and nodes](/en/docs/troubleshooting/installation-nodes).
+If installation fails, the gateway remains offline, or the AI engine is unhealthy, see [Installation and nodes](/docs/troubleshooting/installation-nodes).

--- a/website/en/docs/deployment/index.md
+++ b/website/en/docs/deployment/index.md
@@ -9,18 +9,18 @@ description: Deploy the HyperFileLens control plane, backup components, and Priv
 
 ## Deploy HyperFileLens Community
 
-1. Review the [system requirements](/en/docs/deployment/requirements).
-2. Plan the required [network connections and ports](/en/docs/deployment/network).
-3. Follow [Install HyperFileLens Community](/en/docs/getting-started/install).
-4. Complete the [post-installation checks](/en/docs/deployment/post-install).
+1. Review the [system requirements](/docs/deployment/requirements).
+2. Plan the required [network connections and ports](/docs/deployment/network).
+3. Follow [Install HyperFileLens Community](/docs/getting-started/install).
+4. Complete the [post-installation checks](/docs/deployment/post-install).
 
 ## Deploy components
 
-- [Deploy an Agent](/en/docs/deployment/agent) on a Windows, Linux, or macOS host to read local files and run backup and restore jobs.
-- [Deploy a Proxy](/en/docs/deployment/proxy) on a network that can reach NAS or local storage and provide storage access for backup and restore jobs.
-- [Deploy a Private Data Gateway](/en/docs/deployment/data-gateway) on a network that can reach a private backup repository when the Public Data Gateway cannot. The gateway prepares selected snapshot data for Insights.
+- [Deploy an Agent](/docs/deployment/agent) on a Windows, Linux, or macOS host to read local files and run backup and restore jobs.
+- [Deploy a Proxy](/docs/deployment/proxy) on a network that can reach NAS or local storage and provide storage access for backup and restore jobs.
+- [Deploy a Private Data Gateway](/docs/deployment/data-gateway) on a network that can reach a private backup repository when the Public Data Gateway cannot. The gateway prepares selected snapshot data for Insights.
 
 ## Operate HyperFileLens Community
 
-- Use the installer to [upgrade HyperFileLens Community and recover from upgrade failures](/en/docs/deployment/lifecycle).
-- Use [jobs, alerts, and audit logs](/en/docs/deployment/operations) to monitor day-to-day operation and investigate exceptions.
+- Use the installer to [upgrade HyperFileLens Community and recover from upgrade failures](/docs/deployment/lifecycle).
+- Use [jobs, alerts, and audit logs](/docs/deployment/operations) to monitor day-to-day operation and investigate exceptions.

--- a/website/en/docs/deployment/lifecycle.md
+++ b/website/en/docs/deployment/lifecycle.md
@@ -67,4 +67,4 @@ After a failure:
 1. Do not repeat the upgrade, delete system backups, or replace runtime files manually.
 2. Run `status` and record the current version and unhealthy services.
 3. Keep the installer log and system backups.
-4. Follow the recovery instructions in the target release notes. If none are provided, see [Installation and nodes](/en/docs/troubleshooting/installation-nodes).
+4. Follow the recovery instructions in the target release notes. If none are provided, see [Installation and nodes](/docs/troubleshooting/installation-nodes).

--- a/website/en/docs/deployment/operations.md
+++ b/website/en/docs/deployment/operations.md
@@ -34,4 +34,4 @@ Open <span class="hfl-path">Operations → Audit Logs</span> and filter importan
 
 ## Continue troubleshooting
 
-If the console does not provide enough information, record the affected resource, task ID, error, and time, then use the [Troubleshooting Guide](/en/docs/troubleshooting/). Collect control-plane or component logs only when a troubleshooting step specifically requires them.
+If the console does not provide enough information, record the affected resource, task ID, error, and time, then use the [Troubleshooting Guide](/docs/troubleshooting/). Collect control-plane or component logs only when a troubleshooting step specifically requires them.

--- a/website/en/docs/deployment/post-install.md
+++ b/website/en/docs/deployment/post-install.md
@@ -15,7 +15,7 @@ On the Community host, run:
 sudo /opt/hyperfilelens/install.sh status
 ```
 
-Confirm that all services are running normally and record the installed version. If a service is unhealthy, see [Installation and nodes](/en/docs/troubleshooting/installation-nodes).
+Confirm that all services are running normally and record the installed version. If a service is unhealthy, see [Installation and nodes](/docs/troubleshooting/installation-nodes).
 
 ## 2. Sign in to the console
 
@@ -33,4 +33,4 @@ Confirm that the top navigation includes the following areas and that each one o
 - **Configuration:** Open organization information, member roles, and system settings.
 - **Operations:** Open operational health, alerts, jobs, and audit information.
 
-If a service or page does not open, record the message shown on the page and the product version, then see [Installation and nodes](/en/docs/troubleshooting/installation-nodes).
+If a service or page does not open, record the message shown on the page and the product version, then see [Installation and nodes](/docs/troubleshooting/installation-nodes).

--- a/website/en/docs/deployment/proxy.md
+++ b/website/en/docs/deployment/proxy.md
@@ -9,9 +9,9 @@ Deploy a Proxy on a Linux host that can reach the required NAS or local storage.
 
 ## Before deployment
 
-- Prepare an Ubuntu amd64 host that meets the [system requirements](/en/docs/deployment/requirements).
+- Prepare an Ubuntu amd64 host that meets the [system requirements](/docs/deployment/requirements).
 - Confirm that the host can reach the HyperFileLens control plane and the NAS or local disk you plan to use.
-- For NAS, confirm that the SMB or NFS service and port are reachable from the Proxy host. See [Network and ports](/en/docs/deployment/network).
+- For NAS, confirm that the SMB or NFS service and port are reachable from the Proxy host. See [Network and ports](/docs/deployment/network).
 
 ## Install the Proxy
 
@@ -35,4 +35,4 @@ In the console, confirm that:
 - The expected folders are available from the relevant source or target page.
 - The Proxy reconnects automatically after its host or service restarts.
 
-If registration or storage validation fails, or the Proxy remains offline, see [Installation and nodes](/en/docs/troubleshooting/installation-nodes).
+If registration or storage validation fails, or the Proxy remains offline, see [Installation and nodes](/docs/troubleshooting/installation-nodes).

--- a/website/en/docs/deployment/requirements.md
+++ b/website/en/docs/deployment/requirements.md
@@ -56,4 +56,4 @@ The control plane is installed in `/opt/hyperfilelens`. The installer checks fre
 - Docker Engine is running and can start containers.
 - The host can reach GitHub, the container registry, and Ubuntu package repositories.
 - Hosts used for online installation or component registration can resolve the required domains, establish HTTPS connections, and keep accurate system time.
-- The required paths between the control plane, components, and storage are allowed. See [Network and Ports](/en/docs/deployment/network).
+- The required paths between the control plane, components, and storage are allowed. See [Network and Ports](/docs/deployment/network).

--- a/website/en/docs/getting-started/configure-source.md
+++ b/website/en/docs/getting-started/configure-source.md
@@ -40,4 +40,4 @@ For recurring backups, use **Backup Policy** to select or create a policy. To ex
 - `C:\HFL-Quickstart` appears under **Selected Paths**.
 - No filter rule excludes either test file.
 
-If no repository is available on the **Target** step, continue without leaving the configuration flow: [Add target storage](/en/docs/getting-started/add-target).
+If no repository is available on the **Target** step, continue without leaving the configuration flow: [Add target storage](/docs/getting-started/add-target).

--- a/website/en/docs/help/index.md
+++ b/website/en/docs/help/index.md
@@ -9,14 +9,14 @@ Use the product reference to understand how HyperFileLens works and what it supp
 
 ## Product reference
 
-- [Core Concepts](/en/docs/reference/): Understand organizations, backup sources, target storage, jobs, snapshots, restores, and Data Gateways.
-- [Supported Configurations](/en/docs/reference/support-matrix): Check supported platforms, backup sources, target storage, and Insights capabilities.
-- [Limitations and Security Guidance](/en/docs/reference/limitations-security): Review product limits and guidance for credentials, networks, deletion, and recovery.
+- [Core Concepts](/docs/reference/): Understand organizations, backup sources, target storage, jobs, snapshots, restores, and Data Gateways.
+- [Supported Configurations](/docs/reference/support-matrix): Check supported platforms, backup sources, target storage, and Insights capabilities.
+- [Limitations and Security Guidance](/docs/reference/limitations-security): Review product limits and guidance for credentials, networks, deletion, and recovery.
 
 ## Troubleshooting
 
-- [Troubleshooting Guide](/en/docs/troubleshooting/): Locate a problem by the stage where it occurred.
-- [Accounts and Sign-in](/en/docs/troubleshooting/account-sign-in): Resolve console access, sign-in, and stale-page issues.
-- [Installation and nodes](/en/docs/troubleshooting/installation-nodes): Resolve installation or connectivity issues affecting HyperFileLens Community, an Agent, a Proxy, or a Private Data Gateway.
-- [Backup, Storage, and Restore](/en/docs/troubleshooting/protection): Resolve folder browsing, storage validation, backup, snapshot, and restore failures.
-- [Insights and Data Gateway](/en/docs/troubleshooting/insights): Resolve session creation, data preparation, gateway, and answer quality issues.
+- [Troubleshooting Guide](/docs/troubleshooting/): Locate a problem by the stage where it occurred.
+- [Accounts and Sign-in](/docs/troubleshooting/account-sign-in): Resolve console access, sign-in, and stale-page issues.
+- [Installation and nodes](/docs/troubleshooting/installation-nodes): Resolve installation or connectivity issues affecting HyperFileLens Community, an Agent, a Proxy, or a Private Data Gateway.
+- [Backup, Storage, and Restore](/docs/troubleshooting/protection): Resolve folder browsing, storage validation, backup, snapshot, and restore failures.
+- [Insights and Data Gateway](/docs/troubleshooting/insights): Resolve session creation, data preparation, gateway, and answer quality issues.

--- a/website/en/docs/index.md
+++ b/website/en/docs/index.md
@@ -8,7 +8,7 @@ description: Install HyperFileLens Community, run your first backup, restore a t
 <p class="hfl-doc-lead">Install HyperFileLens Community on an Ubuntu host, then follow the first-use guide to run your first backup, restore a test file, and create an Insights session.</p>
 
 <div class="hfl-doc-grid">
-  <a class="hfl-doc-card" href="/en/docs/getting-started/install">
+  <a class="hfl-doc-card" href="/docs/getting-started/install">
     <small>Self-hosted</small>
     <strong>Install HyperFileLens Community</strong>
     <span>Deploy HyperFileLens Community on your own Ubuntu host and manage the environment yourself.</span>

--- a/website/en/docs/insights/data-gateway.md
+++ b/website/en/docs/insights/data-gateway.md
@@ -28,7 +28,7 @@ Run the generated command on the intended host as instructed. The enrollment com
 
 ![Add Private Data Gateway showing system requirements and installation stages with the enrollment command fully covered and the personal account blurred](/docs/insights/add-private-gateway.png)
 
-See [Deploy a Private Data Gateway](/en/docs/deployment/data-gateway) and [Network and ports](/en/docs/deployment/network) for deployment details.
+See [Deploy a Private Data Gateway](/docs/deployment/data-gateway) and [Network and ports](/docs/deployment/network) for deployment details.
 
 ## Validate before use
 

--- a/website/en/docs/insights/index.md
+++ b/website/en/docs/insights/index.md
@@ -9,12 +9,12 @@ HyperFileLens Insights analyzes protected backup snapshots. A Data Gateway prepa
 
 ## Workflow
 
-1. [Prepare a snapshot](/en/docs/insights/prepare) and confirm that the required files are available.
-2. [Create an Insights session](/en/docs/insights/copilot), choosing a snapshot, data scope, analysis type, and Data Gateway.
+1. [Prepare a snapshot](/docs/insights/prepare) and confirm that the required files are available.
+2. [Create an Insights session](/docs/insights/copilot), choosing a snapshot, data scope, analysis type, and Data Gateway.
 3. Ask a question whose answer can be checked against the selected files and citations.
-4. Have a platform administrator [configure AI models](/en/docs/insights/models) when the required models are not ready.
-5. [Use a Private Data Gateway](/en/docs/insights/data-gateway) only when the Public Data Gateway cannot reach the repository or processing must remain in a managed network.
-6. Understand and manage the [session and data scope](/en/docs/insights/privacy).
+4. Have a platform administrator [configure AI models](/docs/insights/models) when the required models are not ready.
+5. [Use a Private Data Gateway](/docs/insights/data-gateway) only when the Public Data Gateway cannot reach the repository or processing must remain in a managed network.
+6. Understand and manage the [session and data scope](/docs/insights/privacy).
 
 ![AI Copilot answer based on a synthetic CSV with account, host, and Gateway identifiers blurred while the cited result remains visible](/docs/getting-started/chat-answer.png)
 

--- a/website/en/docs/product/index.md
+++ b/website/en/docs/product/index.md
@@ -17,12 +17,12 @@ A snapshot is both the result of a backup and the shared data foundation for res
 
 The data protection lifecycle is straightforward:
 
-1. Add a [backup source](/en/docs/backup-restore/sources) and [target storage](/en/docs/backup-restore/targets), then validate access to both.
-2. [Create and run a backup](/en/docs/backup-restore/create-backup), adding [policies and retention](/en/docs/backup-restore/policies) as needed.
-3. [View tasks and snapshots](/en/docs/backup-restore/snapshots) to confirm that the expected files are present.
-4. [Restore files and directories](/en/docs/backup-restore/restore) to prove that the protected data is usable.
+1. Add a [backup source](/docs/backup-restore/sources) and [target storage](/docs/backup-restore/targets), then validate access to both.
+2. [Create and run a backup](/docs/backup-restore/create-backup), adding [policies and retention](/docs/backup-restore/policies) as needed.
+3. [View tasks and snapshots](/docs/backup-restore/snapshots) to confirm that the expected files are present.
+4. [Restore files and directories](/docs/backup-restore/restore) to prove that the protected data is usable.
 
-See the [backup and restore workflow](/en/docs/backup-restore/) for the complete guide.
+See the [backup and restore workflow](/docs/backup-restore/) for the complete guide.
 
 ## Insights
 
@@ -35,4 +35,4 @@ Insights works with existing backup snapshots and does not read live files from 
 
 ## First-time use
 
-If you are new to HyperFileLens, follow the [Quick start](/en/docs/) to run a backup, restore a test file, and create an Insights session with the same sample data. Once you have completed the workflow, configure schedules, retention, and routine restore tests for the data you need to protect.
+If you are new to HyperFileLens, follow the [Quick start](/docs/) to run a backup, restore a test file, and create an Insights session with the same sample data. Once you have completed the workflow, configure schedules, retention, and routine restore tests for the data you need to protect.

--- a/website/en/docs/reference/limitations-security.md
+++ b/website/en/docs/reference/limitations-security.md
@@ -5,7 +5,7 @@ description: Understand product boundaries and security responsibilities when de
 
 # Limitations and security guidance
 
-This page describes important product boundaries. See [Supported Configurations](/en/docs/reference/support-matrix) for platforms and storage types.
+This page describes important product boundaries. See [Supported Configurations](/docs/reference/support-matrix) for platforms and storage types.
 
 ## Product boundaries
 
@@ -26,7 +26,7 @@ This page describes important product boundaries. See [Supported Configurations]
 
 The certificate included with HyperFileLens Community is intended for initial installation and access. For regular operation, configure a TLS certificate that matches the configured domain and is trusted by browsers and components.
 
-Allow only the connections listed in [Network and Ports](/en/docs/deployment/network), and restrict their source networks. Keep TLS verification enabled where possible instead of disabling it permanently to work around certificate problems.
+Allow only the connections listed in [Network and Ports](/docs/deployment/network), and restrict their source networks. Keep TLS verification enabled where possible instead of disabling it permanently to work around certificate problems.
 
 ## Data and deletion
 

--- a/website/en/docs/reference/support-matrix.md
+++ b/website/en/docs/reference/support-matrix.md
@@ -18,7 +18,7 @@ This page summarizes the primary platforms and capabilities supported by HyperFi
 | Proxy | Ubuntu 20.04, 22.04, or 24.04 | amd64 |
 | Private Data Gateway | Ubuntu 20.04, 22.04, or 24.04 | amd64 |
 
-See [System Requirements](/en/docs/deployment/requirements) for CPU, memory, and disk requirements.
+See [System Requirements](/docs/deployment/requirements) for CPU, memory, and disk requirements.
 
 ## Backup sources
 

--- a/website/en/docs/troubleshooting/index.md
+++ b/website/en/docs/troubleshooting/index.md
@@ -18,22 +18,22 @@ Use the message shown on the page and the job details to identify where the fail
 ## Choose a scenario
 
 <div class="hfl-doc-grid">
-  <a class="hfl-doc-card" href="/en/docs/troubleshooting/account-sign-in">
+  <a class="hfl-doc-card" href="/docs/troubleshooting/account-sign-in">
     <small>Account access</small>
     <strong>Console or sign-in unavailable</strong>
     <span>Check the console address, sign-in method, account state, and browser access.</span>
   </a>
-  <a class="hfl-doc-card" href="/en/docs/troubleshooting/installation-nodes">
+  <a class="hfl-doc-card" href="/docs/troubleshooting/installation-nodes">
     <small>Installation and connectivity</small>
     <strong>Installation failed or a node is offline</strong>
     <span>Check system prerequisites, the installation command, component state, and control-plane connectivity.</span>
   </a>
-  <a class="hfl-doc-card" href="/en/docs/troubleshooting/protection">
+  <a class="hfl-doc-card" href="/docs/troubleshooting/protection">
     <small>Data protection</small>
     <strong>Backup, repository, or restore failed</strong>
     <span>Check folder permissions, object storage, NAS, Proxy storage access, snapshots, and the restore destination.</span>
   </a>
-  <a class="hfl-doc-card" href="/en/docs/troubleshooting/insights">
+  <a class="hfl-doc-card" href="/docs/troubleshooting/insights">
     <small>Insights</small>
     <strong>Data Gateway or AI Copilot unavailable</strong>
     <span>Check models, snapshot scope, the Public or Private Data Gateway, and data-preparation status.</span>

--- a/website/en/docs/troubleshooting/insights.md
+++ b/website/en/docs/troubleshooting/insights.md
@@ -26,7 +26,7 @@ If <span class="hfl-ui">Automatic</span> reports that no Public Data Gateway is 
 - Confirm that its version is compatible with the control plane.
 - Check free disk space on the gateway host.
 
-If installation did not finish, see [Installation and nodes](/en/docs/troubleshooting/installation-nodes).
+If installation did not finish, see [Installation and nodes](/docs/troubleshooting/installation-nodes).
 
 ## Data preparation does not complete
 

--- a/website/en/docs/troubleshooting/installation-nodes.md
+++ b/website/en/docs/troubleshooting/installation-nodes.md
@@ -13,7 +13,7 @@ Check each of the following:
 
 - The host runs Ubuntu 20.04, 22.04, or 24.04 on amd64.
 - The installer was run through `sudo`.
-- Docker Engine and Compose V2 meet the [system requirements](/en/docs/deployment/requirements) and are running.
+- Docker Engine and Compose V2 meet the [system requirements](/docs/deployment/requirements) and are running.
 - CPU, memory, and free space on `/opt` meet the requirements.
 - No other process is using `11442–11445/TCP`.
 - The host can reach GitHub, the container registry, and Ubuntu package repositories.
@@ -46,4 +46,4 @@ Do not delete the node data directory simply to register it again. If its local 
 - Confirm that the host can reach the control plane and the backup repositories it needs.
 - Use the failed installer stage to check download access, free space, or AI engine installation.
 
-See [Deploy a Private Data Gateway](/en/docs/deployment/data-gateway) for deployment requirements and steps.
+See [Deploy a Private Data Gateway](/docs/deployment/data-gateway) for deployment requirements and steps.


### PR DESCRIPTION
## Summary

- serve the English website at `/` and English documentation at `/docs/`
- keep the Chinese website at `/zh/` and Chinese documentation at `/zh/docs/`
- remove the legacy `/en/` publication route and align Website links, Nginx, installer output, health checks, analytics, and deployment contracts
- preserve page-specific language switching, including fallback behavior for Chinese-only documentation
- use a balanced two-column login layout on desktop and restore a single-column layout below 1280 px

## Route contract

- `/` — English homepage
- `/docs/` — English documentation
- `/zh/` — Chinese homepage
- `/zh/docs/` — Chinese documentation
- `/en/` — not published

## Validation

- Website production build
- frontend ESLint and production build
- 37 login and authentication tests
- English source boundary checks
- Website runtime and Google Analytics configuration checks
- lifecycle output, release contract, and Community online-install tests
- browser verification at 375, 768, 1279, 1280, 1440, and 1920 px
- `git diff --check`