### PR TITLE
Use a verified China source for public runtime images

### DIFF
--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -18,7 +18,6 @@ SESSION_DIR=""
 SOURCE_NAME=""
 REGION=""
 TAGS_API_URL=""
-REGISTRY_NAME=""
 RELEASE_VERSION=""
 RELEASE_COMMIT=""
 RECENT_TAGS=""
@@ -203,9 +202,6 @@ print_target() {
 Target
   Version        ${TAG}
   Edition        Community
-  Action         ${INSTALL_ACTION}
-  Source         ${SOURCE_NAME}
-  Registry       ${REGISTRY_NAME}
   Install path   ${INSTALL_ROOT}
   Platform       ${PRETTY_NAME:-Ubuntu} · linux/amd64
   Log file       ${ONLINE_LOG_FILE}
@@ -322,14 +318,12 @@ configure_mirror() {
 		SOURCE_NAME="Gitee"
 		REGION="cn"
 		TAGS_API_URL="https://gitee.com/api/v5/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1"
-		REGISTRY_NAME="Alibaba Cloud"
 		DOCKER_CE_APT_BASE="${HFL_DOCKER_CE_APT_BASE:-${DEFAULT_CN_DOCKER_CE_APT_BASE}}"
 		;;
 	global)
 		SOURCE_NAME="GitHub"
 		REGION="global"
 		TAGS_API_URL="https://api.github.com/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1"
-		REGISTRY_NAME="Docker Hub"
 		DOCKER_CE_APT_BASE="${HFL_DOCKER_CE_APT_BASE:-${DEFAULT_GLOBAL_DOCKER_CE_APT_BASE}}"
 		;;
 	*) fail "--mirror must be cn or global" ;;

--- a/deploy/online/prepare.py
+++ b/deploy/online/prepare.py
@@ -36,7 +36,7 @@ PUBLIC_GLOBAL_PREFIX = os.environ.get(
     "HFL_PUBLIC_GLOBAL_REGISTRY_PREFIX", "docker.io/library"
 ).rstrip("/")
 PUBLIC_CN_PREFIX = os.environ.get(
-    "HFL_PUBLIC_CN_REGISTRY_PREFIX", "docker.io/library"
+    "HFL_PUBLIC_CN_REGISTRY_PREFIX", "dockerproxy.net/library"
 ).rstrip("/")
 
 

--- a/deploy/online/verify-public-images.sh
+++ b/deploy/online/verify-public-images.sh
@@ -92,10 +92,8 @@ if sourcelens_components != {
     "sourcelens-lensnode",
 }:
     raise SystemExit("online SourceLens component metadata is incomplete")
-# Docker Library has no first-party China registry, so its three immutable
-# refs are intentionally shared by both region entries.
-if len(selected) != 19:
-    raise SystemExit(f"expected 19 unique Community image refs, found {len(selected)}")
+if len(selected) != 22:
+    raise SystemExit(f"expected 22 unique Community image refs, found {len(selected)}")
 for ref, digest in sorted(selected.items()):
     print(f"{ref}\t{digest}")
 PY

--- a/release/ci/write-upstream-image-metadata.sh
+++ b/release/ci/write-upstream-image-metadata.sh
@@ -60,10 +60,7 @@ postgres | redis | sourcelens-nginx)
 	local_ref=${pinned%@*}
 	digest=${pinned##*@}
 	global_ref="docker.io/library/${local_ref}"
-	# Docker Library has no first-party China registry. Third-party accelerators
-	# may rewrite manifests, so the formal digest-pinned contract uses Docker Hub
-	# for both regions instead of weakening identity verification.
-	cn_ref="docker.io/library/${local_ref}"
+	cn_ref="dockerproxy.net/library/${local_ref}"
 	;;
 *)
 	printf 'ERROR: unsupported upstream image component: %s\n' "${component}" >&2

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -1353,6 +1353,13 @@ grep -Fq 'Version        v1.2.12' "${latest_log}" || {
 }
 grep -Fq 'Docker Engine  29.6.1 · reuse' "${latest_log}"
 grep -Fq 'Docker Compose 2.39.1 · reuse' "${latest_log}"
+for removed_target_field in Action Source Registry; do
+	if grep -Eq "^  ${removed_target_field}[[:space:]]" "${latest_log}"; then
+		printf 'ERROR: online target still displays %s\n' \
+			"${removed_target_field}" >&2
+		exit 1
+	fi
+done
 latest_session_log="$(find "${test_install_root}/logs" -maxdepth 1 -type f \
 	-name 'install-*.log' -print -quit)"
 [[ -n "${latest_session_log}" ]]
@@ -1535,6 +1542,22 @@ assert manifest["runtime_images"] == {
     "backend": "hyperfilelens-backend:1.2.3",
     "frontend": "hyperfilelens-frontend:1.2.3",
 }
+registry_images = {
+    entry["component"]: entry for entry in manifest["delivery"]["registry_images"]
+}
+for component, local_ref in {
+    "postgres": "postgres:17",
+    "redis": "redis:alpine",
+    "sourcelens-nginx": "nginx:stable-alpine",
+}.items():
+    sources = {
+        source["region"]: source["ref"]
+        for source in registry_images[component]["sources"]
+    }
+    assert sources == {
+        "cn": f"dockerproxy.net/library/{local_ref}",
+        "global": f"docker.io/library/{local_ref}",
+    }
 assets = manifest["delivery"]["asset_images"]
 assert {entry["local_ref"] for entry in assets} == {
     "hyperfilelens-agent-assets:1.2.3",
@@ -1582,10 +1605,13 @@ for entry in entries:
     )
 
 PY
-# LensNode is distributed inside gateway-assets rather than pulled by the
-# Console host, but its sources remain part of publication checks.
-"${ROOT}/release/ci/write-upstream-image-metadata.sh" \
-	sourcelens-lensnode "${metadata}/sourcelens-lensnode.json"
+# Recreate upstream metadata through the same helper used by the release
+# workflow. LensNode remains a publication check even though gateway-assets
+# delivers it to the Gateway host.
+for component in sourcelens-lensnode sourcelens-nginx postgres redis; do
+	"${ROOT}/release/ci/write-upstream-image-metadata.sh" \
+		"${component}" "${metadata}/${component}.json"
+done
 PATH="${fake_bin}:${PATH}" "${online}/verify-public-images.sh" "${metadata}"
 
 # Source only defines functions because install.sh guards main with BASH_SOURCE.


### PR DESCRIPTION
## Summary

- route pinned PostgreSQL, Redis, and NGINX images through dockerproxy.net for China installations while retaining Docker Hub globally
- keep immutable digest and linux/amd64 verification for both regional sources
- remove Action, Source, and Registry from the online installer target summary
- extend the online installation contract tests for distinct public-image sources and the simplified summary

## Validation

- `./tools/quality/test-online-community-install.sh`
- `./tools/quality/check-release-contracts.sh`
- `ruff check deploy/online/prepare.py`
- Bash syntax checks for the changed shell scripts
- `git diff --check`
- verified the pinned PostgreSQL, Redis, and NGINX digests and linux/amd64 platform through dockerproxy.net