### PR TITLE
Harden installer runtime compatibility checks

### DIFF
--- a/deploy/installer/apply-runtime-config.py
+++ b/deploy/installer/apply-runtime-config.py
@@ -399,10 +399,11 @@ def apply_configuration(
             warn(
                 "invalid email-code login value; preserving installed email-code login setting"
             )
-        insecure_tls = runtime_values.get("HFL_INSECURE_TLS", "")
-        if insecure_tls not in {"0", "1"}:
-            raise SystemExit("HFL_INSECURE_TLS must be 0 or 1")
-        updates["HFL_INSECURE_TLS"] = insecure_tls
+        if "HFL_INSECURE_TLS" in runtime_values:
+            insecure_tls = runtime_values["HFL_INSECURE_TLS"]
+            if insecure_tls not in {"0", "1"}:
+                raise SystemExit("HFL_INSECURE_TLS must be 0 or 1")
+            updates["HFL_INSECURE_TLS"] = insecure_tls
         updates.update(smtp_runtime_updates(runtime_values))
         updates.update(google_runtime_updates(runtime_values))
         sentry_updates, sentry_removals = sentry_runtime_updates(runtime_values)

--- a/deploy/installer/compose-runtime.sh
+++ b/deploy/installer/compose-runtime.sh
@@ -37,7 +37,10 @@ PY
 hfl_compose_candidate_version() {
 	local -a candidate=("$@")
 	local version output
-	version="$("${candidate[@]}" version --short 2>/dev/null || true)"
+	output="$("${candidate[@]}" version --short 2>/dev/null || true)"
+	# Some Compose 5 builds return the descriptive form even with --short.
+	# Normalize both short and descriptive output before comparing versions.
+	version="$(grep -Eo '[vV]?[0-9]+\.[0-9]+(\.[0-9]+)?' <<<"${output}" | head -1 || true)"
 	if [[ -z "${version}" ]]; then
 		output="$("${candidate[@]}" version 2>/dev/null || true)"
 		# Ubuntu commonly ships mawk, whose match() has no capture-array

--- a/tools/quality/test-compose-command-compatibility.sh
+++ b/tools/quality/test-compose-command-compatibility.sh
@@ -48,6 +48,10 @@ run_release_resolver() (
 	[[ "${HFL_COMPOSE_VERSION}" == "$4" ]]
 )
 
+run_release_resolver 5.5.1 '' 'docker compose' 5.5.1
+run_release_resolver v5.5.1 '' 'docker compose' 5.5.1
+run_release_resolver 'Docker Compose version v5.5.1' '' 'docker compose' 5.5.1
+run_release_resolver 'Docker Compose version unknown' V5.0.1 docker-compose 5.0.1
 run_release_resolver v2.24.1 V5.0.1 'docker compose' 2.24.1
 run_release_resolver '' V5.0.1 docker-compose 5.0.1
 run_release_resolver 2.19.9 5.0.1 docker-compose 5.0.1

--- a/tools/quality/test-deployment-optional-config.sh
+++ b/tools/quality/test-deployment-optional-config.sh
@@ -233,6 +233,17 @@ python3 "${helper}" --env-file "${insecure_env}" \
 	--runtime-env-file "${insecure_runtime}" >/dev/null
 grep -Fx 'HFL_INSECURE_TLS=1' "${insecure_env}" >/dev/null
 
+missing_tls_env="${tmp}/missing-tls.env"
+missing_tls_runtime="${tmp}/missing-tls-runtime.env"
+cp "${insecure_env}" "${missing_tls_env}"
+cat >"${missing_tls_runtime}" <<'ENV'
+HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=true
+ENV
+python3 "${helper}" --env-file "${missing_tls_env}" \
+	--runtime-env-file "${missing_tls_runtime}" >/dev/null
+grep -Fx 'HFL_INSECURE_TLS=1' "${missing_tls_env}" >/dev/null
+grep -Fx 'HFL_PLATFORM_GATEWAY_AUTO_DEPLOY=true' "${missing_tls_env}" >/dev/null
+
 invalid_tls_env="${tmp}/invalid-tls.env"
 invalid_tls_runtime="${tmp}/invalid-tls-runtime.env"
 cp "${env_file}" "${invalid_tls_env}"
@@ -248,6 +259,21 @@ if python3 "${helper}" --env-file "${invalid_tls_env}" \
 fi
 after_invalid_tls="$(sha256sum "${invalid_tls_env}" | awk '{print $1}')"
 [[ "${before_invalid_tls}" == "${after_invalid_tls}" ]]
+
+empty_tls_env="${tmp}/empty-tls.env"
+empty_tls_runtime="${tmp}/empty-tls-runtime.env"
+cp "${env_file}" "${empty_tls_env}"
+cat >"${empty_tls_runtime}" <<'ENV'
+HFL_INSECURE_TLS=
+ENV
+before_empty_tls="$(sha256sum "${empty_tls_env}" | awk '{print $1}')"
+if python3 "${helper}" --env-file "${empty_tls_env}" \
+	--runtime-env-file "${empty_tls_runtime}" >/dev/null 2>&1; then
+	printf 'ERROR: runtime configuration accepted empty HFL_INSECURE_TLS\n' >&2
+	exit 1
+fi
+after_empty_tls="$(sha256sum "${empty_tls_env}" | awk '{print $1}')"
+[[ "${before_empty_tls}" == "${after_empty_tls}" ]]
 
 ln -s "${runtime_file}" "${tmp}/runtime-link.env"
 if python3 "${helper}" --env-file "${invalid_env}" \


### PR DESCRIPTION
## Summary

- normalize Docker Compose 5 short and descriptive version output before compatibility checks
- preserve the installed `HFL_INSECURE_TLS` value when a staged runtime file omits it
- keep explicit empty or invalid TLS values fail-fast without modifying the installed environment
- add regression coverage for recognized and unrecognized Compose output and partial runtime configuration

Legacy manifest compatibility is intentionally out of scope.

## Validation

- `bash tools/quality/test-compose-command-compatibility.sh`
- `bash tools/quality/test-deployment-optional-config.sh`
- `bash tools/quality/test-upgrade-transaction.sh`
- `bash tools/quality/test-online-community-install.sh`
- `bash tools/quality/check-release-contracts.sh`
- `ruff check deploy/installer/apply-runtime-config.py`
- Python and Bash syntax checks
- `git diff --check`