### PR TITLE
Use pinned upstream runtime images for online deployments

### DIFF
--- a/.github/workflows/enterprise_saas_upgrade.yml
+++ b/.github/workflows/enterprise_saas_upgrade.yml
@@ -163,6 +163,7 @@ jobs:
             release/ci/mirror-saas-image.sh \
             release/ci/prepare-saas-asset-context.sh \
             release/ci/write-saas-image-metadata.sh \
+            release/ci/write-upstream-image-metadata.sh \
             .github/scripts/remote-saas-deploy.sh \
             .github/scripts/reconcile-saas-ai-model.sh
           ./tools/quality/check-release-contracts.sh
@@ -176,8 +177,7 @@ jobs:
     needs:
       - prepare
       - build-hfl-images
-      - build-sourcelens-images
-      - publish-runtime-images
+      - resolve-upstream-images
       - publish-agent-assets
       - publish-gateway-assets
       - publish-language-assets
@@ -342,125 +342,53 @@ jobs:
           path: ${{ matrix.metadata_component }}.json
           retention-days: 3
 
-  build-sourcelens-images:
-    name: Build · SourceLens · ${{ matrix.component }}
-    needs: [prepare, quality]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 120
-    strategy:
-      fail-fast: false
-      matrix:
-        component: [backend, frontend, lensnode]
-    steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        with:
-          persist-credentials: false
-          ref: ${{ needs.prepare.outputs.commit }}
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.CN_REGISTRY_HOST }}
-          username: ${{ secrets.CN_REGISTRY_USERNAME }}
-          password: ${{ secrets.CN_REGISTRY_PASSWORD }}
-      - name: Build global image
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          # Public online installs address the tested SourceLens bundle with the
-          # HFL tag. The existing Release workflow keeps its compound SL tag.
-          SOURCELENS_DISTRIBUTION_TAG_OVERRIDE: ${{ needs.prepare.outputs.version }}
-          SENTRY_URL: ${{ vars.SENTRY_URL }}
-          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
-          SENTRY_FRONTEND_PROJECT: ${{ vars.SENTRY_FRONTEND_PROJECT }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        run: >-
-          ./release/ci/build-sourcelens-image.sh
-          "${{ matrix.component }}" "$REGISTRY_PREFIX"
-          "${{ needs.prepare.outputs.version }}" source.json
-      - name: Mirror to CN and normalize metadata
-        shell: bash
-        run: |
-          set -euo pipefail
-          global_ref="$(jq -r '.ref' source.json)"
-          digest="$(jq -r '.digest' source.json)"
-          tag="${global_ref##*:}"
-          repository="hyperfilelens-sourcelens-${{ matrix.component }}"
-          cn_ref="$CN_REGISTRY_PREFIX/$repository:$tag"
-          ./release/ci/mirror-saas-image.sh "$global_ref" "$digest" "$cn_ref"
-          ./release/ci/write-saas-image-metadata.sh \
-            "sourcelens-${{ matrix.component }}" "$global_ref" "$cn_ref" "$digest" \
-            "$repository:$tag" "sourcelens-${{ matrix.component }}" \
-            "sourcelens-${{ matrix.component }}.json"
-          jq -s '.[0] * .[1]' source.json "sourcelens-${{ matrix.component }}.json" \
-            > merged.json
-          mv merged.json "sourcelens-${{ matrix.component }}.json"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: saas-metadata-sourcelens-${{ matrix.component }}
-          path: sourcelens-${{ matrix.component }}.json
-          retention-days: 3
-
-  publish-runtime-images:
-    name: Publish · Runtime · ${{ matrix.component }}
+  resolve-upstream-images:
+    name: Verify · Upstream · ${{ matrix.component }}
     needs: [prepare, quality]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - component: postgres
-            repository: hyperfilelens-postgres
-            tag: "17"
-            role: shared
-          - component: redis
-            repository: hyperfilelens-redis
-            tag: alpine
-            role: shared
-          - component: sourcelens-nginx
-            repository: hyperfilelens-sourcelens-nginx
-            tag: stable-alpine
-            role: sourcelens-nginx
+        component:
+          - sourcelens-backend
+          - sourcelens-frontend
+          - sourcelens-lensnode
+          - sourcelens-nginx
+          - postgres
+          - redis
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.CN_REGISTRY_HOST }}
-          username: ${{ secrets.CN_REGISTRY_USERNAME }}
-          password: ${{ secrets.CN_REGISTRY_PASSWORD }}
-      - name: Publish pinned runtime image
+      - name: Verify regional sources and record metadata
         shell: bash
         run: |
           set -euo pipefail
-          source tools/dependencies/versions/runtime-images.env
-          case "${{ matrix.component }}" in
-            postgres) source_image="$POSTGRES_IMAGE" ;;
-            redis) source_image="$REDIS_IMAGE" ;;
-            sourcelens-nginx) source_image="$NGINX_IMAGE" ;;
-          esac
-          digest="$source_image"
-          digest="${digest##*@}"
-          global_ref="$REGISTRY_PREFIX/${{ matrix.repository }}:${{ matrix.tag }}"
-          cn_ref="$CN_REGISTRY_PREFIX/${{ matrix.repository }}:${{ matrix.tag }}"
-          docker buildx imagetools create --prefer-index=false --tag "$global_ref" "$source_image"
-          ./release/ci/mirror-saas-image.sh "$global_ref" "$digest" "$cn_ref"
-          ./release/ci/write-saas-image-metadata.sh \
-            "${{ matrix.component }}" "$global_ref" "$cn_ref" "$digest" \
-            "${{ matrix.repository }}:${{ matrix.tag }}" "${{ matrix.role }}" \
-            "${{ matrix.component }}.json"
+          metadata="${{ matrix.component }}.json"
+          ./release/ci/write-upstream-image-metadata.sh \
+            "${{ matrix.component }}" "$metadata"
+          expected="$(jq -r '.digest' "$metadata")"
+          while IFS= read -r ref; do
+            immutable_ref="${ref%:*}@$expected"
+            manifest="$(docker buildx imagetools inspect "$immutable_ref" --format '{{json .Manifest}}')"
+            actual="$(jq -r '.digest // empty' <<<"$manifest")"
+            [[ "$actual" == "$expected" ]] || {
+              printf 'ERROR: upstream digest mismatch for %s (%s != %s)\n' \
+                "$immutable_ref" "${actual:-missing}" "$expected" >&2
+              exit 1
+            }
+            image_config="$(docker buildx imagetools inspect \
+              "$immutable_ref" --format '{{json .Image}}')"
+            jq -e '(.os == "linux" and .architecture == "amd64")
+              or has("linux/amd64")' <<<"$image_config" >/dev/null || {
+              printf 'ERROR: upstream image has no linux/amd64 variant: %s\n' \
+                "$immutable_ref" >&2
+              exit 1
+            }
+          done < <(jq -r '.sources[].ref' "$metadata" | sort -u)
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: saas-metadata-${{ matrix.component }}
@@ -648,7 +576,7 @@ jobs:
     name: Publish · Gateway assets
     needs:
       - prepare
-      - build-sourcelens-images
+      - resolve-upstream-images
       - build-host-assets
     runs-on: ubuntu-24.04
     timeout-minutes: 90
@@ -792,8 +720,7 @@ jobs:
     needs:
       - prepare
       - build-hfl-images
-      - build-sourcelens-images
-      - publish-runtime-images
+      - resolve-upstream-images
       - publish-agent-assets
       - publish-gateway-assets
       - publish-language-assets
@@ -810,11 +737,6 @@ jobs:
           pattern: saas-metadata-*
           path: build/saas-metadata
           merge-multiple: true
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY_HOST }}
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Resolve Enterprise Extension name
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
@@ -833,8 +755,6 @@ jobs:
               --print-extensions)"
           echo "HFL_EXTENSIONS=$extensions" >>"$GITHUB_ENV"
       - name: Assemble thin Candidate
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
           mkdir -p build/saas-candidate
           ./release/ci/assemble-saas-candidate.sh \

--- a/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
+++ b/deploy/bootstrap/gateway-install-lensnode-sidecar.sh
@@ -269,13 +269,37 @@ prepare_sentry_privacy_adapter() {
 prepare_sentry_privacy_adapter
 
 resolve_lensnode_image() {
-	local candidate
-	if [[ -n "${LENSNODE_IMAGE:-}" ]] && docker image inspect "${LENSNODE_IMAGE}" >/dev/null 2>&1; then
-		printf '%s' "${LENSNODE_IMAGE}"
-		return 0
-	fi
+	local candidate compatibility_id candidate_id
 	if command -v docker >/dev/null 2>&1; then
+		if [[ -n "${LENSNODE_IMAGE:-}" \
+			&& "${LENSNODE_IMAGE}" != "hyperfilelens-sourcelens-lensnode:latest" \
+			&& "${LENSNODE_IMAGE}" != "sourcelens-lensnode:latest" \
+			&& "${LENSNODE_IMAGE}" != "oneprocloud/sourcelens-lensnode:latest" ]]; then
+			if docker image inspect "${LENSNODE_IMAGE}" >/dev/null 2>&1; then
+				printf '%s' "${LENSNODE_IMAGE}"
+				return 0
+			fi
+		fi
+		compatibility_id="$(docker image inspect "${LENSNODE_IMAGE:-${DEFAULT_LENSNODE_IMAGE}}" \
+			--format '{{.Id}}' 2>/dev/null || true)"
+		if [[ -n "${compatibility_id}" ]]; then
+			while IFS= read -r candidate; do
+				[[ -n "${candidate}" ]] || continue
+				candidate_id="$(docker image inspect "${candidate}" \
+					--format '{{.Id}}' 2>/dev/null || true)"
+				if [[ "${candidate_id}" == "${compatibility_id}" ]]; then
+					printf '%s' "${candidate}"
+					return 0
+				fi
+			done < <(
+				docker image ls oneprolabs/sourcelens-lensnode \
+					--format '{{.Repository}}:{{.Tag}}' 2>/dev/null \
+					| grep -E '^oneprolabs/sourcelens-lensnode:[0-9]+\.[0-9]+\.[0-9]+$' \
+					| sort -Vr || true
+			)
+		fi
 		for candidate in \
+			"${LENSNODE_IMAGE:-}" \
 			hyperfilelens-sourcelens-lensnode:latest \
 			sourcelens-lensnode:latest \
 			oneprocloud/sourcelens-lensnode:latest \

--- a/deploy/bootstrap/gateway-lifecycle.sh
+++ b/deploy/bootstrap/gateway-lifecycle.sh
@@ -41,6 +41,7 @@ SIDECAR_INSTALL_SCRIPT="gateway-install-lensnode-sidecar.sh"
 COMPOSE_PROJECT="hyperfilelens-gateway"
 DEFAULT_LENSNODE_IMAGE="hyperfilelens-sourcelens-lensnode:latest"
 OWNED_LENSNODE_IMAGES=("${DEFAULT_LENSNODE_IMAGE}")
+RESOLVED_LENSNODE_IMAGE="${DEFAULT_LENSNODE_IMAGE}"
 MIN_COMPOSE_VERSION="${HFL_COMPOSE_MIN_VERSION:-2.20.0}"
 COMPOSE=()
 
@@ -476,12 +477,32 @@ lensnode_image_supports_insecure_tls() {
 }
 
 load_lensnode_image() {
-	local work_dir=$1 ref
+	local work_dir=$1 ref upstream_ref compatibility_id candidate candidate_id
 	local archive="${work_dir}/${LENSNODE_IMAGE_ARCHIVE}"
 	download_bootstrap_file "${LENSNODE_IMAGE_ARCHIVE}" "${archive}"
 	hfl_log "Loading AI engine container image."
 	docker load -i "${archive}"
+	compatibility_id="$(docker image inspect "${DEFAULT_LENSNODE_IMAGE}" \
+		--format '{{.Id}}' 2>/dev/null || true)"
+	upstream_ref=""
+	if [[ -n "${compatibility_id}" ]]; then
+		while IFS= read -r candidate; do
+			[[ -n "${candidate}" ]] || continue
+			candidate_id="$(docker image inspect "${candidate}" \
+				--format '{{.Id}}' 2>/dev/null || true)"
+			if [[ "${candidate_id}" == "${compatibility_id}" ]]; then
+				upstream_ref="${candidate}"
+				break
+			fi
+		done < <(
+			docker image ls oneprolabs/sourcelens-lensnode \
+				--format '{{.Repository}}:{{.Tag}}' 2>/dev/null \
+				| grep -E '^oneprolabs/sourcelens-lensnode:[0-9]+\.[0-9]+\.[0-9]+$' \
+				| sort -Vr || true
+		)
+	fi
 	for ref in \
+		"${upstream_ref}" \
 		"${DEFAULT_LENSNODE_IMAGE}" \
 		sourcelens-lensnode:latest \
 		oneprocloud/sourcelens-lensnode:latest; do
@@ -489,6 +510,7 @@ load_lensnode_image() {
 			if ! lensnode_image_supports_insecure_tls "${ref}"; then
 				hfl_fail "AI engine image ${ref} is missing configurable TLS verification support" 5
 			fi
+			RESOLVED_LENSNODE_IMAGE="${ref}"
 			return 0
 		fi
 	done
@@ -503,7 +525,7 @@ run_sidecar_install_script() {
 	HFL_GATEWAY_COMPOSE_DIR="${COMPOSE_DIR}" \
 	HFL_AGENT_ROOT="${AGENT_ROOT}" \
 		HFL_INSECURE_TLS="${HFL_INSECURE_TLS}" \
-		LENSNODE_IMAGE="${DEFAULT_LENSNODE_IMAGE}" \
+		LENSNODE_IMAGE="${RESOLVED_LENSNODE_IMAGE}" \
 		bash "${script}"
 }
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -199,7 +199,7 @@ services:
     profiles: ["green"]
 
   postgres:
-    image: hyperfilelens-postgres:17
+    image: ${HFL_POSTGRES_IMAGE:-hyperfilelens-postgres:17}
     pull_policy: never
     restart: unless-stopped
     env_file:
@@ -228,7 +228,7 @@ services:
     cpus: 0.50
 
   redis:
-    image: hyperfilelens-redis:alpine
+    image: ${HFL_REDIS_IMAGE:-hyperfilelens-redis:alpine}
     pull_policy: never
     restart: unless-stopped
     volumes:

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -1933,10 +1933,29 @@ if delivery_mode == "registry":
         sources = image.get("sources") or []
         if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", role):
             raise SystemExit("registry delivery has an invalid image role")
-        if not re.fullmatch(
-            r"hyperfilelens-[a-z0-9-]+:[A-Za-z0-9][A-Za-z0-9._-]{0,127}",
-            local_ref,
-        ):
+        valid_local_ref = False
+        if role == "hyperfilelens":
+            valid_local_ref = bool(
+                re.fullmatch(
+                    r"hyperfilelens-(?:backend|frontend):"
+                    r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}",
+                    local_ref,
+                )
+            )
+        elif role in {"sourcelens-backend", "sourcelens-frontend"}:
+            component = role[len("sourcelens-") :]
+            valid_local_ref = bool(
+                re.fullmatch(
+                    rf"oneprolabs/sourcelens-{component}:"
+                    r"[0-9]+\.[0-9]+\.[0-9]+",
+                    local_ref,
+                )
+            )
+        elif role == "sourcelens-nginx":
+            valid_local_ref = local_ref == "nginx:stable-alpine"
+        elif role == "shared":
+            valid_local_ref = local_ref in {"postgres:17", "redis:alpine"}
+        if not valid_local_ref:
             raise SystemExit(f"registry delivery has an invalid local image ref: {local_ref}")
         if local_ref not in declared_refs or local_ref in seen_refs:
             raise SystemExit(f"registry delivery has an undeclared or duplicate image ref: {local_ref}")
@@ -3553,6 +3572,14 @@ import sys
 with open(f"{sys.argv[1]}/MANIFEST.json", encoding="utf-8") as fh:
     manifest = json.load(fh)
 seen = set()
+
+
+def installer_owned_ref(ref):
+    repository = ref.split("@", 1)[0].rsplit(":", 1)[0]
+    name = repository.rsplit("/", 1)[-1]
+    return name.startswith("hyperfilelens-")
+
+
 entries = list(manifest.get("images", []))
 entries.extend(
     {"refs": [entry.get("local_ref", "")]}
@@ -3563,7 +3590,10 @@ for entry in entries:
         continue
     for ref in entry.get("refs", []):
         tag = ref.split("@", 1)[0]
-        if not tag:
+        # Upstream and Docker Library tags are shared host caches rather than
+        # installer-owned artifacts. Removing them could disrupt unrelated
+        # containers on the same host, so only clean HFL-owned image names.
+        if not tag or not installer_owned_ref(tag):
             continue
         if tag in seen:
             continue
@@ -4072,12 +4102,24 @@ import sys
 with open(sys.argv[1], encoding="utf-8") as fh:
     manifest = json.load(fh)
 seen = set()
+
+
+def installer_owned_ref(ref):
+    repository = ref.split("@", 1)[0].rsplit(":", 1)[0]
+    name = repository.rsplit("/", 1)[-1]
+    return name.startswith("hyperfilelens-")
+
+
 for entry in manifest.get("images", []):
     role = entry.get("role", "")
     if not role.startswith("sourcelens"):
         continue
     for ref in entry.get("refs", []):
         tag = ref.split("@", 1)[0]
+        # New registry-backed releases use the upstream SourceLens and Docker
+        # Library names directly. Those shared tags are not owned by HFL.
+        if not installer_owned_ref(tag):
+            continue
         if tag in seen:
             continue
         seen.add(tag)
@@ -4283,13 +4325,29 @@ if deploy.is_dir():
     )
 digest = hashlib.sha256()
 
-# Registry transit references and rebuilt image IDs can change for every HFL
-# tag even while the bundled SourceLens release remains pinned. Only semantic
-# SourceLens identity belongs in the bundle fingerprint; runtime files below
-# capture HFL-owned integration changes.
+# Registry transit references and legacy rebuilt image IDs can change for every
+# HFL tag even while the bundled SourceLens release remains pinned. Preserve
+# their upstream identity, while digest-pinned upstream/public runtime images
+# participate directly in the fingerprint.
 build_info_path = root / "BUILD_INFO.json"
 if build_info_path.is_file():
     info = json.loads(build_info_path.read_text(encoding="utf-8"))
+    semantic_images = {}
+    embedded_lensnode = bool(info.get("embed_local_lensnode", False))
+    for name, image in sorted((info.get("images") or {}).items()):
+        if name == "lensnode" and not embedded_lensnode:
+            continue
+        if name not in {"backend", "frontend", "lensnode", "nginx", "postgres", "redis"}:
+            continue
+        ref = str((image or {}).get("ref") or "")
+        repository = ref.split("@", 1)[0].rsplit(":", 1)[0].rsplit("/", 1)[-1]
+        if repository.startswith("hyperfilelens-sourcelens-"):
+            semantic_images[name] = {}
+        else:
+            semantic_images[name] = {
+                "ref": ref,
+                "digest": str((image or {}).get("digest") or ""),
+            }
     identity = {
         "git_url": info.get("git_url", ""),
         "git_ref": info.get("git_ref", ""),
@@ -4302,6 +4360,7 @@ if build_info_path.is_file():
         "build_adapter_sha256": info.get("build_adapter_sha256", ""),
         "build_compose_file": info.get("build_compose_file", ""),
         "embed_local_lensnode": info.get("embed_local_lensnode", False),
+        "images": semantic_images,
     }
     digest.update(b"BUILD_INFO.identity\0")
     digest.update(

--- a/deploy/installer/sourcelens/docker-compose.template.yml
+++ b/deploy/installer/sourcelens/docker-compose.template.yml
@@ -150,7 +150,7 @@ services:
 # HFL_EMBED_LENSNODE_SERVICE_END
 
   nginx:
-    image: hyperfilelens-sourcelens-nginx:stable-alpine
+    image: __SOURCELENS_NGINX_IMAGE__
     pull_policy: never
     restart: unless-stopped
     volumes:
@@ -181,7 +181,7 @@ services:
     cpus: 0.50
 
   postgres:
-    image: hyperfilelens-postgres:17
+    image: __SOURCELENS_POSTGRES_IMAGE__
     pull_policy: never
     restart: unless-stopped
     env_file:
@@ -216,7 +216,7 @@ services:
     cpus: 0.50
 
   redis:
-    image: hyperfilelens-redis:alpine
+    image: __SOURCELENS_REDIS_IMAGE__
     pull_policy: never
     restart: unless-stopped
     command: redis-server

--- a/deploy/online/prepare.py
+++ b/deploy/online/prepare.py
@@ -32,27 +32,36 @@ CN_PREFIX = os.environ.get(
     "HFL_CN_REGISTRY_PREFIX",
     "registry.cn-beijing.aliyuncs.com/oneprolabs",
 ).rstrip("/")
+PUBLIC_GLOBAL_PREFIX = os.environ.get(
+    "HFL_PUBLIC_GLOBAL_REGISTRY_PREFIX", "docker.io/library"
+).rstrip("/")
+PUBLIC_CN_PREFIX = os.environ.get(
+    "HFL_PUBLIC_CN_REGISTRY_PREFIX", "docker.io/library"
+).rstrip("/")
 
 
 @dataclass(frozen=True)
 class ImageSpec:
-    """Describe one published image and its local runtime identity."""
+    """Describe one image source pair and its local runtime identity."""
 
     component: str
     role: str
-    repository: str
-    tag: str
+    local_ref: str
+    global_ref: str
+    cn_ref: str
+    expected_digest: str = ""
     asset_kind: str = ""
 
-    @property
-    def local_ref(self) -> str:
-        """Return the registry-independent image reference used by Compose."""
-        return f"{self.repository}:{self.tag}"
-
     def source_ref(self, region: str) -> str:
-        """Return the published source reference for a registry region."""
-        prefix = CN_PREFIX if region == "cn" else GLOBAL_PREFIX
-        return f"{prefix}/{self.repository}:{self.tag}"
+        """Return the declared source reference for a registry region."""
+        return self.cn_ref if region == "cn" else self.global_ref
+
+    def pull_ref(self, region: str) -> str:
+        """Return an immutable ref when the source has a pinned digest."""
+        source = self.source_ref(region)
+        if not self.expected_digest:
+            return source
+        return f"{source.rsplit(':', 1)[0]}@{self.expected_digest}"
 
 
 @dataclass(frozen=True)
@@ -192,6 +201,111 @@ def replace_env_values(path: pathlib.Path, values: dict[str, str]) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def load_sourcelens_runtime(source: pathlib.Path) -> dict[str, Any]:
+    """Load and validate the pinned upstream SourceLens image contract."""
+    path = source / "deploy/online/sourcelens/runtime.json"
+    runtime = json.loads(path.read_text(encoding="utf-8"))
+    version = str(runtime.get("version") or "")
+    images = runtime.get("images") or {}
+    git_ref = str(runtime.get("git_ref") or "")
+    git_commit = str(runtime.get("git_commit") or "")
+    if (
+        not VERSION_PATTERN.fullmatch(version)
+        or git_ref != f"v{version}"
+        or not REVISION_PATTERN.fullmatch(git_commit)
+        or set(images)
+        != {
+            "backend",
+            "frontend",
+            "lensnode",
+        }
+    ):
+        raise ValueError("SourceLens runtime image contract is incomplete")
+    for name, image in images.items():
+        digest = str(image.get("digest") or "")
+        local_ref = str(image.get("local_ref") or "")
+        sources = image.get("sources") or {}
+        if not DIGEST_PATTERN.fullmatch(digest):
+            raise ValueError(f"SourceLens {name} image digest is invalid")
+        if local_ref != f"oneprolabs/sourcelens-{name}:{version}":
+            raise ValueError(f"SourceLens {name} local image ref is invalid")
+        if sources != {
+            "cn": (
+                "registry.cn-beijing.aliyuncs.com/oneprolabs/"
+                f"sourcelens-{name}:{version}"
+            ),
+            "global": f"docker.io/oneprolabs/sourcelens-{name}:{version}",
+        }:
+            raise ValueError(f"SourceLens {name} image sources are incomplete")
+    return runtime
+
+
+def load_public_runtime_specs(source: pathlib.Path) -> list[ImageSpec]:
+    """Load pinned Docker Library images without evaluating shell code."""
+    path = source / "tools/dependencies/versions/runtime-images.env"
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        name, separator, value = line.partition("=")
+        if separator:
+            values[name] = value
+    definitions = (
+        ("postgres", "shared", "POSTGRES_IMAGE"),
+        ("redis", "shared", "REDIS_IMAGE"),
+        ("sourcelens-nginx", "sourcelens-nginx", "NGINX_IMAGE"),
+    )
+    specs: list[ImageSpec] = []
+    for component, role, variable in definitions:
+        pinned = values.get(variable, "")
+        local_ref, separator, digest = pinned.partition("@")
+        if not separator or not DIGEST_PATTERN.fullmatch(digest):
+            raise ValueError(f"{variable} must contain a pinned sha256 digest")
+        specs.append(
+            ImageSpec(
+                component,
+                role,
+                local_ref,
+                f"{PUBLIC_GLOBAL_PREFIX}/{local_ref}",
+                f"{PUBLIC_CN_PREFIX}/{local_ref}",
+                digest,
+            )
+        )
+    return specs
+
+
+def sourcelens_image_spec(runtime: dict[str, Any], name: str) -> ImageSpec:
+    """Build one ImageSpec from the SourceLens runtime contract."""
+    image = runtime["images"][name]
+    return ImageSpec(
+        f"sourcelens-{name}",
+        f"sourcelens-{name}",
+        image["local_ref"],
+        image["sources"]["global"],
+        image["sources"]["cn"],
+        image["digest"],
+    )
+
+
+def hfl_image_spec(
+    component: str,
+    role: str,
+    repository: str,
+    tag: str,
+    asset_kind: str = "",
+) -> ImageSpec:
+    """Build one HFL-owned regional image specification."""
+    return ImageSpec(
+        component,
+        role,
+        f"{repository}:{tag}",
+        f"{GLOBAL_PREFIX}/{repository}:{tag}",
+        f"{CN_PREFIX}/{repository}:{tag}",
+        asset_kind=asset_kind,
+    )
+
+
 def copy_runtime_files(
     source: pathlib.Path, target: pathlib.Path, version: str
 ) -> None:
@@ -208,6 +322,8 @@ def copy_runtime_files(
             "HFL_EDITION": "community",
             "HFL_BACKEND_IMAGE": f"hyperfilelens-backend:{version}",
             "HFL_FRONTEND_IMAGE": f"hyperfilelens-frontend:{version}",
+            "HFL_POSTGRES_IMAGE": "postgres:17",
+            "HFL_REDIS_IMAGE": "redis:alpine",
             "HFL_GATEWAY_VERSION": version,
             "HFL_RELEASE_CHANNEL": "release",
             "AGENT_VERSION": version,
@@ -252,9 +368,9 @@ def copy_runtime_files(
 def render_sourcelens_compose(
     template: pathlib.Path,
     destination: pathlib.Path,
-    version: str,
+    image_refs: dict[str, str],
 ) -> None:
-    """Render the shared SourceLens Compose template with HFL-versioned refs."""
+    """Render the shared SourceLens Compose template with upstream refs."""
     text = template.read_text(encoding="utf-8")
     for block in ("EMBED_BACKEND_ENV", "EMBED_LENSNODE_SERVICE"):
         pattern = re.compile(rf"(?ms)^# HFL_{block}_BEGIN\n(.*?)^# HFL_{block}_END\n")
@@ -262,13 +378,12 @@ def render_sourcelens_compose(
             raise ValueError(f"SourceLens template has an invalid {block} block")
         text = pattern.sub("", text)
     replacements = {
-        "__SOURCELENS_BACKEND_IMAGE__": (f"hyperfilelens-sourcelens-backend:{version}"),
-        "__SOURCELENS_FRONTEND_IMAGE__": (
-            f"hyperfilelens-sourcelens-frontend:{version}"
-        ),
-        "__SOURCELENS_LENSNODE_IMAGE__": (
-            f"hyperfilelens-sourcelens-lensnode:{version}"
-        ),
+        "__SOURCELENS_BACKEND_IMAGE__": image_refs["backend"],
+        "__SOURCELENS_FRONTEND_IMAGE__": image_refs["frontend"],
+        "__SOURCELENS_LENSNODE_IMAGE__": image_refs["lensnode"],
+        "__SOURCELENS_NGINX_IMAGE__": image_refs["nginx"],
+        "__SOURCELENS_POSTGRES_IMAGE__": image_refs["postgres"],
+        "__SOURCELENS_REDIS_IMAGE__": image_refs["redis"],
         "__SOURCELENS_CONSOLE_BIND_ADDRESS__": "0.0.0.0",
         "__SOURCELENS_CONSOLE_PORT__": "11445",
     }
@@ -279,7 +394,9 @@ def render_sourcelens_compose(
     destination.write_text(text, encoding="utf-8")
 
 
-def stage_sourcelens(source: pathlib.Path, target: pathlib.Path, version: str) -> None:
+def stage_sourcelens(
+    source: pathlib.Path, target: pathlib.Path, image_refs: dict[str, str]
+) -> None:
     """Stage the repository-owned SourceLens runtime tree."""
     online = source / "deploy/online/sourcelens"
     root = target / "sourcelens"
@@ -306,7 +423,7 @@ def stage_sourcelens(source: pathlib.Path, target: pathlib.Path, version: str) -
     render_sourcelens_compose(
         source / "deploy/installer/sourcelens/docker-compose.template.yml",
         root / "docker-compose.yml",
-        version,
+        image_refs,
     )
     shutil.copy2(online / "nginx/default.conf", root / "deploy/nginx/default.conf")
     shutil.copytree(
@@ -352,7 +469,7 @@ def image_digest(ref: str) -> str:
         capture_output=True,
     )
     values = json.loads((completed.stdout or "[]").strip())
-    repository_path = ref.rsplit(":", 1)[0].split("/", 1)[-1]
+    repository_path = ref.split("@", 1)[0].rsplit(":", 1)[0].split("/", 1)[-1]
     digests = {
         value.rsplit("@", 1)[-1]
         for value in values
@@ -386,7 +503,7 @@ def write_pull_plan(path: pathlib.Path, specs: list[ImageSpec], region: str) -> 
         lines.extend(
             (
                 f"  {spec.component}:",
-                f"    image: {json.dumps(spec.source_ref(region))}",
+                f"    image: {json.dumps(spec.pull_ref(region))}",
                 '    platform: "linux/amd64"',
             )
         )
@@ -428,10 +545,13 @@ def inspect_pulled_images(
     resolved: dict[str, ResolvedImage] = {}
     unresolved: list[ImageSpec] = []
     for spec in specs:
-        source_ref = spec.source_ref(region)
+        source_ref = spec.pull_ref(region)
         try:
             verify_image_platform(source_ref)
-            digest = image_digest(source_ref)
+            # Inspecting an immutable ref proves that Docker retained the
+            # requested manifest identity. Multi-arch pulls may expose both
+            # index and child RepoDigests, so do not require a singular value.
+            digest = spec.expected_digest or image_digest(source_ref)
         except (OSError, RuntimeError, ValueError, json.JSONDecodeError):
             unresolved.append(spec)
             continue
@@ -637,6 +757,7 @@ def write_sourcelens_build_info(
     source: pathlib.Path,
     target: pathlib.Path,
     runtime: list[ResolvedImage],
+    lensnode: ImageSpec,
 ) -> dict[str, Any]:
     """Write the semantic SourceLens bundle identity used by upgrades."""
     base = json.loads(
@@ -657,7 +778,7 @@ def write_sourcelens_build_info(
         "build_compose_file": "docker-compose.standalone.yml",
         "network": "hyperfilelens-bridge",
         "install_dir": "/opt/hyperfilelens/sourcelens",
-        "lensnode_image": by_component["sourcelens-lensnode"].spec.local_ref,
+        "lensnode_image": lensnode.local_ref,
         "embed_local_lensnode": False,
         "images": {
             name: {
@@ -667,14 +788,25 @@ def write_sourcelens_build_info(
                 ),
                 "digest": by_component[f"sourcelens-{name}"].digest,
             }
-            for name in ("backend", "frontend", "lensnode")
+            for name in ("backend", "frontend")
         },
     }
-    nginx = by_component["sourcelens-nginx"]
-    info["images"]["nginx"] = {
-        "ref": nginx.spec.local_ref,
-        "digest": nginx.digest,
+    info["images"]["lensnode"] = {
+        "ref": lensnode.local_ref,
+        "upstream_ref": lensnode.source_ref("global"),
+        "digest": lensnode.expected_digest,
     }
+    for name, component in (
+        ("nginx", "sourcelens-nginx"),
+        ("postgres", "postgres"),
+        ("redis", "redis"),
+    ):
+        image = by_component[component]
+        info["images"][name] = {
+            "ref": image.spec.local_ref,
+            "upstream_ref": image.spec.source_ref("global"),
+            "digest": image.digest,
+        }
     (target / "sourcelens/BUILD_INFO.json").write_text(
         json.dumps(info, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
@@ -777,40 +909,39 @@ def main() -> int:
     target.parent.mkdir(parents=True, exist_ok=True)
 
     copy_runtime_files(source, target, version)
-    stage_sourcelens(source, target, version)
+    sourcelens_runtime = load_sourcelens_runtime(source)
+    sourcelens_specs = [
+        sourcelens_image_spec(sourcelens_runtime, name)
+        for name in ("backend", "frontend")
+    ]
+    lensnode_spec = sourcelens_image_spec(sourcelens_runtime, "lensnode")
+    public_specs = load_public_runtime_specs(source)
+    public_by_component = {spec.component: spec for spec in public_specs}
+    stage_sourcelens(
+        source,
+        target,
+        {
+            "backend": sourcelens_specs[0].local_ref,
+            "frontend": sourcelens_specs[1].local_ref,
+            "lensnode": lensnode_spec.local_ref,
+            "nginx": public_by_component["sourcelens-nginx"].local_ref,
+            "postgres": public_by_component["postgres"].local_ref,
+            "redis": public_by_component["redis"].local_ref,
+        },
+    )
 
     runtime_specs = [
-        ImageSpec("hfl-backend", "hyperfilelens", "hyperfilelens-backend", version),
-        ImageSpec("hfl-frontend", "hyperfilelens", "hyperfilelens-frontend", version),
-        ImageSpec(
-            "sourcelens-backend",
-            "sourcelens-backend",
-            "hyperfilelens-sourcelens-backend",
-            version,
+        hfl_image_spec(
+            "hfl-backend", "hyperfilelens", "hyperfilelens-backend", version
         ),
-        ImageSpec(
-            "sourcelens-frontend",
-            "sourcelens-frontend",
-            "hyperfilelens-sourcelens-frontend",
-            version,
+        hfl_image_spec(
+            "hfl-frontend", "hyperfilelens", "hyperfilelens-frontend", version
         ),
-        ImageSpec(
-            "sourcelens-lensnode",
-            "sourcelens-lensnode",
-            "hyperfilelens-sourcelens-lensnode",
-            version,
-        ),
-        ImageSpec(
-            "sourcelens-nginx",
-            "sourcelens-nginx",
-            "hyperfilelens-sourcelens-nginx",
-            "stable-alpine",
-        ),
-        ImageSpec("postgres", "shared", "hyperfilelens-postgres", "17"),
-        ImageSpec("redis", "shared", "hyperfilelens-redis", "alpine"),
+        *sourcelens_specs,
+        *public_specs,
     ]
     asset_specs = [
-        ImageSpec(
+        hfl_image_spec(
             f"{kind}-assets",
             f"{kind}-assets",
             f"hyperfilelens-{kind}-assets",
@@ -842,7 +973,7 @@ def main() -> int:
         finally:
             discard_asset_image(asset)
         print(f"[ OK ] {label} are ready", flush=True)
-    sourcelens = write_sourcelens_build_info(source, target, runtime)
+    sourcelens = write_sourcelens_build_info(source, target, runtime, lensnode_spec)
     write_manifest(target, version, revision, runtime, assets, sourcelens)
     print(f"[ OK ] Community release package prepared · {target}")
     return 0

--- a/deploy/online/sourcelens/runtime.json
+++ b/deploy/online/sourcelens/runtime.json
@@ -1,5 +1,31 @@
 {
   "git_commit": "d94685d979bd0b105b9f23e5df86fbdcd94869a6",
   "git_ref": "v0.49.5",
+  "images": {
+    "backend": {
+      "digest": "sha256:b4fd19ea5bd3fed17e4c22eb44d4f4178181c33c29cc6ed956484642735408b8",
+      "local_ref": "oneprolabs/sourcelens-backend:0.49.5",
+      "sources": {
+        "cn": "registry.cn-beijing.aliyuncs.com/oneprolabs/sourcelens-backend:0.49.5",
+        "global": "docker.io/oneprolabs/sourcelens-backend:0.49.5"
+      }
+    },
+    "frontend": {
+      "digest": "sha256:2c183e50bc9e6281ea58ede269b3e7227f6e1bdf649a2c6b066cb5c651ecb802",
+      "local_ref": "oneprolabs/sourcelens-frontend:0.49.5",
+      "sources": {
+        "cn": "registry.cn-beijing.aliyuncs.com/oneprolabs/sourcelens-frontend:0.49.5",
+        "global": "docker.io/oneprolabs/sourcelens-frontend:0.49.5"
+      }
+    },
+    "lensnode": {
+      "digest": "sha256:b865673d640ff575883e8321d5bae18ebd7d975d2f9bae3660167fee28e74b69",
+      "local_ref": "oneprolabs/sourcelens-lensnode:0.49.5",
+      "sources": {
+        "cn": "registry.cn-beijing.aliyuncs.com/oneprolabs/sourcelens-lensnode:0.49.5",
+        "global": "docker.io/oneprolabs/sourcelens-lensnode:0.49.5"
+      }
+    }
+  },
   "version": "0.49.5"
 }

--- a/deploy/online/verify-public-images.sh
+++ b/deploy/online/verify-public-images.sh
@@ -52,6 +52,8 @@ for path in sorted(root.glob("*.json")):
             "sourcelens-frontend",
             "sourcelens-lensnode",
         }:
+            name = component[len("sourcelens-") :]
+            image_contract = (runtime.get("images") or {}).get(name) or {}
             for field, expected in {
                 "sourcelens_version": runtime["version"],
                 "sourcelens_git_ref": runtime["git_ref"],
@@ -61,6 +63,17 @@ for path in sorted(root.glob("*.json")):
                     raise SystemExit(
                         f"{component} {field} does not match the online contract"
                     )
+            expected_sources = image_contract.get("sources") or {}
+            actual_sources = {
+                str(source.get("region") or ""): str(source.get("ref") or "")
+                for source in metadata.get("sources") or []
+            }
+            if metadata.get("local_ref") != image_contract.get("local_ref"):
+                raise SystemExit(f"{component} local_ref does not match the online contract")
+            if metadata.get("digest") != image_contract.get("digest"):
+                raise SystemExit(f"{component} digest does not match the online contract")
+            if actual_sources != expected_sources:
+                raise SystemExit(f"{component} sources do not match the online contract")
             sourcelens_components.add(component)
         digest = str(metadata.get("digest") or "")
         sources = metadata.get("sources") or []
@@ -79,23 +92,26 @@ if sourcelens_components != {
     "sourcelens-lensnode",
 }:
     raise SystemExit("online SourceLens component metadata is incomplete")
-if len(selected) != 22:
-    raise SystemExit(f"expected 22 regional Community image refs, found {len(selected)}")
+# Docker Library has no first-party China registry, so its three immutable
+# refs are intentionally shared by both region entries.
+if len(selected) != 19:
+    raise SystemExit(f"expected 19 unique Community image refs, found {len(selected)}")
 for ref, digest in sorted(selected.items()):
     print(f"{ref}\t{digest}")
 PY
 
 while IFS=$'\t' read -r ref expected; do
 	[[ -n "${ref}" ]] || continue
-	printf '[....] Anonymous manifest check: %s\n' "${ref}"
+	immutable_ref="${ref%:*}@${expected}"
+	printf '[....] Anonymous manifest check: %s\n' "${immutable_ref}"
 	manifest="$(DOCKER_CONFIG="${docker_config}" timeout 60s \
-		docker buildx imagetools inspect "${ref}" --format '{{json .Manifest}}')"
+		docker buildx imagetools inspect "${immutable_ref}" --format '{{json .Manifest}}')"
 	actual="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("digest", ""))' \
 		<<<"${manifest}")"
 	[[ "${actual}" == "${expected}" ]] || {
 		printf 'ERROR: public image digest mismatch for %s (%s != %s)\n' \
-			"${ref}" "${actual:-missing}" "${expected}" >&2
+			"${immutable_ref}" "${actual:-missing}" "${expected}" >&2
 		exit 1
 	}
-	printf '[ OK ] Public image available: %s@%s\n' "${ref}" "${actual}"
+	printf '[ OK ] Public image available: %s\n' "${immutable_ref}"
 done <"${tasks}"

--- a/release/build.sh
+++ b/release/build.sh
@@ -554,7 +554,10 @@ stage_release_env_example() {
 	HFL_EXTENSIONS_RUNTIME="${HFL_EXTENSIONS_RUNTIME:-}" \
 		HFL_IMAGE_VERSION="${HFL_IMAGE_VERSION:-}" \
 		HFL_RELEASE_EDITION="${HFL_RELEASE_EDITION:-community}" \
-		HFL_VERSION="${HFL_VERSION:-}" python3 - "${example}" <<'PY'
+		HFL_VERSION="${HFL_VERSION:-}" \
+		HFL_RELEASE_POSTGRES_IMAGE="${HFL_RELEASE_POSTGRES_IMAGE:-}" \
+		HFL_RELEASE_REDIS_IMAGE="${HFL_RELEASE_REDIS_IMAGE:-}" \
+		python3 - "${example}" <<'PY'
 import os
 import pathlib
 import re
@@ -567,6 +570,8 @@ runtime = os.environ.get("HFL_EXTENSIONS_RUNTIME", "").strip()
 image_version = os.environ.get("HFL_IMAGE_VERSION", "").strip()
 product_version = os.environ.get("HFL_VERSION", "").strip()
 edition = os.environ.get("HFL_RELEASE_EDITION", "community").strip()
+postgres_image = os.environ.get("HFL_RELEASE_POSTGRES_IMAGE", "").strip()
+redis_image = os.environ.get("HFL_RELEASE_REDIS_IMAGE", "").strip()
 if image_version:
     replacements = {
         "APP_VERSION": image_version,
@@ -579,6 +584,17 @@ if image_version:
         text = re.sub(
             rf"(?m)^{re.escape(key)}=.*$", f"{key}={value}", text, count=1
         )
+for key, value in {
+    "HFL_POSTGRES_IMAGE": postgres_image,
+    "HFL_REDIS_IMAGE": redis_image,
+}.items():
+    if not value:
+        continue
+    pattern = rf"(?m)^{re.escape(key)}=.*$"
+    if re.search(pattern, text):
+        text = re.sub(pattern, f"{key}={value}", text, count=1)
+    else:
+        text = text.rstrip() + f"\n{key}={value}\n"
 if runtime:
     block = (
         "\n# Baked into this release's control-plane images (Open Core).\n"

--- a/release/ci/assemble-saas-candidate.sh
+++ b/release/ci/assemble-saas-candidate.sh
@@ -6,8 +6,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=../build.sh
 source "${ROOT}/release/build.sh"
-# shellcheck source=../../tools/dependencies/versions/runtime-images.env
-source "${ROOT}/tools/dependencies/versions/runtime-images.env"
 
 [[ $# -eq 6 ]] || {
 	printf 'Usage: %s METADATA_DIR VERSION OSS_COMMIT EE_COMMIT EXTENSIONS OUTPUT\n' "$0" >&2
@@ -54,29 +52,61 @@ mkdir -p \
 	"${pkg_root}/deploy/blue-green" \
 	"${pkg_root}/deploy/logrotate"
 
-pull_and_tag() {
-	local metadata=$1 source_ref digest local_ref immutable_ref
-	source_ref="$(jq -r '.sources[] | select(.region == "global") | .ref' "${metadata}")"
-	digest="$(jq -r '.digest' "${metadata}")"
-	local_ref="$(jq -r '.local_ref' "${metadata}")"
-	immutable_ref="${source_ref%:*}@${digest}"
-	docker pull --platform linux/amd64 "${immutable_ref}"
-	docker tag "${immutable_ref}" "${local_ref}"
-}
+python3 - "${ROOT}" "${pkg_root}" "${metadata_dir}" <<'PY'
+import json
+import pathlib
+import runpy
+import sys
 
-for component in sourcelens-backend sourcelens-frontend sourcelens-lensnode; do
-	pull_and_tag "${metadata_dir}/${component}.json"
-done
-docker pull --platform linux/amd64 "${NGINX_IMAGE}"
-docker tag "${NGINX_IMAGE}" nginx:stable-alpine
+root = pathlib.Path(sys.argv[1])
+package = pathlib.Path(sys.argv[2])
+metadata_root = pathlib.Path(sys.argv[3])
+online = runpy.run_path(str(root / "deploy/online/prepare.py"))
 
-export SOURCELENS_HFL_VERSION="${version}"
-SOURCELENS_DISTRIBUTION_TAG_OVERRIDE="${version}" \
-	BUILD_SOURCELENS=1 "${ROOT}/release/build-sourcelens.sh" \
-	--pkg-root "${pkg_root}" \
-	--images-dir "${images_dir}" \
-	--prebuilt \
-	--runtime-only
+
+def read(name):
+    return json.loads((metadata_root / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def resolved(name):
+    entry = read(name)
+    sources = {source["region"]: source["ref"] for source in entry["sources"]}
+    spec = online["ImageSpec"](
+        entry["component"],
+        entry["role"],
+        entry["local_ref"],
+        sources["global"],
+        sources["cn"],
+        entry["digest"],
+    )
+    return online["ResolvedImage"](spec, entry["digest"], sources["global"])
+
+
+backend = resolved("sourcelens-backend")
+frontend = resolved("sourcelens-frontend")
+lensnode = resolved("sourcelens-lensnode")
+nginx = resolved("sourcelens-nginx")
+postgres = resolved("postgres")
+redis = resolved("redis")
+online["stage_sourcelens"](
+    root,
+    package,
+    {
+        "backend": backend.spec.local_ref,
+        "frontend": frontend.spec.local_ref,
+        "lensnode": lensnode.spec.local_ref,
+        "nginx": nginx.spec.local_ref,
+        "postgres": postgres.spec.local_ref,
+        "redis": redis.spec.local_ref,
+    },
+)
+online["write_sourcelens_build_info"](
+    root,
+    package,
+    [backend, frontend, nginx, postgres, redis],
+    lensnode.spec,
+)
+PY
 
 printf '%s\n' "${version}" >"${pkg_root}/VERSION"
 cp "${ROOT}/deploy/docker-compose.yml" "${pkg_root}/docker-compose.yml"
@@ -84,6 +114,8 @@ HFL_RELEASE_EDITION=enterprise \
 	HFL_IMAGE_VERSION="${version}-ee" \
 	HFL_VERSION="${version}" \
 	HFL_EXTENSIONS_RUNTIME="${extensions}" \
+	HFL_RELEASE_POSTGRES_IMAGE="postgres:17" \
+	HFL_RELEASE_REDIS_IMAGE="redis:alpine" \
 	stage_release_env_example "${pkg_root}"
 stage_default_tls_bundle "${pkg_root}"
 cp "${ROOT}/deploy/nginx/default.conf" "${pkg_root}/deploy/nginx/default.conf"
@@ -119,7 +151,6 @@ runtime = [
     read("hfl-frontend"),
     read("sourcelens-backend"),
     read("sourcelens-frontend"),
-    read("sourcelens-lensnode"),
     read("sourcelens-nginx"),
     read("postgres"),
     read("redis"),

--- a/release/ci/prepare-saas-asset-context.sh
+++ b/release/ci/prepare-saas-asset-context.sh
@@ -87,14 +87,16 @@ gateway)
 	[[ -s "${metadata}" ]]
 	ref="$(jq -r '.sources[] | select(.region == "global") | .ref' "${metadata}")"
 	digest="$(jq -r '.digest' "${metadata}")"
+	local_ref="$(jq -r '.local_ref' "${metadata}")"
 	immutable_ref="${ref%:*}@${digest}"
 	docker pull --platform linux/amd64 "${immutable_ref}"
+	[[ "$(docker image inspect "${immutable_ref}" --format '{{.Os}}/{{.Architecture}}')" == "linux/amd64" ]]
+	docker tag "${immutable_ref}" "${local_ref}"
+	# Preserve the historical local tag for already-installed Agent binaries.
+	# It remains inside the archive and is never pushed as a registry image.
 	docker tag "${immutable_ref}" hyperfilelens-sourcelens-lensnode:latest
-	docker tag "${immutable_ref}" sourcelens-lensnode:latest
 	partial="${gateway_dir}/lensnode-image-linux-amd64.tar.gz.part"
-	# The Gateway bundle uses stable local aliases. Omitting the HFL-versioned
-	# runtime tag keeps this large layer reusable while the SourceLens image is unchanged.
-	docker save hyperfilelens-sourcelens-lensnode:latest sourcelens-lensnode:latest \
+	docker save "${local_ref}" hyperfilelens-sourcelens-lensnode:latest \
 		| gzip -1 -n >"${partial}"
 	mv "${partial}" "${gateway_dir}/lensnode-image-linux-amd64.tar.gz"
 	;;

--- a/release/ci/write-upstream-image-metadata.sh
+++ b/release/ci/write-upstream-image-metadata.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Write immutable registry metadata for one upstream runtime image.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+[[ $# -eq 2 ]] || {
+	printf 'Usage: %s COMPONENT OUTPUT\n' "$0" >&2
+	exit 2
+}
+
+component=$1
+output=$2
+global_ref=""
+cn_ref=""
+local_ref=""
+digest=""
+role=""
+
+case "${component}" in
+sourcelens-backend | sourcelens-frontend | sourcelens-lensnode)
+	name=${component#sourcelens-}
+	readarray -t values < <(python3 - \
+		"${ROOT}/deploy/online/sourcelens/runtime.json" "${name}" <<'PY'
+import json
+import pathlib
+import sys
+
+runtime = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+name = sys.argv[2]
+image = (runtime.get("images") or {}).get(name) or {}
+sources = image.get("sources") or {}
+for value in (
+    image.get("local_ref"),
+    image.get("digest"),
+    sources.get("global"),
+    sources.get("cn"),
+    runtime.get("version"),
+    runtime.get("git_ref"),
+    runtime.get("git_commit"),
+):
+    print(str(value or ""))
+PY
+	)
+	[[ ${#values[@]} -eq 7 ]]
+	local_ref=${values[0]}
+	digest=${values[1]}
+	global_ref=${values[2]}
+	cn_ref=${values[3]}
+	role=${component}
+	;;
+postgres | redis | sourcelens-nginx)
+	# shellcheck source=../../tools/dependencies/versions/runtime-images.env
+	source "${ROOT}/tools/dependencies/versions/runtime-images.env"
+	case "${component}" in
+	postgres) pinned=${POSTGRES_IMAGE}; role=shared ;;
+	redis) pinned=${REDIS_IMAGE}; role=shared ;;
+	sourcelens-nginx) pinned=${NGINX_IMAGE}; role=sourcelens-nginx ;;
+	esac
+	local_ref=${pinned%@*}
+	digest=${pinned##*@}
+	global_ref="docker.io/library/${local_ref}"
+	# Docker Library has no first-party China registry. Third-party accelerators
+	# may rewrite manifests, so the formal digest-pinned contract uses Docker Hub
+	# for both regions instead of weakening identity verification.
+	cn_ref="docker.io/library/${local_ref}"
+	;;
+*)
+	printf 'ERROR: unsupported upstream image component: %s\n' "${component}" >&2
+	exit 2
+	;;
+esac
+
+[[ "${component}" =~ ^[a-z0-9][a-z0-9-]*$ ]]
+[[ "${role}" =~ ^[a-z0-9][a-z0-9-]*$ ]]
+[[ "${global_ref}" == */*:* && "${cn_ref}" == */*:* ]]
+[[ "${local_ref}" =~ ^[a-z0-9][a-z0-9._/-]*:[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ \
+	&& "${local_ref}" != *//* && "${local_ref}" != *..* ]]
+[[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+mkdir -p "$(dirname "${output}")"
+jq -n \
+	--arg component "${component}" \
+	--arg role "${role}" \
+	--arg local_ref "${local_ref}" \
+	--arg digest "${digest}" \
+	--arg global_ref "${global_ref}" \
+	--arg cn_ref "${cn_ref}" \
+	'{
+	  component: $component,
+	  role: $role,
+	  local_ref: $local_ref,
+	  digest: $digest,
+	  platform: "linux/amd64",
+	  sources: [
+	    {region: "cn", ref: $cn_ref},
+	    {region: "global", ref: $global_ref}
+	  ]
+	}' >"${output}"
+
+if [[ "${component}" == "sourcelens-backend" \
+	|| "${component}" == "sourcelens-frontend" \
+	|| "${component}" == "sourcelens-lensnode" ]]; then
+	temporary="${output}.tmp"
+	jq \
+		--arg version "${values[4]}" \
+		--arg git_ref "${values[5]}" \
+		--arg git_commit "${values[6]}" \
+		'. + {
+		  sourcelens_version: $version,
+		  sourcelens_git_ref: $git_ref,
+		  sourcelens_git_commit: $git_commit
+		}' "${output}" >"${temporary}"
+	mv "${temporary}" "${output}"
+fi

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1633,7 +1633,8 @@ if grep -F -- '--network host' "${smoke_runner}" >/dev/null; then
 	printf 'ERROR: browser smoke must reach published ports through host-gateway\n' >&2
 	exit 1
 fi
-grep -F 'image: hyperfilelens-postgres:17' "${ROOT}/deploy/docker-compose.yml" >/dev/null
+grep -F 'image: ${HFL_POSTGRES_IMAGE:-hyperfilelens-postgres:17}' \
+	"${ROOT}/deploy/docker-compose.yml" >/dev/null
 grep -F 'absolute_redirect off;' "${ROOT}/deploy/nginx/default.conf" >/dev/null
 # Website pool (:8082) must keep / → /en/ relative; absolute redirects leak the
 # unpublished internal listen port through the public :11442 gateway.

--- a/tools/quality/test-gateway-lifecycle-upgrade.sh
+++ b/tools/quality/test-gateway-lifecycle-upgrade.sh
@@ -342,6 +342,68 @@ test_upgrade_keeps_existing_sidecar_until_replacement_starts() {
 	grep -Eq '^[[:space:]]*run_sidecar_install_script([[:space:]]|$)' <<<"${body}"
 }
 
+test_lensnode_resolution_ignores_unrelated_newer_image() (
+	# New Gateway archives carry the official version tag and the historical
+	# compatibility alias for the same image ID. A newer leftover image must
+	# never override the image selected by the Console bundle.
+	# shellcheck disable=SC1090
+	source <(sed -n '/^resolve_lensnode_image() {/,/^}/p' "${SIDECAR_INSTALLER}")
+	DEFAULT_LENSNODE_IMAGE=hyperfilelens-sourcelens-lensnode:latest
+	LENSNODE_IMAGE=hyperfilelens-sourcelens-lensnode:latest
+	docker() {
+		case "$*" in
+		"image inspect hyperfilelens-sourcelens-lensnode:latest --format {{.Id}}")
+			printf '%s\n' sha256:selected
+			;;
+		"image ls oneprolabs/sourcelens-lensnode --format {{.Repository}}:{{.Tag}}")
+			printf '%s\n' \
+				oneprolabs/sourcelens-lensnode:0.50.0 \
+				oneprolabs/sourcelens-lensnode:0.49.5
+			;;
+		"image inspect oneprolabs/sourcelens-lensnode:0.50.0 --format {{.Id}}")
+			printf '%s\n' sha256:unrelated
+			;;
+		"image inspect oneprolabs/sourcelens-lensnode:0.49.5 --format {{.Id}}")
+			printf '%s\n' sha256:selected
+			;;
+		*) printf 'unexpected fake Docker invocation: %s\n' "$*" >&2; return 90 ;;
+		esac
+	}
+	[[ "$(resolve_lensnode_image)" == "oneprolabs/sourcelens-lensnode:0.49.5" ]]
+)
+
+test_lifecycle_passes_exact_loaded_lensnode_image() (
+	# shellcheck disable=SC1090
+	source "${LIFECYCLE}"
+	local work_dir="${tmp}/lensnode-resolution"
+	mkdir -p "${work_dir}"
+	download_bootstrap_file() { : >"$2"; }
+	lensnode_image_supports_insecure_tls() { return 0; }
+	docker() {
+		case "$*" in
+		"load -i ${work_dir}/lensnode-image-linux-amd64.tar.gz") ;;
+		"image inspect hyperfilelens-sourcelens-lensnode:latest --format {{.Id}}")
+			printf '%s\n' sha256:selected
+			;;
+		"image ls oneprolabs/sourcelens-lensnode --format {{.Repository}}:{{.Tag}}")
+			printf '%s\n' \
+				oneprolabs/sourcelens-lensnode:0.50.0 \
+				oneprolabs/sourcelens-lensnode:0.49.5
+			;;
+		"image inspect oneprolabs/sourcelens-lensnode:0.50.0 --format {{.Id}}")
+			printf '%s\n' sha256:unrelated
+			;;
+		"image inspect oneprolabs/sourcelens-lensnode:0.49.5 --format {{.Id}}")
+			printf '%s\n' sha256:selected
+			;;
+		"image inspect oneprolabs/sourcelens-lensnode:0.49.5") ;;
+		*) printf 'unexpected fake Docker invocation: %s\n' "$*" >&2; return 90 ;;
+		esac
+	}
+	load_lensnode_image "${work_dir}"
+	[[ "${RESOLVED_LENSNODE_IMAGE}" == "oneprolabs/sourcelens-lensnode:0.49.5" ]]
+)
+
 test_lifecycle_accepts_persisted_node_credential() (
 	# shellcheck disable=SC1090
 	source "${LIFECYCLE}"
@@ -540,6 +602,8 @@ test_sidecar_start_failure_restores_previous_compose
 test_first_sidecar_start_failure_cleans_partial_project
 test_forced_sidecar_recreate_is_opt_in
 test_upgrade_keeps_existing_sidecar_until_replacement_starts
+test_lensnode_resolution_ignores_unrelated_newer_image
+test_lifecycle_passes_exact_loaded_lensnode_image
 test_lifecycle_accepts_persisted_node_credential
 test_lifecycle_rejects_relative_persisted_agent_root
 test_lifecycle_rejects_relative_agent_env_path

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -106,10 +106,51 @@ if grep -Eq 'publish-community-channel|community-channel|git push origin HEAD:ma
 	printf 'ERROR: SaaS workflow must not manage a separate Community channel branch\n' >&2
 	exit 1
 fi
-grep -Fq 'SOURCELENS_DISTRIBUTION_TAG_OVERRIDE="${version}"' \
-	"${ROOT}/release/ci/assemble-saas-candidate.sh"
-grep -Fq 'SOURCELENS_DISTRIBUTION_TAG_OVERRIDE: ${{ needs.prepare.outputs.version }}' \
-	"${workflow}"
+grep -Fq 'write-upstream-image-metadata.sh' "${workflow}"
+grep -Fq 'resolve-upstream-images:' "${workflow}"
+if grep -Eq '^  (build-sourcelens-images|publish-runtime-images):' "${workflow}"; then
+	printf 'ERROR: SaaS workflow still publishes rebuilt upstream images\n' >&2
+	exit 1
+fi
+python3 - "${workflow}" <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+for forbidden in (
+    "hyperfilelens-sourcelens-backend",
+    "hyperfilelens-sourcelens-frontend",
+    "hyperfilelens-sourcelens-lensnode",
+    "hyperfilelens-sourcelens-nginx",
+    "hyperfilelens-postgres",
+    "hyperfilelens-redis",
+    "slcache-",
+):
+    if forbidden in text:
+        raise SystemExit(f"SaaS workflow still publishes legacy image {forbidden}")
+build = text.split("  build-hfl-images:\n", 1)[1].split(
+    "\n  resolve-upstream-images:\n", 1
+)[0]
+expected = {
+    "Community · Backend",
+    "Community · Frontend",
+    "Enterprise · Backend",
+    "Enterprise · Frontend",
+}
+actual = {
+    line.strip()[len("- name: ") :]
+    for line in build.splitlines()
+    if line.startswith("          - name: ")
+}
+if actual != expected:
+    raise SystemExit(f"unexpected HFL publish matrix: {sorted(actual)}")
+# One matrix build publishes four HFL tags; the three asset jobs publish one
+# tag each. No third-party image may introduce another push operation.
+if text.count("          push: true\n") != 4:
+    raise SystemExit("SaaS workflow must contain exactly seven effective image publishes")
+if 'has("linux/amd64")' not in text:
+    raise SystemExit("upstream image verification does not require linux/amd64")
+PY
 if grep -E 'hyperfilelens-(agent|gateway|language)-assets:.*image_version' "${workflow}"; then
 	printf 'ERROR: OSS asset images must not use the Enterprise image suffix\n' >&2
 	exit 1
@@ -198,11 +239,21 @@ with tempfile.TemporaryDirectory() as temporary:
     module.render_sourcelens_compose(
         root / "deploy/installer/sourcelens/docker-compose.template.yml",
         output,
-        "1.2.3",
+        {
+            "backend": runtime["images"]["backend"]["local_ref"],
+            "frontend": runtime["images"]["frontend"]["local_ref"],
+            "lensnode": runtime["images"]["lensnode"]["local_ref"],
+            "nginx": "nginx:stable-alpine",
+            "postgres": "postgres:17",
+            "redis": "redis:alpine",
+        },
     )
     compose = output.read_text(encoding="utf-8")
     for component in ("backend", "frontend"):
-        expected = f"hyperfilelens-sourcelens-{component}:1.2.3"
+        expected = runtime["images"][component]["local_ref"]
+        if expected not in compose:
+            raise SystemExit(f"rendered SourceLens Compose is missing {expected}")
+    for expected in ("nginx:stable-alpine", "postgres:17", "redis:alpine"):
         if expected not in compose:
             raise SystemExit(f"rendered SourceLens Compose is missing {expected}")
     if "__SOURCELENS_" in compose or "HFL_EMBED_" in compose:
@@ -339,6 +390,17 @@ cat >"${fake_bin}/docker" <<'SH'
 set -euo pipefail
 digest="sha256:$(printf 'b%.0s' {1..64})"
 revision="$(printf 'c%.0s' {1..40})"
+digest_for_ref() {
+	case "$1" in
+	*sourcelens-backend*) printf '%s' sha256:b4fd19ea5bd3fed17e4c22eb44d4f4178181c33c29cc6ed956484642735408b8 ;;
+	*sourcelens-frontend*) printf '%s' sha256:2c183e50bc9e6281ea58ede269b3e7227f6e1bdf649a2c6b066cb5c651ecb802 ;;
+	*sourcelens-lensnode*) printf '%s' sha256:b865673d640ff575883e8321d5bae18ebd7d975d2f9bae3660167fee28e74b69 ;;
+	*postgres*) printf '%s' sha256:0027bef26712baaee437a4ea48fdf3d2d2e2bc5f0d81615374408ca320f3c7e3 ;;
+	*redis*) printf '%s' sha256:09160599abd229764c0fb44cb6be640294e1d360a54b19985ab4843dcf2d90f1 ;;
+	*nginx*) printf '%s' sha256:0d3b80406a13a767339fbe2f41406d6c7da727ab89cf8fae399e81f780f814d1 ;;
+	*) printf '%s' "${digest}" ;;
+	esac
+}
 case "${1:-} ${2:-}" in
 "info ")
 	[[ "${HFL_TEST_DOCKER_INFO_FAIL:-0}" != "1" ]]
@@ -384,6 +446,7 @@ case "${1:-} ${2:-}" in
 "image inspect")
 	ref=${3:-}
 	format=${5:-}
+	resolved_digest="$(digest_for_ref "${ref}")"
 	if [[ "${HFL_TEST_DOCKER_PULL_FAIL:-0}" == "1" && "${ref}" == */* ]]; then
 		exit 1
 	fi
@@ -392,7 +455,9 @@ case "${1:-} ${2:-}" in
 		exit 1
 	fi
 	if [[ "${format}" == *RepoDigests* ]]; then
-		printf '["%s@%s"]\n' "${ref%:*}" "${digest}"
+		repository=${ref%%@*}
+		repository=${repository%:*}
+		printf '["%s@%s"]\n' "${repository}" "${resolved_digest}"
 	elif [[ "${format}" == *Architecture* ]]; then
 		printf 'linux/amd64\n'
 	else
@@ -400,7 +465,7 @@ case "${1:-} ${2:-}" in
 	fi
 	;;
 "buildx imagetools")
-	printf '{"digest":"%s"}\n' "${digest}"
+	printf '{"digest":"%s"}\n' "$(digest_for_ref "${4:-}")"
 	;;
 "image rm")
 	printf 'Untagged: %s\n' "${3:-unknown}"
@@ -1402,16 +1467,16 @@ PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 		--version v1.2.3 \
 		--region global \
 		--output "${candidate}" >"${prepare_log}" 2>&1
-grep -F 'Docker Compose native pull progress: parallel=5 images=11' \
+grep -F 'Docker Compose native pull progress: parallel=5 images=10' \
 	"${prepare_log}" >/dev/null
 for heading in 'Installation images' 'Release package'; do
 	grep -Fx "${heading}" "${prepare_log}" >/dev/null
 done
-grep -F '[....] Pulling 11 installation images concurrently · maximum 5 active downloads' \
+grep -F '[....] Pulling 10 installation images concurrently · maximum 5 active downloads' \
 	"${prepare_log}" >/dev/null
-grep -F '[ OK ] Installation image 1/11 ready ·' "${prepare_log}" >/dev/null
-grep -F '[ OK ] Installation image 11/11 ready ·' "${prepare_log}" >/dev/null
-grep -F '[ OK ] All 11 installation images are ready' "${prepare_log}" >/dev/null
+grep -F '[ OK ] Installation image 1/10 ready ·' "${prepare_log}" >/dev/null
+grep -F '[ OK ] Installation image 10/10 ready ·' "${prepare_log}" >/dev/null
+grep -F '[ OK ] All 10 installation images are ready' "${prepare_log}" >/dev/null
 grep -F '[ OK ] Community release package prepared ·' "${prepare_log}" >/dev/null
 if grep -F 'Untagged:' "${prepare_log}" >/dev/null; then
 	printf 'ERROR: temporary asset image cleanup leaked into online output\n' >&2
@@ -1515,7 +1580,12 @@ for entry in entries:
     (target / f"{component}.json").write_text(
         json.dumps(metadata) + "\n", encoding="utf-8"
     )
+
 PY
+# LensNode is distributed inside gateway-assets rather than pulled by the
+# Console host, but its sources remain part of publication checks.
+"${ROOT}/release/ci/write-upstream-image-metadata.sh" \
+	sourcelens-lensnode "${metadata}/sourcelens-lensnode.json"
 PATH="${fake_bin}:${PATH}" "${online}/verify-public-images.sh" "${metadata}"
 
 # Source only defines functions because install.sh guards main with BASH_SOURCE.

--- a/tools/quality/test-release-purge-all.sh
+++ b/tools/quality/test-release-purge-all.sh
@@ -123,6 +123,49 @@ fi
 	sourcelens_runtime_present
 )
 
+# Uninstall removes historical HFL aliases but preserves upstream and Docker
+# Library image tags, which may be shared by unrelated workloads on the host.
+(
+	set -euo pipefail
+	source "${REPO_ROOT}/deploy/installer/install.sh"
+	ROOT="${fixture}/image-ownership-root"
+	mkdir -p "${ROOT}"
+	cat >"${ROOT}/MANIFEST.json" <<'JSON'
+{
+  "images": [
+    {"role": "hyperfilelens", "refs": ["hyperfilelens-backend:1.0.0"]},
+    {"role": "shared", "refs": ["postgres:17", "redis:alpine"]},
+    {"role": "sourcelens-backend", "refs": ["oneprolabs/sourcelens-backend:0.49.5"]},
+    {"role": "sourcelens-nginx", "refs": ["nginx:stable-alpine"]},
+    {"role": "sourcelens-frontend", "refs": ["hyperfilelens-sourcelens-frontend:legacy"]}
+  ]
+}
+JSON
+	removed="${fixture}/removed-image-tags"
+	: >"${removed}"
+	mkdir -p "${fixture}/image-ownership-bin"
+	cat >"${fixture}/image-ownership-bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+"image ls --quiet --no-trunc hyperfilelens-backend:1.0.0") printf '%s\n' backend-id ;;
+"image ls --quiet --no-trunc hyperfilelens-sourcelens-frontend:legacy") printf '%s\n' sourcelens-id ;;
+"image rm -f hyperfilelens-backend:1.0.0") printf '%s\n' hyperfilelens-backend:1.0.0 >>"${HFL_TEST_REMOVED_TAGS}" ;;
+"image rm -f hyperfilelens-sourcelens-frontend:legacy") printf '%s\n' hyperfilelens-sourcelens-frontend:legacy >>"${HFL_TEST_REMOVED_TAGS}" ;;
+*) printf 'unexpected Docker image cleanup: %s\n' "$*" >&2; exit 90 ;;
+esac
+SH
+	chmod 755 "${fixture}/image-ownership-bin/docker"
+	export HFL_TEST_REMOVED_TAGS="${removed}"
+	export PATH="${fixture}/image-ownership-bin:${PATH}"
+	step() { :; }
+	remove_manifest_images
+	remove_sourcelens_images
+	mapfile -t removed_tags <"${removed}"
+	[[ "${removed_tags[*]}" == \
+		'hyperfilelens-backend:1.0.0 hyperfilelens-sourcelens-frontend:legacy' ]]
+)
+
 # The real SourceLens fallback must remove verified orphan containers before
 # images and data. Image cleanup failure must preserve data for retry.
 run_sourcelens_component_contract() (

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -527,6 +527,136 @@ if (validate_package_identity "${identity_root}") >/dev/null 2>&1; then
 	exit 1
 fi
 
+# Assemble the same thin Candidate consumed by the SaaS deployment. This
+# catches drift between upstream metadata, Compose refs, and the installer
+# manifest without pulling or rebuilding any third-party image.
+candidate_metadata="${tmp}/candidate-metadata"
+candidate_archive="${tmp}/candidate.tar.gz"
+candidate_extract="${tmp}/candidate-extract"
+mkdir -p "${candidate_metadata}" "${candidate_extract}"
+python3 - "${candidate_metadata}" "${ROOT}/deploy/online/sourcelens/runtime.json" \
+	"${ROOT}/tools/dependencies/versions/runtime-images.env" "${digest}" "${revision}" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+target = pathlib.Path(sys.argv[1])
+sourcelens = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+runtime_values = {}
+for line in pathlib.Path(sys.argv[3]).read_text(encoding="utf-8").splitlines():
+    match = re.fullmatch(r"([A-Z_]+)=(.+)", line.strip())
+    if match:
+        runtime_values[match.group(1)] = match.group(2)
+hfl_digest = sys.argv[4]
+
+
+def write(name, local_ref, role, digest, global_ref, cn_ref, **extra):
+    payload = {
+        "component": name,
+        "role": role,
+        "local_ref": local_ref,
+        "digest": digest,
+        "platform": "linux/amd64",
+        "sources": [
+            {"region": "cn", "ref": cn_ref},
+            {"region": "global", "ref": global_ref},
+        ],
+        **extra,
+    }
+    (target / f"{name}.json").write_text(
+        json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+for component in ("backend", "frontend"):
+    local_ref = f"hyperfilelens-{component}:1.0.0-ee"
+    write(
+        f"hfl-{component}",
+        local_ref,
+        "hyperfilelens",
+        hfl_digest,
+        f"docker.io/example/{local_ref}",
+        f"registry.example.cn/example/{local_ref}",
+    )
+for component, image in sourcelens["images"].items():
+    write(
+        f"sourcelens-{component}",
+        image["local_ref"],
+        f"sourcelens-{component}",
+        image["digest"],
+        image["sources"]["global"],
+        image["sources"]["cn"],
+        sourcelens_version=sourcelens["version"],
+        sourcelens_git_ref=sourcelens["git_ref"],
+        sourcelens_git_commit=sourcelens["git_commit"],
+    )
+for component, variable, role in (
+    ("postgres", "POSTGRES_IMAGE", "shared"),
+    ("redis", "REDIS_IMAGE", "shared"),
+    ("sourcelens-nginx", "NGINX_IMAGE", "sourcelens-nginx"),
+):
+    local_ref, pinned_digest = runtime_values[variable].split("@", 1)
+    source = f"docker.io/library/{local_ref}"
+    write(component, local_ref, role, pinned_digest, source, source)
+for kind in ("agent", "gateway", "language"):
+    local_ref = f"hyperfilelens-{kind}-assets:1.0.0"
+    write(
+        f"{kind}-assets",
+        local_ref,
+        f"{kind}-assets",
+        hfl_digest,
+        f"docker.io/example/{local_ref}",
+        f"registry.example.cn/example/{local_ref}",
+        asset_kind=kind,
+    )
+PY
+"${ROOT}/release/ci/assemble-saas-candidate.sh" \
+	"${candidate_metadata}" 1.0.0 "${revision}" "$(printf 'c%.0s' {1..40})" \
+	/opt/hfl/extensions/hyperfilelens-ee "${candidate_archive}"
+tar -xzf "${candidate_archive}" -C "${candidate_extract}"
+assembled_root="${candidate_extract}/hyperfilelens-1.0.0-ee-saas"
+grep -Fx 'HFL_POSTGRES_IMAGE=postgres:17' "${assembled_root}/.env.example" >/dev/null
+grep -Fx 'HFL_REDIS_IMAGE=redis:alpine' "${assembled_root}/.env.example" >/dev/null
+grep -F 'image: oneprolabs/sourcelens-backend:0.49.5' \
+	"${assembled_root}/sourcelens/docker-compose.yml" >/dev/null
+grep -F 'image: nginx:stable-alpine' \
+	"${assembled_root}/sourcelens/docker-compose.yml" >/dev/null
+python3 - "${assembled_root}" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+manifest = json.loads((root / "MANIFEST.json").read_text(encoding="utf-8"))
+registry = manifest["delivery"]["registry_images"]
+refs = {entry["local_ref"] for entry in registry}
+assert refs == {
+    "hyperfilelens-backend:1.0.0-ee",
+    "hyperfilelens-frontend:1.0.0-ee",
+    "oneprolabs/sourcelens-backend:0.49.5",
+    "oneprolabs/sourcelens-frontend:0.49.5",
+    "nginx:stable-alpine",
+    "postgres:17",
+    "redis:alpine",
+}
+assert not any("lensnode" in ref for ref in refs)
+build_info = json.loads(
+    (root / "sourcelens/BUILD_INFO.json").read_text(encoding="utf-8")
+)
+assert build_info["lensnode_image"] == "oneprolabs/sourcelens-lensnode:0.49.5"
+assert {
+    name: build_info["images"][name]["ref"]
+    for name in ("nginx", "postgres", "redis")
+} == {
+    "nginx": "nginx:stable-alpine",
+    "postgres": "postgres:17",
+    "redis": "redis:alpine",
+}
+assert not any((root / "images").iterdir())
+PY
+validate_package_identity "${assembled_root}"
+
 sourcelens_root="${tmp}/sourcelens-candidate"
 mkdir -p \
 	"${sourcelens_root}/sourcelens/deploy/nginx/hfl-maintenance" \

--- a/tools/quality/test-sourcelens-runtime-contract.sh
+++ b/tools/quality/test-sourcelens-runtime-contract.sh
@@ -5,6 +5,20 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 temporary="$(mktemp -d)"
 trap 'rm -rf "${temporary}"' EXIT
 repository="${temporary}/source"
+
+# The checked-in contract must keep its source identity, official image tags,
+# regional repositories, and immutable digests internally consistent.
+python3 - "${ROOT}" <<'PY'
+import pathlib
+import runpy
+import sys
+
+root = pathlib.Path(sys.argv[1])
+online = runpy.run_path(str(root / "deploy/online/prepare.py"))
+runtime = online["load_sourcelens_runtime"](root)
+assert set(runtime["images"]) == {"backend", "frontend", "lensnode"}
+PY
+
 git init --quiet "${repository}"
 git -C "${repository}" config user.name "Runtime Contract Test"
 git -C "${repository}" config user.email "runtime-contract@example.invalid"
@@ -35,6 +49,19 @@ annotated_contract="${temporary}/annotated.json"
 	--git-url "${repository}" --output "${annotated_contract}"
 "${ROOT}/tools/sourcelens/update-runtime-contract.sh" --check \
 	--git-url "${repository}" --output "${annotated_contract}"
+
+# A version update must not retain an image lock from another SourceLens
+# release and leave a contract that later packaging stages cannot consume.
+locked_contract="${temporary}/image-locked.json"
+cp "${ROOT}/deploy/online/sourcelens/runtime.json" "${locked_contract}"
+locked_before="$(sha256sum "${locked_contract}" | cut -d' ' -f1)"
+if "${ROOT}/tools/sourcelens/update-runtime-contract.sh" v1.2.4 \
+	--git-url "${repository}" --output "${locked_contract}" >/dev/null 2>&1; then
+	printf 'ERROR: SourceLens identity update retained a mismatched image lock\n' >&2
+	exit 1
+fi
+[[ "$(sha256sum "${locked_contract}" | cut -d' ' -f1)" == "${locked_before}" ]]
+
 python3 - "${lightweight_contract}" "${annotated_contract}" "${commit}" <<'PY'
 import json
 import pathlib

--- a/tools/quality/test-sourcelens-runtime-fingerprint.sh
+++ b/tools/quality/test-sourcelens-runtime-fingerprint.sh
@@ -16,7 +16,7 @@ printf 'DJANGO_DEBUG=true\n' >"${ROOT}/data/sourcelens/config/.env"
 ln -s "${ROOT}/data/sourcelens/config/.env" "${SOURCELENS_INSTALL_DIR}/.env"
 
 write_bundle() {
-	local root=$1 patchset=$2
+	local root=$1 patchset=$2 nginx_digest=${3:-sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
 	cat >"${root}/BUILD_INFO.json" <<JSON
 {
   "git_url": "https://github.com/oneprolabs/sourcelens.git",
@@ -31,6 +31,10 @@ write_bundle() {
     },
     "frontend": {
       "ref": "hyperfilelens-sourcelens-frontend:main-fixture-sl0.20.0"
+    },
+    "nginx": {
+      "ref": "nginx:stable-alpine",
+      "digest": "${nginx_digest}"
     }
   }
 }
@@ -89,6 +93,17 @@ sourcelens_bundle_changed "${tmp}/target"
 record_sourcelens_installed_bundle "${target}"
 if sourcelens_bundle_changed "${tmp}/target"; then
 	printf 'ERROR: recorded SourceLens runtime was reported as changed\n' >&2
+	exit 1
+fi
+
+# Stable upstream tags must still converge when their immutable image lock
+# changes between releases.
+write_bundle "${target}" new-patchset \
+	sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+sourcelens_bundle_changed "${tmp}/target"
+record_sourcelens_installed_bundle "${target}"
+if sourcelens_bundle_changed "${tmp}/target"; then
+	printf 'ERROR: recorded SourceLens image lock was reported as changed\n' >&2
 	exit 1
 fi
 

--- a/tools/sourcelens/common.sh
+++ b/tools/sourcelens/common.sh
@@ -1597,14 +1597,18 @@ PY
 sourcelens_write_runtime_compose() {
 	local compose_path=$1
 	local template="${SOURCELENS_INSTALLER_DIR}/sourcelens/docker-compose.template.yml"
-	local backend_image frontend_image lensnode_image
+	local backend_image frontend_image lensnode_image nginx_image postgres_image redis_image
 	backend_image="$(sourcelens_backend_image_ref)"
 	frontend_image="$(sourcelens_frontend_image_ref)"
 	lensnode_image="$(sourcelens_lensnode_image_ref)"
+	nginx_image="hyperfilelens-sourcelens-nginx:stable-alpine"
+	postgres_image="hyperfilelens-postgres:17"
+	redis_image="hyperfilelens-redis:alpine"
 	[[ -f "${template}" ]] || sourcelens_die "missing SourceLens Compose template: ${template}"
 
 	python3 - "${template}" "${compose_path}" \
 		"${backend_image}" "${frontend_image}" "${lensnode_image}" \
+		"${nginx_image}" "${postgres_image}" "${redis_image}" \
 		"${SOURCELENS_CONSOLE_BIND_ADDRESS}" \
 		"${SOURCELENS_CONSOLE_PORT}" \
 		"${SOURCELENS_EMBED_LENSNODE}" <<'PY'
@@ -1612,7 +1616,19 @@ import pathlib
 import re
 import sys
 
-template_path, compose_path, backend_image, frontend_image, lensnode_image, bind_address, https_port, embed_raw = sys.argv[1:9]
+(
+    template_path,
+    compose_path,
+    backend_image,
+    frontend_image,
+    lensnode_image,
+    nginx_image,
+    postgres_image,
+    redis_image,
+    bind_address,
+    https_port,
+    embed_raw,
+) = sys.argv[1:12]
 embed_lensnode = str(embed_raw).strip().lower() in {"1", "true", "yes", "on"}
 text = pathlib.Path(template_path).read_text(encoding="utf-8")
 
@@ -1633,6 +1649,9 @@ replacements = {
     "__SOURCELENS_BACKEND_IMAGE__": backend_image,
     "__SOURCELENS_FRONTEND_IMAGE__": frontend_image,
     "__SOURCELENS_LENSNODE_IMAGE__": lensnode_image,
+    "__SOURCELENS_NGINX_IMAGE__": nginx_image,
+    "__SOURCELENS_POSTGRES_IMAGE__": postgres_image,
+    "__SOURCELENS_REDIS_IMAGE__": redis_image,
     "__SOURCELENS_CONSOLE_BIND_ADDRESS__": bind_address,
     "__SOURCELENS_CONSOLE_PORT__": https_port,
 }

--- a/tools/sourcelens/update-runtime-contract.sh
+++ b/tools/sourcelens/update-runtime-contract.sh
@@ -127,29 +127,75 @@ python3 - "${mode}" "${output}" "${git_ref}" "${version}" "${git_commit}" <<'PY'
 import json
 import os
 import pathlib
+import re
 import sys
 import tempfile
 
 mode = sys.argv[1]
 output = pathlib.Path(sys.argv[2])
-payload = {
+identity = {
     "git_commit": sys.argv[5],
     "git_ref": sys.argv[3],
     "version": sys.argv[4],
 }
+
+
+def validate_image_lock(contract, version):
+    images = contract.get("images")
+    if images is None:
+        return
+    if not isinstance(images, dict) or set(images) != {
+        "backend",
+        "frontend",
+        "lensnode",
+    }:
+        raise SystemExit("SourceLens runtime image lock is incomplete")
+    for name, image in images.items():
+        if not isinstance(image, dict):
+            raise SystemExit(f"SourceLens {name} image lock is invalid")
+        digest = str(image.get("digest") or "")
+        local_ref = str(image.get("local_ref") or "")
+        sources = image.get("sources") or {}
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+            raise SystemExit(f"SourceLens {name} image digest is invalid")
+        if local_ref != f"oneprolabs/sourcelens-{name}:{version}":
+            raise SystemExit(
+                f"SourceLens {name} image lock does not match v{version}"
+            )
+        if sources != {
+            "cn": (
+                "registry.cn-beijing.aliyuncs.com/oneprolabs/"
+                f"sourcelens-{name}:{version}"
+            ),
+            "global": f"docker.io/oneprolabs/sourcelens-{name}:{version}",
+        }:
+            raise SystemExit(f"SourceLens {name} image sources are invalid")
+
+
 if mode == "check":
     try:
         actual = json.loads(output.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise SystemExit(f"invalid SourceLens runtime contract: {exc}") from exc
-    if actual != payload:
-        differences = sorted(set(actual) | set(payload), key=str)
-        differences = [name for name in differences if actual.get(name) != payload.get(name)]
+    validate_image_lock(actual, identity["version"])
+    differences = [
+        name for name, value in identity.items() if actual.get(name) != value
+    ]
+    if differences:
         raise SystemExit(
             "SourceLens runtime contract differs from the peeled tag identity: "
             + ", ".join(differences)
         )
     raise SystemExit(0)
+
+payload = {}
+if output.is_file():
+    try:
+        payload = json.loads(output.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid SourceLens runtime contract: {exc}") from exc
+validate_image_lock(payload, identity["version"])
+payload.update(identity)
 
 descriptor, temporary = tempfile.mkstemp(prefix=f".{output.name}.", dir=output.parent)
 try:


### PR DESCRIPTION
## Summary

- use digest-pinned upstream SourceLens and Docker Library images for Community online installs and Enterprise SaaS deployments
- limit HFL image publication to the Community and Enterprise application images plus Agent, language, and Gateway asset images
- package the verified upstream LensNode image in Gateway assets while preserving compatibility with existing offline Data Gateway installations
- retain legacy aliases for full offline releases and avoid removing shared upstream images during uninstall
- include upstream runtime identities in SourceLens upgrade fingerprints and strengthen release contract validation

## Validation

- `tools/quality/check-release-contracts.sh`
- `tools/quality/test-saas-registry-delivery.sh`
- `tools/quality/test-online-community-install.sh`
- `tools/quality/test-ci-release-assembly.sh`
- `tools/quality/test-sourcelens-runtime-contract.sh`
- `tools/quality/test-sourcelens-runtime-fingerprint.sh`
- `tools/quality/test-blue-green-recovery.sh`
- `tools/quality/test-gateway-lifecycle-upgrade.sh`
- `tools/quality/test-release-purge-all.sh`
- `tools/quality/test-upgrade-transaction.sh`
- `tools/quality/test-enterprise-release-flow.sh`
- Python Ruff checks, Shell syntax checks, YAML parsing, Compose configuration parsing, and `git diff --check`