### PR TITLE
Standardize release job names and retry registry stream errors

### DIFF
--- a/.github/workflows/community_release.yml
+++ b/.github/workflows/community_release.yml
@@ -28,7 +28,7 @@ jobs:
           }
 
   release-community:
-    name: Build, Release & Deploy · Community
+    name: Release · Community
     needs: validate-community-release
     uses: ./.github/workflows/release_pipeline.yml
     with:

--- a/.github/workflows/enterprise_prod_promotion.yml
+++ b/.github/workflows/enterprise_prod_promotion.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   validate-production-promotion:
-    name: Validate · Manual promotion
+    name: Validate · PROD promotion
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/.github/workflows/enterprise_release.yml
+++ b/.github/workflows/enterprise_release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   validate-enterprise-build:
-    name: Validate · Enterprise build
+    name: Validate · Enterprise release
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -28,7 +28,7 @@ jobs:
           }
 
   build-enterprise:
-    name: Build & Deploy · Enterprise
+    name: Release · Enterprise
     needs: validate-enterprise-build
     uses: ./.github/workflows/release_pipeline.yml
     with:

--- a/.github/workflows/enterprise_saas_upgrade.yml
+++ b/.github/workflows/enterprise_saas_upgrade.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   prepare:
-    name: Prepare · Images and Enterprise candidate
+    name: Validate · Release context
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
@@ -143,7 +143,7 @@ jobs:
           echo "commit=$commit" >>"$GITHUB_OUTPUT"
 
   quality:
-    name: Verify · SaaS delivery contracts
+    name: Verify · Delivery contracts
     needs: prepare
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -173,7 +173,7 @@ jobs:
           ./tools/sourcelens/update-runtime-contract.sh --check
 
   verify-public-images:
-    name: Verify · Public Community images
+    name: Verify · Community image delivery
     needs:
       - prepare
       - build-hfl-images
@@ -198,7 +198,7 @@ jobs:
         run: ./deploy/online/verify-public-images.sh build/saas-metadata
 
   build-hfl-images:
-    name: Build · HFL · ${{ matrix.name }}
+    name: Publish · HFL image · ${{ matrix.name }}
     needs: [prepare, quality]
     runs-on: ubuntu-24.04
     timeout-minutes: 90
@@ -343,20 +343,26 @@ jobs:
           retention-days: 3
 
   resolve-upstream-images:
-    name: Verify · Upstream · ${{ matrix.component }}
+    name: Verify · Upstream image · ${{ matrix.name }}
     needs: [prepare, quality]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        component:
-          - sourcelens-backend
-          - sourcelens-frontend
-          - sourcelens-lensnode
-          - sourcelens-nginx
-          - postgres
-          - redis
+        include:
+          - component: sourcelens-backend
+            name: SourceLens Backend
+          - component: sourcelens-frontend
+            name: SourceLens Frontend
+          - component: sourcelens-lensnode
+            name: SourceLens LensNode
+          - component: sourcelens-nginx
+            name: NGINX
+          - component: postgres
+            name: PostgreSQL
+          - component: redis
+            name: Redis
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -396,7 +402,7 @@ jobs:
           retention-days: 3
 
   build-agent-assets:
-    name: Build · Agent asset · ${{ matrix.asset }}
+    name: Build · Agent bundle · ${{ matrix.name }}
     needs: [prepare, quality]
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -406,14 +412,19 @@ jobs:
         include:
           - target: linux:amd64
             asset: linux-amd64
+            name: Linux/AMD64
           - target: linux:arm64
             asset: linux-arm64
+            name: Linux/ARM64
           - target: darwin:amd64
             asset: darwin-amd64
+            name: macOS/AMD64
           - target: darwin:arm64
             asset: darwin-arm64
+            name: macOS/ARM64
           - target: windows:amd64
             asset: windows-amd64
+            name: Windows/AMD64
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -474,7 +485,7 @@ jobs:
           retention-days: 3
 
   build-language-assets:
-    name: Build · Language assets
+    name: Build · Language bundle
     needs: [prepare, quality]
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -716,7 +727,7 @@ jobs:
           retention-days: 3
 
   assemble-candidate:
-    name: Assemble · Registry candidate
+    name: Assemble · Enterprise SaaS candidate
     needs:
       - prepare
       - build-hfl-images

--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   prepare:
-    name: Prepare
+    name: Prepare · Release candidate
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -318,7 +318,7 @@ jobs:
           fi
 
   quality:
-    name: Quality
+    name: Verify · Quality gates
     if: ${{ needs.prepare.outputs.build_required == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
@@ -544,7 +544,7 @@ jobs:
         run: go test ./...
 
   build-hfl-images:
-    name: Build · HFL · ${{ matrix.component == 'hfl-backend' && 'backend' || 'frontend' }}
+    name: Build · HFL image · ${{ matrix.name }}
     if: ${{ needs.prepare.outputs.build_required == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
@@ -556,12 +556,14 @@ jobs:
       matrix:
         include:
           - component: hfl-backend
+            name: Backend
             repository: hyperfilelens-backend
             context: .
             dockerfile: deploy/docker/backend.Dockerfile
             cache_scope: hfl-backend
             needs_kopia: true
           - component: hfl-frontend
+            name: Frontend
             repository: hyperfilelens-frontend
             context: .
             dockerfile: deploy/docker/frontend.Dockerfile
@@ -681,7 +683,7 @@ jobs:
           docker system df || true
 
   build-sourcelens-images:
-    name: Build · SourceLens · ${{ matrix.component }}
+    name: Build · SourceLens image · ${{ matrix.name }}
     if: ${{ needs.prepare.outputs.build_required == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 120
@@ -691,7 +693,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [backend, frontend, lensnode]
+        include:
+          - component: backend
+            name: Backend
+          - component: frontend
+            name: Frontend
+          - component: lensnode
+            name: LensNode
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -733,7 +741,7 @@ jobs:
           docker builder prune -af || true
 
   build-agent:
-    name: Build · Agent · ${{ matrix.asset }}
+    name: Build · Agent bundle · ${{ matrix.name }}
     if: ${{ needs.prepare.outputs.build_required == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -746,14 +754,19 @@ jobs:
         include:
           - target: linux:amd64
             asset: linux-amd64
+            name: Linux/AMD64
           - target: linux:arm64
             asset: linux-arm64
+            name: Linux/ARM64
           - target: darwin:amd64
             asset: darwin-amd64
+            name: macOS/AMD64
           - target: darwin:arm64
             asset: darwin-arm64
+            name: macOS/ARM64
           - target: windows:amd64
             asset: windows-amd64
+            name: Windows/AMD64
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -782,7 +795,7 @@ jobs:
 
   certify-source-host:
     if: ${{ needs.prepare.outputs.build_required == 'true' }}
-    name: Certify · Agent · ${{ matrix.asset }}
+    name: Certify · Agent bundle · ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     needs: [prepare, build-agent]
@@ -796,26 +809,31 @@ jobs:
             platform: linux
             arch: amd64
             asset: linux-amd64
+            name: Linux/AMD64
             runner: ubuntu-24.04
           - target: linux:arm64
             platform: linux
             arch: arm64
             asset: linux-arm64
+            name: Linux/ARM64
             runner: ubuntu-24.04-arm
           - target: darwin:amd64
             platform: darwin
             arch: amd64
             asset: darwin-amd64
+            name: macOS/AMD64
             runner: macos-15-intel
           - target: darwin:arm64
             platform: darwin
             arch: arm64
             asset: darwin-arm64
+            name: macOS/ARM64
             runner: macos-15
           - target: windows:amd64
             platform: windows
             arch: amd64
             asset: windows-amd64
+            name: Windows/AMD64
             runner: windows-2022
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
@@ -992,7 +1010,7 @@ jobs:
         run: ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" _internal-hfl-images.tar --clobber
 
   export-sourcelens-bundle:
-    name: Package · SourceLens
+    name: Package · SourceLens bundle
     if: ${{ needs.prepare.outputs.build_required == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
@@ -1054,7 +1072,7 @@ jobs:
         run: ./release/ci/gh-release-upload.sh "${{ needs.prepare.outputs.tag }}" _internal-runtime-images.tar --clobber
 
   build-language-packs:
-    name: Build · Language packs
+    name: Build · Language bundle
     if: ${{ needs.prepare.outputs.build_required == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20

--- a/release/ci/mirror-saas-image.sh
+++ b/release/ci/mirror-saas-image.sh
@@ -29,7 +29,7 @@ trap 'rm -f "${copy_log}" "${inspect_log}" "${inspect_output}"' EXIT
 
 mirror_error_is_retryable() {
 	grep -Eiq \
-		'too many requests|(status|response|http)[^[:cntrl:]]*(408|429|500|502|503|504)|request timeout|timeout|deadline exceeded|connection (reset|refused)|unexpected eof|tls handshake timeout|temporary failure|i/o timeout|network is unreachable|no such host' \
+		'too many requests|(status|response|http)[^[:cntrl:]]*(408|429|500|502|503|504)|request timeout|timeout|deadline exceeded|connection (reset|refused)|unexpected eof|tls handshake timeout|temporary failure|i/o timeout|network is unreachable|no such host|stream error[^[:cntrl:]]*internal_error' \
 		"$@"
 }
 

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -157,9 +157,13 @@ case "${1:-} ${2:-}" in
 		count=$((count + 1))
 		printf '%s\n' "${count}" >"${HFL_TEST_MIRROR_MARKER}"
 		case "${HFL_TEST_MIRROR_MODE:-success}" in
-		flaky429 | always429)
+		flaky429 | always429 | flakyStream)
 			if [[ "${count}" -lt 3 ]]; then
-				printf 'unexpected status from HEAD request: 429 Too Many Requests\n' >&2
+				if [[ "${HFL_TEST_MIRROR_MODE}" == "flakyStream" ]]; then
+					printf 'failed to copy: stream error: stream ID 1; INTERNAL_ERROR; received from peer\n' >&2
+				else
+					printf 'unexpected status from HEAD request: 429 Too Many Requests\n' >&2
+				fi
 				exit 1
 			fi
 			if [[ "${HFL_TEST_MIRROR_MODE}" == always429 ]]; then
@@ -280,6 +284,16 @@ HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
 
 printf '0\n' >"${mirror_marker}"
 HFL_TEST_MIRROR_MODE=flaky429 \
+	HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
+	HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS=0 \
+	"${ROOT}/release/ci/mirror-saas-image.sh" \
+		docker.io/example/hyperfilelens-backend:1.0.0-ee \
+		"${digest}" \
+		registry.example.cn/example/hyperfilelens-backend:1.0.0-ee
+[[ "$(cat "${mirror_marker}")" -eq 3 ]]
+
+printf '0\n' >"${mirror_marker}"
+HFL_TEST_MIRROR_MODE=flakyStream \
 	HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
 	HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS=0 \
 	"${ROOT}/release/ci/mirror-saas-image.sh" \


### PR DESCRIPTION
## Summary

- standardize internal release and SaaS workflow job names without changing workflow titles or execution behavior
- add human-readable platform and component labels to matrix jobs
- retry transient BuildKit stream `INTERNAL_ERROR` failures during cross-registry image mirroring
- preserve fast failure for permanent authorization errors

## Validation

- workflow behavior-equivalence checks
- GitHub Actions YAML parsing
- Shell syntax checks
- `tools/quality/test-saas-registry-delivery.sh`
- `tools/quality/check-release-contracts.sh`
- `git diff --check`