### PR TITLE
Limit hosted image validation to global sources

### DIFF
--- a/.github/workflows/enterprise_saas_upgrade.yml
+++ b/.github/workflows/enterprise_saas_upgrade.yml
@@ -173,7 +173,7 @@ jobs:
           ./tools/sourcelens/update-runtime-contract.sh --check
 
   verify-public-images:
-    name: Verify · Community image delivery
+    name: Verify · Community image delivery · Global
     needs:
       - prepare
       - build-hfl-images
@@ -194,8 +194,8 @@ jobs:
           path: build/saas-metadata
           merge-multiple: true
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Verify anonymous access and mirror identity
-        run: ./deploy/online/verify-public-images.sh build/saas-metadata
+      - name: Verify global anonymous access and image identity
+        run: ./deploy/online/verify-public-images.sh build/saas-metadata global
 
   build-hfl-images:
     name: Publish · HFL image · ${{ matrix.name }}
@@ -369,7 +369,7 @@ jobs:
           persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Verify regional sources and record metadata
+      - name: Verify global source and record metadata
         shell: bash
         run: |
           set -euo pipefail
@@ -377,24 +377,25 @@ jobs:
           ./release/ci/write-upstream-image-metadata.sh \
             "${{ matrix.component }}" "$metadata"
           expected="$(jq -r '.digest' "$metadata")"
-          while IFS= read -r ref; do
-            immutable_ref="${ref%:*}@$expected"
-            manifest="$(docker buildx imagetools inspect "$immutable_ref" --format '{{json .Manifest}}')"
-            actual="$(jq -r '.digest // empty' <<<"$manifest")"
-            [[ "$actual" == "$expected" ]] || {
-              printf 'ERROR: upstream digest mismatch for %s (%s != %s)\n' \
-                "$immutable_ref" "${actual:-missing}" "$expected" >&2
-              exit 1
-            }
-            image_config="$(docker buildx imagetools inspect \
-              "$immutable_ref" --format '{{json .Image}}')"
-            jq -e '(.os == "linux" and .architecture == "amd64")
-              or has("linux/amd64")' <<<"$image_config" >/dev/null || {
-              printf 'ERROR: upstream image has no linux/amd64 variant: %s\n' \
-                "$immutable_ref" >&2
-              exit 1
-            }
-          done < <(jq -r '.sources[].ref' "$metadata" | sort -u)
+          ref="$(jq -er '[.sources[] | select(.region == "global") | .ref]
+            | if length == 1 then .[0] else error("missing unique global source") end' \
+            "$metadata")"
+          immutable_ref="${ref%:*}@$expected"
+          manifest="$(docker buildx imagetools inspect "$immutable_ref" --format '{{json .Manifest}}')"
+          actual="$(jq -r '.digest // empty' <<<"$manifest")"
+          [[ "$actual" == "$expected" ]] || {
+            printf 'ERROR: upstream digest mismatch for %s (%s != %s)\n' \
+              "$immutable_ref" "${actual:-missing}" "$expected" >&2
+            exit 1
+          }
+          image_config="$(docker buildx imagetools inspect \
+            "$immutable_ref" --format '{{json .Image}}')"
+          jq -e '(.os == "linux" and .architecture == "amd64")
+            or has("linux/amd64")' <<<"$image_config" >/dev/null || {
+            printf 'ERROR: upstream image has no linux/amd64 variant: %s\n' \
+              "$immutable_ref" >&2
+            exit 1
+          }
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: saas-metadata-${{ matrix.component }}

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -1151,14 +1151,8 @@ version = str(manifest.get("version") or "")
 commit = str(manifest.get("git_commit") or "").lower()
 if expected_tag != f"v{version}":
     raise SystemExit("prepared Community version does not match the published release")
-if not re.fullmatch(r"[0-9a-f]{40}", commit):
-    raise SystemExit("prepared Community image revision is invalid")
-if commit != expected_commit:
-    print(
-        "WARNING: prepared Community image revision differs from the published "
-        f"release ({commit[:12]} != {expected_commit[:12]}); continuing",
-        file=sys.stderr,
-    )
+if not re.fullmatch(r"[0-9a-f]{40}", commit) or commit != expected_commit:
+    raise SystemExit("prepared Community image revision does not match the published release")
 if manifest.get("edition") != "community" or manifest.get("channel") != "release":
     raise SystemExit("prepared package is not a Community release")
 PY

--- a/deploy/online/verify-public-images.sh
+++ b/deploy/online/verify-public-images.sh
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
-# Verify that the complete Community online-install image set is anonymous.
+# Verify one region of the complete Community online-install image set.
 set -euo pipefail
 
-[[ $# -eq 1 && -d "$1" ]] || {
-	printf 'Usage: %s METADATA_DIR\n' "$0" >&2
+[[ $# -eq 2 && -d "$1" ]] || {
+	printf 'Usage: %s METADATA_DIR cn|global\n' "$0" >&2
 	exit 2
 }
 metadata_dir=$1
+region=$2
+[[ "${region}" == cn || "${region}" == global ]] || {
+	printf 'ERROR: image verification region must be cn or global\n' >&2
+	exit 2
+}
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 docker_config="$(mktemp -d)"
 tasks="$(mktemp)"
 trap 'rm -rf "${docker_config}"; rm -f "${tasks}"' EXIT
 
-python3 - "${metadata_dir}" "${root}/deploy/online/sourcelens/runtime.json" >"${tasks}" <<'PY'
+python3 - "${metadata_dir}" "${root}/deploy/online/sourcelens/runtime.json" \
+	"${region}" >"${tasks}" <<'PY'
 import json
 import pathlib
 import re
@@ -20,6 +26,7 @@ import sys
 
 root = pathlib.Path(sys.argv[1])
 runtime = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+selected_region = sys.argv[3]
 if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", str(runtime.get("git_ref") or "")):
     raise SystemExit("invalid online SourceLens git_ref")
 if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", str(runtime.get("version") or "")):
@@ -83,6 +90,8 @@ for path in sorted(root.glob("*.json")):
         if len(sources) != 2 or regions != {"cn", "global"}:
             raise SystemExit(f"public image sources are incomplete in {path}")
         for source in sources:
+            if str(source.get("region") or "") != selected_region:
+                continue
             ref = str(source.get("ref") or "")
             selected[ref] = digest
 
@@ -92,8 +101,11 @@ if sourcelens_components != {
     "sourcelens-lensnode",
 }:
     raise SystemExit("online SourceLens component metadata is incomplete")
-if len(selected) != 22:
-    raise SystemExit(f"expected 22 unique Community image refs, found {len(selected)}")
+if len(selected) != 11:
+    raise SystemExit(
+        f"expected 11 unique {selected_region} Community image refs, "
+        f"found {len(selected)}"
+    )
 for ref, digest in sorted(selected.items()):
     print(f"{ref}\t{digest}")
 PY

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -28,9 +28,7 @@ grep -Fq 'api.github.com/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1
 grep -Fq 'gitee.com/api/v5/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1' \
 	"${online}/install.sh"
 grep -Fq 'recent fallback tags:' "${online}/install.sh"
-grep -Fq 'prepared Community image revision is invalid' \
-	"${online}/install.sh"
-grep -Fq 'prepared Community image revision differs from the published' \
+grep -Fq 'prepared Community image revision does not match the published release' \
 	"${online}/install.sh"
 grep -Fq 'run this command through sudo' "${online}/install.sh"
 grep -Fq 'https://mirrors.aliyun.com/docker-ce/linux/ubuntu' "${online}/install.sh"
@@ -110,6 +108,12 @@ if grep -Eq 'publish-community-channel|community-channel|git push origin HEAD:ma
 fi
 grep -Fq 'write-upstream-image-metadata.sh' "${workflow}"
 grep -Fq 'resolve-upstream-images:' "${workflow}"
+grep -Fq './deploy/online/verify-public-images.sh build/saas-metadata global' "${workflow}"
+grep -Fq 'select(.region == "global")' "${workflow}"
+if grep -Fq ".sources[].ref" "${workflow}"; then
+	printf 'ERROR: SaaS workflow still verifies every regional upstream source\n' >&2
+	exit 1
+fi
 if grep -Eq '^  (build-sourcelens-images|publish-runtime-images):' "${workflow}"; then
 	printf 'ERROR: SaaS workflow still publishes rebuilt upstream images\n' >&2
 	exit 1
@@ -560,18 +564,20 @@ mkdir -p "${identity_candidate}"
 cat >"${identity_candidate}/MANIFEST.json" <<'JSON'
 {"version":"1.2.3","git_commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","edition":"community","channel":"release"}
 JSON
-revision_warning_log="${tmp}/revision-warning.log"
-(
+revision_mismatch_log="${tmp}/revision-mismatch.log"
+if (
 	# shellcheck disable=SC1090
 	source "${online_functions}"
 	candidate="${identity_candidate}"
 	TAG=v1.2.3
 	RELEASE_COMMIT=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 	verify_candidate_release
-) >"${revision_warning_log}" 2>&1
-grep -Fq 'prepared Community image revision differs from the published release' \
-	"${revision_warning_log}"
-grep -Fq '(aaaaaaaaaaaa != bbbbbbbbbbbb); continuing' "${revision_warning_log}"
+) >"${revision_mismatch_log}" 2>&1; then
+	printf 'ERROR: mismatched Community image revision was accepted\n' >&2
+	exit 1
+fi
+grep -Fq 'prepared Community image revision does not match the published release' \
+	"${revision_mismatch_log}"
 matching_revision_log="${tmp}/matching-revision.log"
 (
 	# shellcheck disable=SC1090
@@ -604,7 +610,8 @@ if (
 	printf 'ERROR: invalid Community image revision was accepted\n' >&2
 	exit 1
 fi
-grep -Fq 'prepared Community image revision is invalid' "${invalid_revision_log}"
+grep -Fq 'prepared Community image revision does not match the published release' \
+	"${invalid_revision_log}"
 
 apt_retry_log="${tmp}/apt-retry.log"
 apt_retry_saved="${tmp}/logs/install-test-apt.log"
@@ -1665,7 +1672,8 @@ for component in sourcelens-lensnode sourcelens-nginx postgres redis; do
 	"${ROOT}/release/ci/write-upstream-image-metadata.sh" \
 		"${component}" "${metadata}/${component}.json"
 done
-PATH="${fake_bin}:${PATH}" "${online}/verify-public-images.sh" "${metadata}"
+PATH="${fake_bin}:${PATH}" "${online}/verify-public-images.sh" "${metadata}" global
+PATH="${fake_bin}:${PATH}" "${online}/verify-public-images.sh" "${metadata}" cn
 
 # Source only defines functions because install.sh guards main with BASH_SOURCE.
 source "${ROOT}/deploy/installer/install.sh"


### PR DESCRIPTION
## Summary

- validate only global upstream and Community image sources from GitHub-hosted runners
- retain both CN and global immutable sources in release metadata and SaaS candidates
- restore strict Community image revision validation after the temporary compatibility allowance
- preserve authenticated CN image publication and digest verification

## Validation

- `./tools/quality/test-online-community-install.sh`
- `./tools/quality/test-saas-registry-delivery.sh`
- `./tools/quality/check-release-contracts.sh`
- shell syntax checks
- workflow YAML parse
- `git diff --check`