### PR TITLE
Allow Community installs when image revisions differ from tags

### DIFF
--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -1151,8 +1151,14 @@ version = str(manifest.get("version") or "")
 commit = str(manifest.get("git_commit") or "").lower()
 if expected_tag != f"v{version}":
     raise SystemExit("prepared Community version does not match the published release")
-if not re.fullmatch(r"[0-9a-f]{40}", commit) or commit != expected_commit:
-    raise SystemExit("prepared Community image revision does not match the published release")
+if not re.fullmatch(r"[0-9a-f]{40}", commit):
+    raise SystemExit("prepared Community image revision is invalid")
+if commit != expected_commit:
+    print(
+        "WARNING: prepared Community image revision differs from the published "
+        f"release ({commit[:12]} != {expected_commit[:12]}); continuing",
+        file=sys.stderr,
+    )
 if manifest.get("edition") != "community" or manifest.get("channel") != "release":
     raise SystemExit("prepared package is not a Community release")
 PY

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -28,7 +28,9 @@ grep -Fq 'api.github.com/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1
 grep -Fq 'gitee.com/api/v5/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1' \
 	"${online}/install.sh"
 grep -Fq 'recent fallback tags:' "${online}/install.sh"
-grep -Fq 'prepared Community image revision does not match the published release' \
+grep -Fq 'prepared Community image revision is invalid' \
+	"${online}/install.sh"
+grep -Fq 'prepared Community image revision differs from the published' \
 	"${online}/install.sh"
 grep -Fq 'run this command through sudo' "${online}/install.sh"
 grep -Fq 'https://mirrors.aliyun.com/docker-ce/linux/ubuntu' "${online}/install.sh"
@@ -552,6 +554,57 @@ if source.count(marker) != 1:
     raise SystemExit("online installer entrypoint marker is ambiguous")
 pathlib.Path(sys.argv[2]).write_text(source.split(marker, 1)[0], encoding="utf-8")
 PY
+
+identity_candidate="${tmp}/identity-candidate"
+mkdir -p "${identity_candidate}"
+cat >"${identity_candidate}/MANIFEST.json" <<'JSON'
+{"version":"1.2.3","git_commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","edition":"community","channel":"release"}
+JSON
+revision_warning_log="${tmp}/revision-warning.log"
+(
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	candidate="${identity_candidate}"
+	TAG=v1.2.3
+	RELEASE_COMMIT=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+	verify_candidate_release
+) >"${revision_warning_log}" 2>&1
+grep -Fq 'prepared Community image revision differs from the published release' \
+	"${revision_warning_log}"
+grep -Fq '(aaaaaaaaaaaa != bbbbbbbbbbbb); continuing' "${revision_warning_log}"
+matching_revision_log="${tmp}/matching-revision.log"
+(
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	candidate="${identity_candidate}"
+	TAG=v1.2.3
+	RELEASE_COMMIT=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+	verify_candidate_release
+) >"${matching_revision_log}" 2>&1
+[[ ! -s "${matching_revision_log}" ]]
+python3 - "${identity_candidate}/MANIFEST.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["git_commit"] = "invalid"
+path.write_text(json.dumps(manifest) + "\n", encoding="utf-8")
+PY
+invalid_revision_log="${tmp}/invalid-revision.log"
+if (
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	candidate="${identity_candidate}"
+	TAG=v1.2.3
+	RELEASE_COMMIT=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+	verify_candidate_release
+) >"${invalid_revision_log}" 2>&1; then
+	printf 'ERROR: invalid Community image revision was accepted\n' >&2
+	exit 1
+fi
+grep -Fq 'prepared Community image revision is invalid' "${invalid_revision_log}"
 
 apt_retry_log="${tmp}/apt-retry.log"
 apt_retry_saved="${tmp}/logs/install-test-apt.log"


### PR DESCRIPTION
## Summary

- continue Community installation when a valid image revision differs from the selected tag commit
- retain strict validation for malformed image revisions and all other release identity fields
- add behavioral coverage for matching, mismatched, and invalid revisions

## Validation

- `./tools/quality/test-online-community-install.sh`
- `./tools/quality/check-release-contracts.sh`
- `bash -n deploy/online/install.sh tools/quality/test-online-community-install.sh`
- `git diff --check`