### PR TITLE
Simplify Community installation output

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -337,10 +337,38 @@ print_value() {
 	printf '  %-14s %s\n' "${label}" "${value}"
 }
 
+print_status_value() {
+	local label=$1 value=${2:-}
+	[[ -n "${value}" ]] || return 0
+	printf '  %-17s %s\n' "${label}" "${value}"
+}
+
 print_result() {
 	printf '\n%s\n%s\n%s\n' \
 		'================================================================' "$1" \
 		'================================================================'
+}
+
+online_console_enabled() {
+	[[ "${HFL_ONLINE_CHILD:-0}" == "1" \
+		&& -n "${HFL_ONLINE_CONSOLE_MARKER:-}" ]]
+}
+
+online_console_line() {
+	online_console_enabled || return 0
+	printf '%s%s\n' "${HFL_ONLINE_CONSOLE_MARKER}" "${1:-}"
+}
+
+online_console_section() {
+	online_console_line
+	online_console_line "$1"
+}
+
+online_console_block() {
+	local line
+	while IFS= read -r line || [[ -n "${line}" ]]; do
+		online_console_line "${line}"
+	done
 }
 
 print_warning_summary() {
@@ -1151,6 +1179,21 @@ active_api_service() {
 container_health_status() {
 	local cid=$1
 	docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "${cid}" 2>/dev/null || true
+}
+
+service_group_ready_now() {
+	local compose_function=$1 service cids cid status
+	shift
+	for service in "$@"; do
+		cids="$("${compose_function}" ps -q "${service}" 2>/dev/null)" || return 1
+		[[ -n "${cids}" ]] || return 1
+		while IFS= read -r cid; do
+			[[ -n "${cid}" ]] || continue
+			status="$(container_health_status "${cid}")"
+			[[ "${status}" == "healthy" || "${status}" == "running" ]] || return 1
+		done <<<"${cids}"
+	done
+	return 0
 }
 
 wait_for_services_health() {
@@ -3951,6 +3994,83 @@ print_console_access_summary() {
 	fi
 }
 
+print_online_community_summary() {
+	local env_file="${ROOT}/.env"
+	local host seed seed_email seed_pass seed_org tenant_port admin_port
+	local show_credentials=0 credentials_note
+	[[ -f "${env_file}" ]] || return 0
+	host="$(resolve_console_host)"
+	seed="$(read_env_value SEED_INITIAL_DATA)"
+	seed_email="$(read_env_value SEED_ADMIN_EMAIL)"
+	seed_pass="$(read_env_value SEED_ADMIN_PASSWORD)"
+	seed_org="$(read_env_value SEED_ORG_NAME)"
+	tenant_port="$(read_env_value HFL_TENANT_PORT)"
+	[[ -n "${tenant_port}" ]] || tenant_port=11443
+	admin_port="$(read_env_value HFL_ADMIN_PORT)"
+	[[ -n "${admin_port}" ]] || admin_port=11444
+
+	if [[ "${seed}" == "1" ]]; then
+		[[ -n "${seed_email}" ]] || seed_email="admin@hyperfilelens.com"
+		[[ -n "${seed_pass}" ]] || seed_pass="Admin@123"
+		[[ -n "${seed_org}" ]] || seed_org="HyperFileLens"
+		case "${SHOW_GENERATED_CREDENTIALS}" in
+		1 | true | yes | on) show_credentials=1 ;;
+		0 | false | no | off) show_credentials=0 ;;
+		auto) [[ "${INTERACTIVE_SESSION}" -eq 1 ]] && show_credentials=1 || true ;;
+		*) die "invalid HFL_SHOW_GENERATED_CREDENTIALS=${SHOW_GENERATED_CREDENTIALS}" ;;
+		esac
+		credentials_note="stored in ${env_file}; values are hidden in non-interactive logs"
+	fi
+
+	print_result "Installation completed successfully"
+	print_section "Installation summary"
+	print_value "Version" "$(read_version)"
+	print_value "Edition" "$(display_edition_from_dir "${ROOT}")"
+	print_value "Platform" "$(installation_platform_display)"
+	print_value "Install path" "${ROOT}"
+	print_value "Config file" "${env_file}"
+	print_value "Log file" "${LOG_FILE}"
+
+	print_section "Access"
+	printf '  HyperFileLens · %s\n' "${tenant_port}"
+	print_nested_value "URL" "https://${host}:${tenant_port}/"
+	if [[ "${seed}" == "1" ]]; then
+		if [[ "${show_credentials}" -eq 1 ]]; then
+			print_nested_value "Email" "${seed_email}"
+			print_nested_value "Password" "${seed_pass}"
+		else
+			print_nested_value "Credentials" "${credentials_note}"
+		fi
+		print_nested_value "Organization" "${seed_org}"
+	fi
+
+	printf '\n  Platform Ops · %s\n' "${admin_port}"
+	print_nested_value "URL" "https://${host}:${admin_port}/"
+	if [[ "${seed}" == "1" ]]; then
+		if [[ "${show_credentials}" -eq 1 ]]; then
+			print_nested_value "Email" "${seed_email}"
+			print_nested_value "Password" "${seed_pass}"
+		else
+			print_nested_value "Credentials" "${credentials_note}"
+		fi
+	else
+		warn "Initial seeding is disabled (SEED_INITIAL_DATA=${seed:-0}); no default admin account will be created automatically."
+	fi
+
+	if [[ "${seed}" == "1" ]]; then
+		SESSION_WARNINGS+=("Change all default passwords after the first login.")
+	fi
+	print_warning_summary
+
+	print_section "Management commands"
+	print_value "Status" "sudo ${ROOT}/install.sh status"
+	print_value "Logs" "sudo docker compose -f ${ROOT}/docker-compose.yml logs -f"
+	print_value "Restart" "sudo ${ROOT}/install.sh restart"
+	print_value "Backup" "sudo ${ROOT}/install.sh backup"
+	print_value "Upgrade" "sudo ${ROOT}/install.sh upgrade --from /path/to/new-release.tar.gz"
+	print_value "Uninstall" "sudo ${ROOT}/install.sh uninstall"
+}
+
 print_platform_gateway_summary() {
 	local host=$1 tenant_port=$2
 	local node_id organization version service container_id ai_engine console_state
@@ -5225,7 +5345,7 @@ repair_existing_multimodal_model() {
 # --- Commands ---
 
 cmd_install() {
-	local sourcelens_mode=-1 allow_main_build=0
+	local sourcelens_mode=-1 allow_main_build=0 concise_online=0 summary_output=""
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--with-sourcelens) sourcelens_mode=1 ;;
@@ -5252,6 +5372,12 @@ cmd_install() {
 	# destination .env remains authoritative when auto-deploy was disabled.
 	ROOT="${INSTALL_DIR}"
 	preflight_local_platform_gateway_agent_conflict
+	if online_console_enabled; then
+		concise_online=1
+		online_console_section "[3/4] Starting HyperFileLens"
+		online_console_line
+		online_console_line "  [....] Preparing configuration and runtime assets"
+	fi
 	if [[ "${HFL_ONLINE_CHILD:-0}" != "1" ]]; then
 		print_section "Target"
 		print_value "Version" "${version}"
@@ -5310,6 +5436,11 @@ cmd_install() {
 	if [[ "${HFL_ONLINE_CHILD:-0}" != "1" ]]; then
 		ok "Required container images are available"
 	fi
+	if [[ "${concise_online}" -eq 1 ]]; then
+		online_console_line "  [ OK ] Configuration and runtime assets are ready"
+		online_console_line
+		online_console_line "  [....] Starting HyperFileLens and Insight services"
+	fi
 
 	print_section "[5/8] Installing insight services"
 	if should_install_sourcelens "${sourcelens_mode}"; then
@@ -5345,6 +5476,11 @@ cmd_install() {
 				|| die "could not record the installed SourceLens bundle identity"
 		fi
 	fi
+	if [[ "${concise_online}" -eq 1 ]]; then
+		online_console_line "  [ OK ] Application services are ready"
+		online_console_line
+		online_console_line "  [....] Preparing the local Platform Data Gateway"
+	fi
 	print_section "[7/8] Preparing platform services"
 	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
 		print_section "Identity and email"
@@ -5360,6 +5496,15 @@ cmd_install() {
 	ensure_local_platform_gateway
 	prune_agent_release_media
 	ok "Platform configuration and managed services are ready"
+	if [[ "${concise_online}" -eq 1 ]]; then
+		if local_platform_gateway_agent_is_managed \
+			&& [[ "${LOCAL_PLATFORM_GATEWAY_VERIFIED}" -eq 1 ]]; then
+			online_console_line "  [ OK ] Platform Data Gateway is online"
+		else
+			online_console_line "  [ OK ] Platform services are ready"
+		fi
+		online_console_section "[4/4] Verifying installation"
+	fi
 
 	print_section "[8/8] Verifying installation"
 	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
@@ -5367,8 +5512,27 @@ cmd_install() {
 	else
 		compose_all_profiles ps
 	fi
-	print_result "Installation completed successfully"
-	print_console_access_summary
+	if [[ "${concise_online}" -eq 1 ]]; then
+		online_console_line
+		online_console_line "  HyperFileLens       Ready"
+		online_console_line "  Platform Ops        Ready"
+		if [[ "${sourcelens_mode}" -ne 0 \
+			&& "$(configured_sourcelens_mode)" == "bundled" ]] \
+			&& sourcelens_installed; then
+			online_console_line "  Insight services    Ready"
+		fi
+		if local_platform_gateway_agent_is_managed \
+			&& [[ "${LOCAL_PLATFORM_GATEWAY_VERIFIED}" -eq 1 ]]; then
+			online_console_line "  Platform Gateway    Online"
+		fi
+		online_console_line
+		online_console_line "  [ OK ] Installation verification passed"
+		summary_output="$(print_online_community_summary)"
+		online_console_block <<<"${summary_output}"
+	else
+		print_result "Installation completed successfully"
+		print_console_access_summary
+	fi
 }
 
 cmd_platform_gateway() {
@@ -5457,41 +5621,65 @@ cmd_restart() {
 
 cmd_status() {
 	init_install_root
-	local version
-	version="$(read_version)"
-	printf 'Version: %s\n' "${version}"
-	printf 'Install dir: %s\n' "${ROOT}"
-	local active_color deployment_phase
-	if active_color="$(read_active_color)"; then
-		printf 'Active color: %s\n' "${active_color}"
-	else
-		printf 'Active color: legacy/unset\n'
-	fi
-	deployment_phase="$(grep -E '^phase=' "$(blue_green_state_dir)/deployment-state" 2>/dev/null | head -1 | cut -d= -f2- || true)"
-	printf 'Deployment phase: %s\n' "${deployment_phase:-unknown}"
-	if sourcelens_installed; then
-		printf 'Insight services: installed at %s (network %s)\n' \
-			"${SOURCELENS_INSTALL_DIR}" "${HFL_BRIDGE_NETWORK}"
-	else
-		printf 'Insight services: not installed\n'
-	fi
-	if [[ -f "${ROOT}/data/media/gateway-bootstrap/lensnode-image-linux-amd64.tar.gz" ]]; then
-		printf 'Platform Data Gateway: AI engine bundle present\n'
-	else
-		printf 'Platform Data Gateway: AI engine bundle missing\n'
-	fi
-	if [[ -d "${ROOT}/data/media/agent-releases" ]]; then
-		local versions
-		versions="$(find "${ROOT}/data/media/agent-releases" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null | sort -V | tr '\n' ' ')"
-		printf 'Agent releases: %s\n' "${versions:-none}"
-	fi
-	if [[ -f "${ROOT}/.env" ]]; then
-		require_docker
-		compose_all_profiles ps
-		print_console_access_summary "Access and management" 0
-	else
+	if [[ ! -f "${ROOT}/.env" ]]; then
 		warn "missing .env; install has not been run"
+		return 0
 	fi
+	require_docker
+	local version active_color host tenant_port admin_port
+	local hfl_status="Degraded" insight_status="Not installed" gateway_status="Not installed"
+	local container_id=""
+	version="$(read_version)"
+	host="$(resolve_console_host)"
+	tenant_port="$(read_env_value HFL_TENANT_PORT)"
+	[[ -n "${tenant_port}" ]] || tenant_port=11443
+	admin_port="$(read_env_value HFL_ADMIN_PORT)"
+	[[ -n "${admin_port}" ]] || admin_port=11444
+
+	if active_color="$(read_active_color)" \
+		&& service_group_ready_now compose_all_profiles \
+			postgres redis worker scheduler "api-${active_color}" "web-${active_color}" nginx; then
+		hfl_status="Healthy"
+	fi
+	if [[ "$(configured_sourcelens_mode)" == "external" ]]; then
+		insight_status="External"
+	elif sourcelens_installed; then
+		insight_status="Degraded"
+		if service_group_ready_now sourcelens_compose \
+			api "$(sourcelens_web_service)" worker scheduler postgres redis nginx; then
+			insight_status="Healthy"
+		fi
+	fi
+	if local_platform_gateway_agent_is_managed; then
+		gateway_status="Degraded"
+		container_id="$(docker ps -q \
+			--filter 'label=com.hyperfilelens.managed=true' \
+			--filter 'label=com.hyperfilelens.component=gateway-lensnode' \
+			--filter 'label=com.docker.compose.project=hyperfilelens-gateway' \
+			--filter 'label=com.docker.compose.service=lensnode' 2>/dev/null | head -1)"
+		if systemctl is-active --quiet hyperfilelens-agent.service \
+			&& [[ -n "${container_id}" ]]; then
+			gateway_status="Running"
+		fi
+	fi
+
+	print_section "HyperFileLens"
+	print_status_value "Version" "${version}"
+	print_status_value "Edition" "$(display_edition_from_dir "${ROOT}")"
+	print_status_value "Status" "${hfl_status}"
+	print_status_value "Install path" "${ROOT}"
+
+	print_section "Access"
+	print_status_value "HyperFileLens" "https://${host}:${tenant_port}/"
+	print_status_value "Platform Ops" "https://${host}:${admin_port}/"
+
+	print_section "Services"
+	print_status_value "Insight" "${insight_status}"
+	print_status_value "Platform Gateway" "${gateway_status}"
+
+	print_section "Management"
+	print_status_value "Logs" "sudo docker compose -f ${ROOT}/docker-compose.yml logs -f"
+	print_status_value "Restart" "sudo ${ROOT}/install.sh restart"
 }
 
 cmd_manage() {

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -26,6 +26,7 @@ INSTALL_ACTION="Install"
 MAX_TAG_PAGES=100
 ONLINE_LOG_FILE=""
 ONLINE_INTERACTIVE=0
+ONLINE_CHILD_CONSOLE_MARKER="__HFL_ONLINE_CONSOLE__"
 HOST_UBUNTU_CODENAME=""
 DOCKER_CE_APT_BASE=""
 DOCKER_CE_GPG_URL=""
@@ -101,6 +102,21 @@ capture_log_stream() {
 	tee "/dev/fd/${console_fd}" \
 		| tr '\r' '\n' \
 		| timestamp_log_stream "${log_file}"
+}
+
+capture_child_install_stream() {
+	local log_file=$1 console_fd=$2 line timestamp rendered
+	local TZ=UTC
+	export TZ
+	while IFS= read -r line || [[ -n "${line}" ]]; do
+		rendered="${line}"
+		if [[ "${line}" == "${ONLINE_CHILD_CONSOLE_MARKER}"* ]]; then
+			rendered="${line#"${ONLINE_CHILD_CONSOLE_MARKER}"}"
+			printf '%s\n' "${rendered}" >"/dev/fd/${console_fd}"
+		fi
+		printf -v timestamp '%(%Y-%m-%dT%H:%M:%S.000Z)T' -1
+		printf '[%s] %s\n' "${timestamp}" "${rendered}" >>"${log_file}"
+	done
 }
 
 apt_failure_is_transient() {
@@ -207,28 +223,55 @@ Target
   Log file       ${ONLINE_LOG_FILE}
 EOF
 
-	printf '\nHost runtime\n'
+	if [[ "${INSTALL_ACTION}" == "Upgrade" ]]; then
+		printf '\nHost runtime\n'
+		case "${DOCKER_RUNTIME_ACTION}" in
+		install)
+			printf '  Docker Engine  not installed → install %s\n' "${DOCKER_TARGET_ENGINE_VERSION}"
+			printf '  Docker Compose not installed → install %s\n' "${DOCKER_TARGET_COMPOSE_VERSION}"
+			printf '  Package source %s\n' "${DOCKER_CE_SOURCE_NAME}"
+			printf '  Docker service enable and start\n'
+			printf '  Lifecycle      retained when HyperFileLens is removed\n'
+			;;
+		install-compose)
+			printf '  Docker Engine  %s · reuse\n' "${DOCKER_ENGINE_VERSION}"
+			printf '  Docker Compose not installed → install docker-compose-plugin %s\n' \
+				"${DOCKER_COMPOSE_PACKAGE_VERSION}"
+			printf '  Package source %s\n' "${DOCKER_CE_SOURCE_NAME}"
+			printf '  Install scope  Compose V2 plugin only\n'
+			printf '  Docker service active\n'
+			printf '  Lifecycle      retained when HyperFileLens is removed\n'
+			;;
+		reuse)
+			printf '  Docker Engine  %s · reuse\n' "${DOCKER_ENGINE_VERSION}"
+			printf '  Docker Compose %s · reuse\n' "${DOCKER_COMPOSE_VERSION}"
+			printf '  Docker service active\n'
+			;;
+		*) fail "internal Docker runtime action is invalid" ;;
+		esac
+		return 0
+	fi
+
+	printf '\nSystem requirements\n\n'
 	case "${DOCKER_RUNTIME_ACTION}" in
 	install)
-		printf '  Docker Engine  not installed → install %s\n' "${DOCKER_TARGET_ENGINE_VERSION}"
-		printf '  Docker Compose not installed → install %s\n' "${DOCKER_TARGET_COMPOSE_VERSION}"
-		printf '  Package source %s\n' "${DOCKER_CE_SOURCE_NAME}"
-		printf '  Docker service enable and start\n'
-		printf '  Lifecycle      retained when HyperFileLens is removed\n'
+		printf '  %-16s %s\n' 'Docker Engine' "Will install · ${DOCKER_TARGET_ENGINE_VERSION}"
+		printf '  %-16s %s\n' 'Docker Compose' "Will install · ${DOCKER_TARGET_COMPOSE_VERSION}"
+		printf '  %-16s %s\n' 'Docker service' 'Will enable and start'
+		printf '\nThe required container runtime will be installed on this host.\n'
 		;;
 	install-compose)
-		printf '  Docker Engine  %s · reuse\n' "${DOCKER_ENGINE_VERSION}"
-		printf '  Docker Compose not installed → install docker-compose-plugin %s\n' \
-			"${DOCKER_COMPOSE_PACKAGE_VERSION}"
-		printf '  Package source %s\n' "${DOCKER_CE_SOURCE_NAME}"
-		printf '  Install scope  Compose V2 plugin only\n'
-		printf '  Docker service active\n'
-		printf '  Lifecycle      retained when HyperFileLens is removed\n'
+		printf '  %-16s %s\n' 'Docker Engine' "Ready · ${DOCKER_ENGINE_VERSION}"
+		printf '  %-16s %s\n' 'Docker Compose' \
+			"Will install · ${DOCKER_COMPOSE_PACKAGE_VERSION}"
+		printf '  %-16s %s\n' 'Docker service' 'Running'
+		printf '\nThe required Docker Compose plugin will be installed on this host.\n'
 		;;
 	reuse)
-		printf '  Docker Engine  %s · reuse\n' "${DOCKER_ENGINE_VERSION}"
-		printf '  Docker Compose %s · reuse\n' "${DOCKER_COMPOSE_VERSION}"
-		printf '  Docker service active\n'
+		printf '  %-16s %s\n' 'Docker Engine' "Ready · ${DOCKER_ENGINE_VERSION}"
+		printf '  %-16s %s\n' 'Docker Compose' "Ready · ${DOCKER_COMPOSE_VERSION}"
+		printf '  %-16s %s\n' 'Docker service' 'Running'
+		printf '\n  [ OK ] System requirements are satisfied\n'
 		;;
 	*) fail "internal Docker runtime action is invalid" ;;
 	esac
@@ -943,16 +986,35 @@ download_file() {
 	local output=$2
 	local max_time=${3:-120}
 	local partial="${output}.part"
-	rm -f -- "${partial}"
+	local diagnostics="${output}.curl-errors"
+	rm -f -- "${partial}" "${diagnostics}"
+	if [[ "${INSTALL_ACTION}" == "Upgrade" ]]; then
+		if curl --fail --show-error --silent --location \
+			"${CURL_RETRY_ARGS[@]}" \
+			--connect-timeout 15 --max-time "${max_time}" \
+			-H 'Cache-Control: no-cache' "${url}" -o "${partial}"; then
+			if mv -f -- "${partial}" "${output}"; then
+				return 0
+			fi
+		fi
+		rm -f -- "${partial}"
+		return 1
+	fi
 	if curl --fail --show-error --silent --location \
 		"${CURL_RETRY_ARGS[@]}" \
 		--connect-timeout 15 --max-time "${max_time}" \
-		-H 'Cache-Control: no-cache' "${url}" -o "${partial}"; then
+		-H 'Cache-Control: no-cache' "${url}" -o "${partial}" \
+		2>"${diagnostics}"; then
+		if [[ -s "${diagnostics}" && -n "${ONLINE_LOG_FILE}" ]]; then
+			timestamp_log_stream "${ONLINE_LOG_FILE}" <"${diagnostics}"
+		fi
+		rm -f -- "${diagnostics}"
 		if mv -f -- "${partial}" "${output}"; then
 			return 0
 		fi
 	fi
-	rm -f -- "${partial}"
+	[[ ! -s "${diagnostics}" ]] || cat "${diagnostics}" >&2
+	rm -f -- "${partial}" "${diagnostics}"
 	return 1
 }
 
@@ -976,7 +1038,11 @@ resolve_tag() {
 	local -a values=()
 	local -A seen_page_fingerprints=()
 	requested_tag="${TAG}"
-	printf '[....] Resolving Community tags from %s\n' "${SOURCE_NAME}"
+	if [[ "${INSTALL_ACTION}" == "Install" ]]; then
+		printf '  [....] Resolving HyperFileLens Community release from %s\n' "${SOURCE_NAME}"
+	else
+		printf '[....] Resolving Community tags from %s\n' "${SOURCE_NAME}"
+	fi
 	page=1
 	while :; do
 		page_url="$(tag_page_url "${page}")"
@@ -1099,8 +1165,13 @@ PY
 	TAG="${values[0]}"
 	RELEASE_VERSION="${values[1]}"
 	RELEASE_COMMIT="${values[2]}"
-	printf '[ OK ] Community release resolved · %s · commit %s\n' \
-		"${TAG}" "${RELEASE_COMMIT:0:12}"
+	if [[ "${INSTALL_ACTION}" == "Install" ]]; then
+		printf '  [ OK ] Community release resolved · %s · commit %s\n' \
+			"${TAG}" "${RELEASE_COMMIT:0:12}"
+	else
+		printf '[ OK ] Community release resolved · %s · commit %s\n' \
+			"${TAG}" "${RELEASE_COMMIT:0:12}"
+	fi
 }
 
 confirm_installation() {
@@ -1108,8 +1179,36 @@ confirm_installation() {
 	((ASSUME_YES == 1)) && return 0
 	[[ -r /dev/tty ]] \
 		|| fail "interactive confirmation requires a terminal; use --yes only for automation"
-	read -r -p 'Continue? [y/N] ' answer </dev/tty
+	if [[ "${INSTALL_ACTION}" == "Upgrade" ]]; then
+		read -r -p 'Continue? [y/N] ' answer </dev/tty
+	else
+		read -r -p "Proceed with the HyperFileLens Community ${TAG} installation? [y/N] " answer </dev/tty
+	fi
 	case "${answer}" in y | Y | yes | YES | Yes) ;; *) fail "installation cancelled" ;; esac
+}
+
+run_fresh_community_install() {
+	local package=$1 rc status
+	local -a pipeline_status=()
+	set +e
+	HFL_REGISTRY_REGION="${REGION}" HFL_ONLINE_CHILD=1 HFL_PARENT_LOGGING=1 \
+		HFL_PARENT_INTERACTIVE="${ONLINE_INTERACTIVE}" HFL_LOG_FILE="${ONLINE_LOG_FILE}" \
+		HFL_ONLINE_CONSOLE_MARKER="${ONLINE_CHILD_CONSOLE_MARKER}" HFL_NO_BANNER=1 \
+		bash "${package}/install.sh" install --with-sourcelens --yes \
+		2>&1 \
+		| tr '\r' '\n' \
+		| sed $'s/\033\\[[0-9;?]*[ -/]*[@-~]//g' \
+		| capture_child_install_stream "${ONLINE_LOG_FILE}" 3
+	pipeline_status=("${PIPESTATUS[@]}")
+	set -e
+	rc=${pipeline_status[0]}
+	for status in "${pipeline_status[@]:1}"; do
+		[[ "${status}" -eq 0 ]] \
+			|| fail "could not write the complete installation output to ${ONLINE_LOG_FILE}"
+	done
+	if [[ "${rc}" -ne 0 ]]; then
+		fail "HyperFileLens Community ${TAG} installation failed; review the full log: ${ONLINE_LOG_FILE}"
+	fi
 }
 
 download_source_archive() {
@@ -1118,9 +1217,14 @@ download_source_archive() {
 	global) url="https://codeload.github.com/oneprolabs/hyperfilelens/tar.gz/${RELEASE_COMMIT}" ;;
 	cn) url="https://gitee.com/oneprolabs/hyperfilelens/repository/archive/${RELEASE_COMMIT}.tar.gz" ;;
 	esac
-	printf '\nRelease contract\n'
-	printf '[....] Downloading %s installation contract from %s (commit %s)\n' \
-		"${TAG}" "${SOURCE_NAME}" "${RELEASE_COMMIT:0:12}"
+	if [[ "${INSTALL_ACTION}" == "Install" ]]; then
+		printf '  [....] Downloading %s installation contract from %s (commit %s)\n' \
+			"${TAG}" "${SOURCE_NAME}" "${RELEASE_COMMIT:0:12}"
+	else
+		printf '\nRelease contract\n'
+		printf '[....] Downloading %s installation contract from %s (commit %s)\n' \
+			"${TAG}" "${SOURCE_NAME}" "${RELEASE_COMMIT:0:12}"
+	fi
 	if ! download_file "${url}" "${SESSION_DIR}/source.tar.gz" 300; then
 		fail_with_tag_guidance "Community release ${TAG} cannot be downloaded from ${SOURCE_NAME}"
 	fi
@@ -1130,7 +1234,11 @@ download_source_archive() {
 	[[ -x "${SESSION_DIR}/source/deploy/online/install.sh" \
 		&& -f "${SESSION_DIR}/source/deploy/online/prepare.py" ]] \
 		|| fail_with_tag_guidance "Community tag ${TAG} does not provide the online installation contract"
-	printf '[ OK ] Downloaded installation contract from %s\n' "${SOURCE_NAME}"
+	if [[ "${INSTALL_ACTION}" == "Install" ]]; then
+		printf '  [ OK ] Installation contract downloaded from %s\n' "${SOURCE_NAME}"
+	else
+		printf '[ OK ] Downloaded installation contract from %s\n' "${SOURCE_NAME}"
+	fi
 }
 
 verify_candidate_release() {
@@ -1209,28 +1317,47 @@ if [[ "${DOCKER_RUNTIME_ACTION}" != reuse ]]; then
 fi
 print_target
 confirm_installation
+
+if [[ "${INSTALL_ACTION}" == "Install" ]]; then
+	printf '\n[1/4] Preparing installation\n\n'
+	printf '  [....] Validating the release package and host environment\n'
+fi
 install_host_tools
 if [[ "${DOCKER_RUNTIME_ACTION}" == reuse ]]; then
 	download_source_archive
 fi
 ensure_online_docker_runtime
+if [[ "${INSTALL_ACTION}" == "Install" ]]; then
+	printf '  [ OK ] Release package and host requirements are ready\n'
+	printf '\n[2/4] Downloading installation assets\n\n'
+fi
 
 export HFL_GLOBAL_REGISTRY_PREFIX="${GLOBAL_REGISTRY_PREFIX}"
 export HFL_CN_REGISTRY_PREFIX="${CN_REGISTRY_PREFIX}"
 export HFL_REGISTRY_REGION="${REGION}"
 export HFL_ONLINE_NATIVE_PROGRESS="${ONLINE_INTERACTIVE}"
 candidate="${SESSION_DIR}/hyperfilelens-${RELEASE_VERSION}-online"
+prepare_args=(
+	--source-root "${SESSION_DIR}/source"
+	--version "${TAG}"
+	--region "${REGION}"
+	--output "${candidate}"
+)
+if [[ "${INSTALL_ACTION}" == "Install" ]]; then
+	prepare_args+=(--concise-output)
+fi
 if ! python3 "${SESSION_DIR}/source/deploy/online/prepare.py" \
-	--source-root "${SESSION_DIR}/source" \
-	--version "${TAG}" \
-	--region "${REGION}" \
-	--output "${candidate}"; then
+	"${prepare_args[@]}"; then
 	fail_with_tag_guidance "Community tag ${TAG} is incomplete or unavailable"
 fi
 if ! verify_candidate_release; then
 	fail_with_tag_guidance "Community tag ${TAG} failed release identity validation"
 fi
-printf '[ OK ] Release package and installation assets are ready\n'
+if [[ "${INSTALL_ACTION}" == "Install" ]]; then
+	printf '  [ OK ] All installation assets are ready\n'
+else
+	printf '[ OK ] Release package and installation assets are ready\n'
+fi
 
 if [[ "${INSTALL_ACTION}" == Upgrade ]]; then
 	printf '[....] Upgrading the existing installation to %s\n' "${TAG}"
@@ -1239,9 +1366,5 @@ if [[ "${INSTALL_ACTION}" == Upgrade ]]; then
 		HFL_NO_BANNER=1 bash "${candidate}/install.sh" \
 		upgrade --from "${candidate}" --yes --with-sourcelens
 else
-	printf '[....] Installing HyperFileLens Community %s\n' "${TAG}"
-	HFL_REGISTRY_REGION="${REGION}" HFL_ONLINE_CHILD=1 HFL_PARENT_LOGGING=1 \
-		HFL_PARENT_INTERACTIVE="${ONLINE_INTERACTIVE}" HFL_LOG_FILE="${ONLINE_LOG_FILE}" \
-		HFL_NO_BANNER=1 bash "${candidate}/install.sh" \
-		install --with-sourcelens --yes
+	run_fresh_community_install "${candidate}"
 fi

--- a/deploy/online/prepare.py
+++ b/deploy/online/prepare.py
@@ -511,17 +511,23 @@ def write_pull_plan(path: pathlib.Path, specs: list[ImageSpec], region: str) -> 
 
 
 def pull_image_batch(
-    specs: list[ImageSpec], region: str
+    specs: list[ImageSpec], region: str, *, concise_output: bool = False
 ) -> subprocess.CompletedProcess[str]:
     """Pull one image batch through Docker Compose's native scheduler."""
     with tempfile.TemporaryDirectory(prefix="hfl-online-pull-") as temporary:
         compose_file = pathlib.Path(temporary) / "docker-compose.yml"
         write_pull_plan(compose_file, specs, region)
-        print(
-            f"[....] Pulling {len(specs)} installation images concurrently "
-            f"· maximum {PULL_PARALLELISM} active downloads",
-            flush=True,
-        )
+        if concise_output:
+            message = (
+                f"  [....] Pulling {len(specs)} container images "
+                f"· up to {PULL_PARALLELISM} concurrent downloads"
+            )
+        else:
+            message = (
+                f"[....] Pulling {len(specs)} installation images concurrently "
+                f"· maximum {PULL_PARALLELISM} active downloads"
+            )
+        print(message, flush=True)
         # A PTY preserves Compose's familiar aggregate progress renderer. The
         # online parent mirrors the relayed stream into its durable log.
         return run_with_native_progress(
@@ -563,27 +569,38 @@ def inspect_pulled_images(
     return resolved, unresolved
 
 
-def pull_images(specs: list[ImageSpec], preferred_region: str) -> list[ResolvedImage]:
+def pull_images(
+    specs: list[ImageSpec],
+    preferred_region: str,
+    *,
+    concise_output: bool = False,
+) -> list[ResolvedImage]:
     """Pull all images concurrently with a selective regional fallback."""
     fallback_region = "global" if preferred_region == "cn" else "cn"
-    primary = pull_image_batch(specs, preferred_region)
+    primary = pull_image_batch(
+        specs, preferred_region, concise_output=concise_output
+    )
     resolved, unresolved = inspect_pulled_images(specs, preferred_region)
 
     if unresolved:
+        prefix = "  " if concise_output else ""
         print(
-            f"[WARN] {len(unresolved)} installation image(s) were not available "
-            "from the preferred registry",
+            f"{prefix}[WARN] {len(unresolved)} installation image(s) were not "
+            "available from the preferred registry",
             flush=True,
         )
 
     fallback_output = ""
     if unresolved:
+        prefix = "  " if concise_output else ""
         print(
-            f"[....] Retrying {len(unresolved)} installation image(s) from "
-            "the fallback registry",
+            f"{prefix}[....] Retrying {len(unresolved)} installation image(s) "
+            "from the fallback registry",
             flush=True,
         )
-        fallback = pull_image_batch(unresolved, fallback_region)
+        fallback = pull_image_batch(
+            unresolved, fallback_region, concise_output=concise_output
+        )
         fallback_output = fallback.stdout or ""
         fallback_resolved, unresolved = inspect_pulled_images(
             unresolved, fallback_region
@@ -615,11 +632,12 @@ def pull_images(specs: list[ImageSpec], preferred_region: str) -> list[ResolvedI
     for position, spec in enumerate(specs, start=1):
         image = resolved[spec.component]
         run(["docker", "tag", image.source_ref, spec.local_ref])
-        print(
-            f"[ OK ] Installation image {position}/{total} ready · "
-            f"{spec.local_ref}@{image.digest}",
-            flush=True,
-        )
+        if not concise_output:
+            print(
+                f"[ OK ] Installation image {position}/{total} ready · "
+                f"{spec.local_ref}@{image.digest}",
+                flush=True,
+            )
         result.append(image)
     return result
 
@@ -893,6 +911,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--version", required=True)
     parser.add_argument("--region", choices=("cn", "global"), required=True)
     parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--concise-output", action="store_true")
     return parser.parse_args()
 
 
@@ -950,11 +969,19 @@ def main() -> int:
         )
         for kind in ("agent", "gateway", "language")
     ]
-    print("\nInstallation images", flush=True)
-    images = pull_images(runtime_specs + asset_specs, args.region)
+    if not args.concise_output:
+        print("\nInstallation images", flush=True)
+    images = pull_images(
+        runtime_specs + asset_specs,
+        args.region,
+        concise_output=args.concise_output,
+    )
     runtime = images[: len(runtime_specs)]
     assets = images[len(runtime_specs) :]
-    print(f"[ OK ] All {len(images)} installation images are ready", flush=True)
+    if args.concise_output:
+        print(f"  [ OK ] All {len(images)} container images are ready", flush=True)
+    else:
+        print(f"[ OK ] All {len(images)} installation images are ready", flush=True)
 
     revision = image_revision(f"hyperfilelens-backend:{version}")
     if image_revision(f"hyperfilelens-frontend:{version}") != revision:
@@ -964,18 +991,32 @@ def main() -> int:
         "gateway": "Data Gateway packages",
         "language": "Language packs",
     }
-    print("\nRelease package", flush=True)
+    if args.concise_output:
+        print(
+            "\n  [....] Preparing Agent, Data Gateway, and language packages",
+            flush=True,
+        )
+    else:
+        print("\nRelease package", flush=True)
     for asset in assets:
         label = asset_labels[asset.spec.asset_kind]
-        print(f"[....] Preparing {label}", flush=True)
+        if not args.concise_output:
+            print(f"[....] Preparing {label}", flush=True)
         try:
             extract_asset(asset, target / "payload")
         finally:
             discard_asset_image(asset)
-        print(f"[ OK ] {label} are ready", flush=True)
+        if not args.concise_output:
+            print(f"[ OK ] {label} are ready", flush=True)
+    if args.concise_output:
+        print(
+            "  [ OK ] Agent, Data Gateway, and language packages are ready",
+            flush=True,
+        )
     sourcelens = write_sourcelens_build_info(source, target, runtime, lensnode_spec)
     write_manifest(target, version, revision, runtime, assets, sourcelens)
-    print(f"[ OK ] Community release package prepared · {target}")
+    if not args.concise_output:
+        print(f"[ OK ] Community release package prepared · {target}")
     return 0
 
 

--- a/tools/quality/test-lifecycle-output-contract.sh
+++ b/tools/quality/test-lifecycle-output-contract.sh
@@ -60,26 +60,27 @@ grep -F 'adminpassword' <<<"${output}" >/dev/null
 grep -F 'install.sh upgrade --from /path/to/new-release.tar.gz' <<<"${output}" >/dev/null
 grep -F 'install.sh uninstall' <<<"${output}" >/dev/null
 
-# The online installer groups each login with its endpoint while preserving
-# the same credential visibility policy as the standalone installer.
+# A fresh Community online installation exposes only the two user-facing
+# entry points while preserving the existing credential visibility policy.
 SESSION_WARNINGS=()
 HFL_ONLINE_CHILD=1
-online_output="$(print_console_access_summary 2>&1)"
-unset HFL_ONLINE_CHILD
-for heading in \
-	'Website · 11442' \
-	'Tenant · 11443' \
-	'Platform Ops · 11444' \
-	'Django Admin · 11444' \
-	'Insight Console · 11445' \
-	'API / Swagger · 11443'; do
+HFL_ONLINE_CONSOLE_MARKER=__TEST_ONLINE_CONSOLE__
+online_output="$(print_online_community_summary 2>&1)"
+unset HFL_ONLINE_CHILD HFL_ONLINE_CONSOLE_MARKER
+for heading in 'HyperFileLens · 11443' 'Platform Ops · 11444'; do
 	grep -F "${heading}" <<<"${online_output}" >/dev/null
 done
 grep -F 'linux/amd64' <<<"${online_output}" >/dev/null
 grep -F 'Email          admin@hyperfilelens.com' <<<"${online_output}" >/dev/null
 grep -F 'Password       Admin@123' <<<"${online_output}" >/dev/null
-grep -F 'Username       admin' <<<"${online_output}" >/dev/null
 grep -F 'sudo docker compose -f' <<<"${online_output}" >/dev/null
+for internal_endpoint in 'Website ·' 'Tenant ·' 'Django Admin' 'Insight Console' \
+	'API / Swagger' 0.0.0.0; do
+	if grep -F "${internal_endpoint}" <<<"${online_output}" >/dev/null; then
+		echo "Online summary exposed internal endpoint detail: ${internal_endpoint}" >&2
+		exit 1
+	fi
+done
 if grep -F 'Login credentials' <<<"${online_output}" >/dev/null; then
 	echo 'Online summary split credentials away from their access endpoints' >&2
 	exit 1
@@ -88,14 +89,16 @@ fi
 INTERACTIVE_SESSION=0
 SESSION_WARNINGS=()
 HFL_ONLINE_CHILD=1
-noninteractive_online_output="$(print_console_access_summary 2>&1)"
-unset HFL_ONLINE_CHILD
+HFL_ONLINE_CONSOLE_MARKER=__TEST_ONLINE_CONSOLE__
+noninteractive_online_output="$(print_online_community_summary 2>&1)"
+unset HFL_ONLINE_CHILD HFL_ONLINE_CONSOLE_MARKER
 INTERACTIVE_SESSION=1
 grep -F 'values are hidden in non-interactive logs' \
 	<<<"${noninteractive_online_output}" >/dev/null
 if grep -F 'Admin@123' <<<"${noninteractive_online_output}" >/dev/null \
 	|| grep -F 'adminpassword' <<<"${noninteractive_online_output}" >/dev/null; then
 	echo 'Online non-interactive summary exposed generated credentials' >&2
+	printf '%s\n' "${noninteractive_online_output}" >&2
 	exit 1
 fi
 
@@ -128,6 +131,52 @@ if grep -F 'Insight Console' <<<"${hfl_only_output}" >/dev/null; then
 	exit 1
 fi
 sourcelens_installed() { return 0; }
+
+# Compact status resolves service health without emitting Compose tables or
+# internal-only entry points.
+status_output="$(
+	init_install_root() { :; }
+	require_docker() { :; }
+	read_active_color() { printf 'blue'; }
+	service_group_ready_now() { return 0; }
+	configured_sourcelens_mode() { printf 'bundled'; }
+	sourcelens_installed() { return 0; }
+	local_platform_gateway_agent_is_managed() { return 0; }
+	systemctl() { [[ "$*" == 'is-active --quiet hyperfilelens-agent.service' ]]; }
+	docker() {
+		[[ "${1:-}" == ps ]]
+		printf 'fixture-gateway-container\n'
+	}
+	cmd_status
+)"
+grep -F 'Status            Healthy' <<<"${status_output}" >/dev/null
+grep -F 'HyperFileLens     https://192.0.2.10:11443/' <<<"${status_output}" >/dev/null
+grep -F 'Platform Ops      https://192.0.2.10:11444/' <<<"${status_output}" >/dev/null
+grep -F 'Insight           Healthy' <<<"${status_output}" >/dev/null
+grep -F 'Platform Gateway  Running' <<<"${status_output}" >/dev/null
+for hidden_status_detail in 11442 '/admin/' 11445 swagger 0.0.0.0 'Active color' \
+	'Deployment phase' 'Agent releases'; do
+	if grep -F "${hidden_status_detail}" <<<"${status_output}" >/dev/null; then
+		echo "Compact status exposed unnecessary detail: ${hidden_status_detail}" >&2
+		exit 1
+	fi
+done
+
+# Immediate health inspection requires every requested service to exist and be
+# running or healthy.
+(
+	compose_fixture() {
+		[[ "${1:-}" == ps && "${2:-}" == -q ]]
+		printf 'cid-%s\n' "${3}"
+	}
+	container_health_status() { printf 'healthy'; }
+	service_group_ready_now compose_fixture api web
+	container_health_status() {
+		[[ "$1" != cid-web ]] || { printf 'exited'; return 0; }
+		printf 'healthy'
+	}
+	! service_group_ready_now compose_fixture api web
+)
 
 # The online status table is diagnostic output, not a new installation gate.
 # A transient Compose inspection failure must remain visible without turning a

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -88,7 +88,8 @@ for summary_contract in \
 	grep -Fq "${summary_contract}" "${installer}"
 done
 for online_output_contract in \
-	'[4/8] Verifying prepared container images' \
+	'[3/4] Starting HyperFileLens' \
+	'[4/4] Verifying installation' \
 	'Verifying prepared runtime image' \
 	'Core data services' \
 	'Database initialization' \
@@ -587,7 +588,77 @@ matching_revision_log="${tmp}/matching-revision.log"
 	RELEASE_COMMIT=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	verify_candidate_release
 ) >"${matching_revision_log}" 2>&1
-[[ ! -s "${matching_revision_log}" ]]
+if [[ -s "${matching_revision_log}" ]]; then
+	printf 'ERROR: matching Community release validation produced unexpected output\n' >&2
+	cat "${matching_revision_log}" >&2
+	exit 1
+fi
+
+# A fresh online installation keeps child details in the durable log and
+# forwards only explicitly marked lines to the terminal.
+child_success_package="${tmp}/child-success-package"
+child_success_log="${tmp}/child-success.log"
+child_success_terminal="${tmp}/child-success.terminal"
+mkdir -p "${child_success_package}"
+cat >"${child_success_package}/install.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'framework detail retained only in the durable log\n'
+printf '%s%s\n' "${HFL_ONLINE_CONSOLE_MARKER}" '  [ OK ] Concise child result'
+SH
+chmod 755 "${child_success_package}/install.sh"
+(
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	REGION=global
+	TAG=v1.2.3
+	ONLINE_LOG_FILE="${child_success_log}"
+	exec 3>"${child_success_terminal}"
+	run_fresh_community_install "${child_success_package}"
+)
+grep -Fq 'framework detail retained only in the durable log' "${child_success_log}"
+grep -Fq '  [ OK ] Concise child result' "${child_success_log}"
+grep -Fxq '  [ OK ] Concise child result' "${child_success_terminal}"
+if grep -Fq 'framework detail retained only in the durable log' \
+	"${child_success_terminal}" \
+	|| grep -Fq '__HFL_ONLINE_CONSOLE__' "${child_success_log}" \
+	|| grep -Fq '__HFL_ONLINE_CONSOLE__' "${child_success_terminal}"; then
+	printf 'ERROR: fresh-install child output filtering contract was violated\n' >&2
+	exit 1
+fi
+
+child_failure_package="${tmp}/child-failure-package"
+child_failure_log="${tmp}/child-failure.log"
+child_failure_terminal="${tmp}/child-failure.terminal"
+mkdir -p "${child_failure_package}"
+cat >"${child_failure_package}/install.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'internal child failure detail\n'
+exit 23
+SH
+chmod 755 "${child_failure_package}/install.sh"
+if (
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	REGION=global
+	TAG=v1.2.3
+	ONLINE_LOG_FILE="${child_failure_log}"
+	exec 3>&1
+	run_fresh_community_install "${child_failure_package}"
+) >"${child_failure_terminal}" 2>&1; then
+	printf 'ERROR: a failed child installer was reported as successful\n' >&2
+	exit 1
+fi
+grep -Fq 'internal child failure detail' "${child_failure_log}"
+grep -Fq '[FAIL] HyperFileLens Community v1.2.3 installation failed' \
+	"${child_failure_terminal}"
+grep -Fq "review the full log: ${child_failure_log}" "${child_failure_terminal}"
+if grep -Fq 'internal child failure detail' "${child_failure_terminal}"; then
+	printf 'ERROR: child failure details leaked into concise terminal output\n' >&2
+	exit 1
+fi
+
 python3 - "${identity_candidate}/MANIFEST.json" <<'PY'
 import json
 import pathlib
@@ -1017,10 +1088,33 @@ compose_target_log="${tmp}/compose-target.log"
 	DOCKER_CE_SOURCE_NAME='Docker CE · https://download.docker.com/linux/ubuntu'
 	print_target
 ) >"${compose_target_log}"
-grep -Fq 'Docker Engine  29.2.1 · reuse' "${compose_target_log}"
-grep -Fq 'Docker Compose not installed → install docker-compose-plugin 5.0.2-1~ubuntu.24.04~noble' \
+grep -Fq 'System requirements' "${compose_target_log}"
+grep -Fq 'Docker Engine    Ready · 29.2.1' "${compose_target_log}"
+grep -Fq 'Docker Compose   Will install · 5.0.2-1~ubuntu.24.04~noble' \
 	"${compose_target_log}"
-grep -Fq 'Install scope  Compose V2 plugin only' "${compose_target_log}"
+grep -Fq 'Docker service   Running' "${compose_target_log}"
+grep -Fq 'The required Docker Compose plugin will be installed on this host.' \
+	"${compose_target_log}"
+
+upgrade_target_log="${tmp}/upgrade-target.log"
+(
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	TAG=v1.2.3
+	ONLINE_LOG_FILE=/opt/hyperfilelens/logs/install-test.log
+	INSTALL_ACTION=Upgrade
+	DOCKER_RUNTIME_ACTION=reuse
+	DOCKER_ENGINE_VERSION=29.2.1
+	DOCKER_COMPOSE_VERSION=5.0.2
+	print_target
+) >"${upgrade_target_log}"
+grep -Fx 'Host runtime' "${upgrade_target_log}" >/dev/null
+grep -Fq 'Docker Engine  29.2.1 · reuse' "${upgrade_target_log}"
+grep -Fq 'Docker Compose 5.0.2 · reuse' "${upgrade_target_log}"
+if grep -Fq 'System requirements' "${upgrade_target_log}"; then
+	printf 'ERROR: fresh-install system-requirements output leaked into upgrades\n' >&2
+	exit 1
+fi
 (
 	# shellcheck disable=SC1090
 	source "${online_functions}"
@@ -1345,9 +1439,7 @@ source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
 replacements = {
     'INSTALL_ROOT="/opt/hyperfilelens"': f'INSTALL_ROOT="{sys.argv[3]}"',
     '[[ "${EUID}" -eq 0 ]] || fail "run this command through sudo"': ":",
-    "\nconfirm_installation\ninstall_host_tools\n": (
-        "\nconfirm_installation\n:\n"
-    ),
+    "\ninstall_host_tools\n": "\n:\n",
     'SESSION_DIR="$(mktemp -d /var/tmp/hyperfilelens-online.XXXXXX)"': (
         f'SESSION_DIR="$(mktemp -d "{sys.argv[4]}/online-session.XXXXXX")"'
     ),
@@ -1411,8 +1503,9 @@ grep -Fq 'Version        v1.2.12' "${latest_log}" || {
 	cat "${latest_log}" >&2
 	exit 1
 }
-grep -Fq 'Docker Engine  29.6.1 · reuse' "${latest_log}"
-grep -Fq 'Docker Compose 2.39.1 · reuse' "${latest_log}"
+grep -Fq 'System requirements' "${latest_log}"
+grep -Fq 'Docker Engine    Ready · 29.6.1' "${latest_log}"
+grep -Fq 'Docker Compose   Ready · 2.39.1' "${latest_log}"
 for removed_target_field in Action Source Registry; do
 	if grep -Eq "^  ${removed_target_field}[[:space:]]" "${latest_log}"; then
 		printf 'ERROR: online target still displays %s\n' \
@@ -1424,9 +1517,10 @@ latest_session_log="$(find "${test_install_root}/logs" -maxdepth 1 -type f \
 	-name 'install-*.log' -print -quit)"
 [[ -n "${latest_session_log}" ]]
 grep -Fq 'HyperFileLens Community Online Installer' "${latest_session_log}"
-grep -Fq 'Resolving Community tags from GitHub' "${latest_session_log}"
+grep -Fq 'Resolving HyperFileLens Community release from GitHub' "${latest_session_log}"
 grep -Fq 'Community release resolved · v1.2.12 · commit cccccccccccc' "${latest_session_log}"
-grep -Fq 'Release contract' "${latest_session_log}"
+grep -Fq 'Downloading v1.2.12 installation contract from GitHub' \
+	"${latest_session_log}"
 grep -Fq "Log file       ${latest_session_log}" "${latest_log}"
 grep -Fq 'recent fallback tags: v1.2.11, v1.2.10, v1.2.9, v1.2.8, v1.2.7, v1.2.6, v1.2.5, v1.2.4, v1.2.3, v1.2.2' \
 	"${latest_log}"
@@ -1533,18 +1627,21 @@ PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 		--source-root "${ROOT}" \
 		--version v1.2.3 \
 		--region global \
+		--concise-output \
 		--output "${candidate}" >"${prepare_log}" 2>&1
 grep -F 'Docker Compose native pull progress: parallel=5 images=10' \
 	"${prepare_log}" >/dev/null
-for heading in 'Installation images' 'Release package'; do
-	grep -Fx "${heading}" "${prepare_log}" >/dev/null
-done
-grep -F '[....] Pulling 10 installation images concurrently · maximum 5 active downloads' \
+grep -F '[....] Pulling 10 container images · up to 5 concurrent downloads' \
 	"${prepare_log}" >/dev/null
-grep -F '[ OK ] Installation image 1/10 ready ·' "${prepare_log}" >/dev/null
-grep -F '[ OK ] Installation image 10/10 ready ·' "${prepare_log}" >/dev/null
-grep -F '[ OK ] All 10 installation images are ready' "${prepare_log}" >/dev/null
-grep -F '[ OK ] Community release package prepared ·' "${prepare_log}" >/dev/null
+grep -F '[ OK ] All 10 container images are ready' "${prepare_log}" >/dev/null
+grep -F '[....] Preparing Agent, Data Gateway, and language packages' \
+	"${prepare_log}" >/dev/null
+grep -F '[ OK ] Agent, Data Gateway, and language packages are ready' \
+	"${prepare_log}" >/dev/null
+if grep -F 'Installation image 1/10 ready' "${prepare_log}" >/dev/null; then
+	printf 'ERROR: per-image digest confirmation leaked into concise output\n' >&2
+	exit 1
+fi
 if grep -F 'Untagged:' "${prepare_log}" >/dev/null; then
 	printf 'ERROR: temporary asset image cleanup leaked into online output\n' >&2
 	exit 1
@@ -1553,6 +1650,24 @@ if grep -F 'cid-' "${prepare_log}" >/dev/null; then
 	printf 'ERROR: temporary asset container cleanup leaked into online output\n' >&2
 	exit 1
 fi
+
+# Online upgrades continue to use the existing detailed preparation output.
+upgrade_candidate="${tmp}/upgrade-candidate"
+upgrade_prepare_log="${tmp}/prepare-upgrade.log"
+PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
+	python3 "${online}/prepare.py" \
+		--source-root "${ROOT}" \
+		--version v1.2.3 \
+		--region global \
+		--output "${upgrade_candidate}" >"${upgrade_prepare_log}" 2>&1
+grep -Fx 'Installation images' "${upgrade_prepare_log}" >/dev/null
+grep -F '[....] Pulling 10 installation images concurrently · maximum 5 active downloads' \
+	"${upgrade_prepare_log}" >/dev/null
+grep -F '[ OK ] Installation image 1/10 ready ·' "${upgrade_prepare_log}" >/dev/null
+grep -Fx 'Release package' "${upgrade_prepare_log}" >/dev/null
+grep -F '[ OK ] Community release package prepared ·' \
+	"${upgrade_prepare_log}" >/dev/null
+
 fallback_candidate="${tmp}/fallback-candidate"
 fallback_prepare_log="${tmp}/prepare-fallback.log"
 PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
@@ -1562,6 +1677,7 @@ PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 		--source-root "${ROOT}" \
 		--version v1.2.3 \
 		--region global \
+		--concise-output \
 		--output "${fallback_candidate}" >"${fallback_prepare_log}" 2>&1
 grep -F '[WARN] 1 installation image(s) were not available from the preferred registry' \
 	"${fallback_prepare_log}" >/dev/null
@@ -1576,6 +1692,7 @@ if PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 		--source-root "${ROOT}" \
 		--version v1.2.3 \
 		--region global \
+		--concise-output \
 		--output "${tmp}/failed-candidate" \
 		>"${failed_prepare_log}" 2>&1; then
 	printf 'ERROR: failed Docker pulls unexpectedly prepared an online package\n' >&2


### PR DESCRIPTION
## Summary

- present fresh Community installations as four concise stages while preserving native concurrent image-pull progress
- keep detailed child installer output in the durable installation log and surface concise failures with the log path
- reduce the final access summary and status output to user-facing endpoints and essential service state
- preserve the existing detailed online-upgrade and offline-installation output contracts

## Validation

- `bash tools/quality/test-online-community-install.sh`
- `bash tools/quality/test-lifecycle-output-contract.sh`
- `bash tools/quality/check-release-contracts.sh`
- `bash tools/quality/test-platform-gateway-auto-deploy.sh`
- `bash tools/quality/test-blue-green-recovery.sh`
- `bash tools/quality/test-installer-image-refresh.sh`
- Bash syntax checks
- Python byte-compilation and Ruff
- `git diff --check`