### PR TITLE
Improve regional Community installation reliability

### DIFF
--- a/.github/workflows/enterprise_saas_upgrade.yml
+++ b/.github/workflows/enterprise_saas_upgrade.yml
@@ -173,7 +173,7 @@ jobs:
           ./tools/sourcelens/update-runtime-contract.sh --check
 
   verify-public-images:
-    name: Verify · Community image delivery · Global
+    name: Verify · Community image delivery · ${{ matrix.name }}
     needs:
       - prepare
       - build-hfl-images
@@ -183,6 +183,14 @@ jobs:
       - publish-language-assets
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Global
+            region: global
+          - name: CN
+            region: cn
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -194,8 +202,10 @@ jobs:
           path: build/saas-metadata
           merge-multiple: true
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Verify global anonymous access and image identity
-        run: ./deploy/online/verify-public-images.sh build/saas-metadata global
+      - name: Verify anonymous access and image identity
+        run: >-
+          ./deploy/online/verify-public-images.sh
+          build/saas-metadata ${{ matrix.region }}
 
   build-hfl-images:
     name: Publish · HFL image · ${{ matrix.name }}
@@ -343,7 +353,7 @@ jobs:
           retention-days: 3
 
   resolve-upstream-images:
-    name: Verify · Upstream image · ${{ matrix.name }}
+    name: ${{ matrix.name }}
     needs: [prepare, quality]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -352,34 +362,55 @@ jobs:
       matrix:
         include:
           - component: sourcelens-backend
-            name: SourceLens Backend
+            name: Verify · Upstream image · SourceLens Backend
+            mirror_shared: false
           - component: sourcelens-frontend
-            name: SourceLens Frontend
+            name: Verify · Upstream image · SourceLens Frontend
+            mirror_shared: false
           - component: sourcelens-lensnode
-            name: SourceLens LensNode
+            name: Verify · Upstream image · SourceLens LensNode
+            mirror_shared: false
           - component: sourcelens-nginx
-            name: NGINX
+            name: Publish · Shared runtime image · NGINX
+            mirror_shared: true
           - component: postgres
-            name: PostgreSQL
+            name: Publish · Shared runtime image · PostgreSQL
+            mirror_shared: true
           - component: redis
-            name: Redis
+            name: Publish · Shared runtime image · Redis
+            mirror_shared: true
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           persist-credentials: false
           ref: ${{ needs.prepare.outputs.commit }}
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Verify global source and record metadata
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        if: matrix.mirror_shared
+        with:
+          registry: ${{ env.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        if: matrix.mirror_shared
+        with:
+          registry: ${{ env.CN_REGISTRY_HOST }}
+          username: ${{ secrets.CN_REGISTRY_USERNAME }}
+          password: ${{ secrets.CN_REGISTRY_PASSWORD }}
+      - name: Verify upstream source and record metadata
         shell: bash
         run: |
           set -euo pipefail
           metadata="${{ matrix.component }}.json"
-          ./release/ci/write-upstream-image-metadata.sh \
+          HFL_GLOBAL_REGISTRY_PREFIX="$REGISTRY_PREFIX" \
+          HFL_CN_REGISTRY_PREFIX="$CN_REGISTRY_PREFIX" \
+            ./release/ci/write-upstream-image-metadata.sh \
             "${{ matrix.component }}" "$metadata"
           expected="$(jq -r '.digest' "$metadata")"
-          ref="$(jq -er '[.sources[] | select(.region == "global") | .ref]
-            | if length == 1 then .[0] else error("missing unique global source") end' \
-            "$metadata")"
+          ref="$(jq -er '.upstream_ref //
+            ([.sources[] | select(.region == "global") | .ref]
+             | if length == 1 then .[0] else error("missing unique global source") end)' \
+              "$metadata")"
           immutable_ref="${ref%:*}@$expected"
           manifest="$(docker buildx imagetools inspect "$immutable_ref" --format '{{json .Manifest}}')"
           actual="$(jq -r '.digest // empty' <<<"$manifest")"
@@ -396,6 +427,18 @@ jobs:
               "$immutable_ref" >&2
             exit 1
           }
+      - name: Ensure owned delivery mirrors
+        if: matrix.mirror_shared
+        shell: bash
+        run: |
+          set -euo pipefail
+          metadata="${{ matrix.component }}.json"
+          source_ref="$(jq -er '.upstream_ref' "$metadata")"
+          digest="$(jq -er '.digest' "$metadata")"
+          while IFS= read -r destination_ref; do
+            ./release/ci/mirror-saas-image.sh \
+              "$source_ref" "$digest" "$destination_ref" --if-missing
+          done < <(jq -er '.sources[].ref' "$metadata")
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: saas-metadata-${{ matrix.component }}

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -337,6 +337,12 @@ print_value() {
 	printf '  %-14s %s\n' "${label}" "${value}"
 }
 
+print_management_value() {
+	local label=$1 value=${2:-}
+	[[ -n "${value}" ]] || return 0
+	printf '  %-15s %s\n' "${label}" "${value}"
+}
+
 print_status_value() {
 	local label=$1 value=${2:-}
 	[[ -n "${value}" ]] || return 0
@@ -1703,7 +1709,7 @@ ensure_bridge_network() {
 }
 
 warn_host_resources() {
-	local cpu_count mem_total_kib mem_available_kib swap_total_kib
+	local cpu_count mem_total_kib mem_available_kib
 	cpu_count="$(getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || echo 0)"
 	if [[ ! "${cpu_count}" =~ ^[0-9]+$ || "${cpu_count}" -lt 4 ]]; then
 		warn "fewer than the minimum 4 CPU cores detected (${cpu_count:-unknown}); installation will continue but may be unstable under concurrent load"
@@ -1712,7 +1718,6 @@ warn_host_resources() {
 	fi
 	mem_total_kib="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null)"
 	mem_available_kib="$(awk '/^MemAvailable:/ {print $2}' /proc/meminfo 2>/dev/null)"
-	swap_total_kib="$(awk '/^SwapTotal:/ {print $2}' /proc/meminfo 2>/dev/null)"
 	if [[ "${mem_total_kib:-0}" -lt $((8 * 1024 * 1024)) ]]; then
 		warn "less than the minimum 8 GiB physical memory detected; installation will continue but may be unstable under concurrent load"
 	elif [[ "${mem_total_kib:-0}" -lt $((16 * 1024 * 1024)) ]]; then
@@ -1720,9 +1725,6 @@ warn_host_resources() {
 	fi
 	if [[ "${mem_available_kib:-0}" -lt $((2500 * 1024)) ]]; then
 		warn "less than 2.5 GiB memory is currently available; installation will continue"
-	fi
-	if [[ "${swap_total_kib:-0}" -eq 0 ]]; then
-		warn "no swap is configured; installation will continue, but memory pressure can invoke the host OOM killer"
 	fi
 }
 
@@ -3788,6 +3790,10 @@ print_console_access_summary() {
 	local host seed seed_email seed_pass seed_org sourcelens_mode sourcelens_console_port
 	local website_bind website_port tenant_bind tenant_port admin_bind admin_port sourcelens_console_bind
 	local sl_env sl_user sl_email sl_pass show_credentials=0 credentials_note
+	local management_printer=print_value
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		management_printer=print_management_value
+	fi
 	host="$(resolve_console_host)"
 	seed="$(read_env_value SEED_INITIAL_DATA)"
 	seed_email="$(read_env_value SEED_ADMIN_EMAIL)"
@@ -3978,20 +3984,43 @@ print_console_access_summary() {
 	print_warning_summary
 
 	print_section "Management commands"
-	print_value "Status" "sudo ${ROOT}/install.sh status"
+	"${management_printer}" "Status" "sudo ${ROOT}/install.sh status"
 	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
-		print_value "Logs" "sudo docker compose -f ${ROOT}/docker-compose.yml logs -f"
+		"${management_printer}" "Logs" \
+			"sudo docker compose -f ${ROOT}/docker-compose.yml logs -f"
 	fi
-	print_value "Start" "sudo ${ROOT}/install.sh start"
-	print_value "Stop" "sudo ${ROOT}/install.sh stop"
-	print_value "Restart" "sudo ${ROOT}/install.sh restart"
-	print_value "Backup" "sudo ${ROOT}/install.sh backup"
-	print_value "Upgrade" "sudo ${ROOT}/install.sh upgrade --from /path/to/new-release.tar.gz"
-	print_value "Uninstall" "sudo ${ROOT}/install.sh uninstall"
+	"${management_printer}" "Start" "sudo ${ROOT}/install.sh start"
+	"${management_printer}" "Stop" "sudo ${ROOT}/install.sh stop"
+	"${management_printer}" "Restart" "sudo ${ROOT}/install.sh restart"
+	"${management_printer}" "Backup" "sudo ${ROOT}/install.sh backup"
+	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]]; then
+		"${management_printer}" "Online upgrade" "$(online_community_upgrade_command)"
+		"${management_printer}" "Offline upgrade" \
+			"sudo ${ROOT}/install.sh upgrade --from /path/to/new-release.tar.gz"
+	else
+		"${management_printer}" "Upgrade" \
+			"sudo ${ROOT}/install.sh upgrade --from /path/to/new-release.tar.gz"
+	fi
+	"${management_printer}" "Uninstall" "sudo ${ROOT}/install.sh uninstall"
 	if [[ "${HFL_ONLINE_CHILD:-0}" == "1" ]] \
 		&& local_platform_gateway_agent_is_managed; then
-		print_value "Gateway status" "sudo ${LOCAL_PLATFORM_AGENT_INSTALL_DIR}/install.sh status"
+		"${management_printer}" "Gateway status" \
+			"sudo ${LOCAL_PLATFORM_AGENT_INSTALL_DIR}/install.sh status"
 	fi
+}
+
+online_community_upgrade_command() {
+	case "${HFL_REGISTRY_REGION:-}" in
+	cn)
+		printf '%s' \
+			'curl -fsSL https://gitee.com/oneprolabs/hyperfilelens/raw/main/deploy/online/install.sh | sudo bash -s -- --mirror cn'
+		;;
+	global)
+		printf '%s' \
+			'curl -fsSL https://raw.githubusercontent.com/oneprolabs/hyperfilelens/main/deploy/online/install.sh | sudo bash -s -- --mirror global'
+		;;
+	*) die "online Community summary requires HFL_REGISTRY_REGION=cn or global" ;;
+	esac
 }
 
 print_online_community_summary() {
@@ -4063,12 +4092,14 @@ print_online_community_summary() {
 	print_warning_summary
 
 	print_section "Management commands"
-	print_value "Status" "sudo ${ROOT}/install.sh status"
-	print_value "Logs" "sudo docker compose -f ${ROOT}/docker-compose.yml logs -f"
-	print_value "Restart" "sudo ${ROOT}/install.sh restart"
-	print_value "Backup" "sudo ${ROOT}/install.sh backup"
-	print_value "Upgrade" "sudo ${ROOT}/install.sh upgrade --from /path/to/new-release.tar.gz"
-	print_value "Uninstall" "sudo ${ROOT}/install.sh uninstall"
+	print_management_value "Status" "sudo ${ROOT}/install.sh status"
+	print_management_value "Logs" "sudo docker compose -f ${ROOT}/docker-compose.yml logs -f"
+	print_management_value "Restart" "sudo ${ROOT}/install.sh restart"
+	print_management_value "Backup" "sudo ${ROOT}/install.sh backup"
+	print_management_value "Online upgrade" "$(online_community_upgrade_command)"
+	print_management_value "Offline upgrade" \
+		"sudo ${ROOT}/install.sh upgrade --from /path/to/new-release.tar.gz"
+	print_management_value "Uninstall" "sudo ${ROOT}/install.sh uninstall"
 }
 
 print_platform_gateway_summary() {

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -207,6 +207,29 @@ preserve_apt_failure_log() {
 	printf '[INFO] Full APT output saved to %s\n' "${preserved_log}" >&2
 }
 
+apt_update_quiet() {
+	local update_log=$1
+	if LC_ALL=C apt-get "${APT_RETRY_ARGS[@]}" update >"${update_log}" 2>&1; then
+		if [[ -n "${ONLINE_LOG_FILE}" && -s "${update_log}" ]]; then
+			timestamp_log_stream "${ONLINE_LOG_FILE}" <"${update_log}"
+		fi
+		return 0
+	fi
+	if [[ -n "${ONLINE_LOG_FILE}" && -s "${update_log}" ]]; then
+		timestamp_log_stream "${ONLINE_LOG_FILE}" <"${update_log}"
+	fi
+	preserve_apt_failure_log "${update_log}"
+	tail -n 20 "${update_log}" >&2 || true
+	return 1
+}
+
+installation_step_indent() {
+	if [[ "${INSTALL_ACTION}" == "Install" ]]; then
+		printf '  '
+	fi
+	return 0
+}
+
 print_target() {
 	# Keep the online bootstrap target separate from the child package installer.
 	# The child runs in parent-session mode and therefore does not print another
@@ -330,6 +353,7 @@ check_host() {
 install_host_tools() {
 	local -a missing=()
 	local tool plan="${SESSION_DIR}/host-tools-apt-plan.log"
+	local update_log="${SESSION_DIR}/host-tools-apt-update.log"
 	for tool in ca-certificates openssl python3 rsync tar; do
 		case "${tool}" in
 		ca-certificates) [[ -f /etc/ssl/certs/ca-certificates.crt ]] || missing+=(ca-certificates) ;;
@@ -337,8 +361,9 @@ install_host_tools() {
 		esac
 	done
 	if ((${#missing[@]})); then
-		printf '[....] Installing required host tools: %s\n' "${missing[*]}"
-		apt-get "${APT_RETRY_ARGS[@]}" update \
+		printf '%s[....] Installing required host tools: %s\n' \
+			"$(installation_step_indent)" "${missing[*]}"
+		apt_update_quiet "${update_log}" \
 			|| fail "could not refresh Ubuntu package metadata for required host tools"
 		if ! LC_ALL=C apt-get "${APT_RETRY_ARGS[@]}" --simulate --no-remove --no-upgrade \
 			--no-install-recommends install \
@@ -715,12 +740,14 @@ install_docker_prerequisites() {
 	local -a missing=()
 	local plan="${SESSION_DIR}/docker-prerequisites.plan"
 	local install_log="${SESSION_DIR}/docker-prerequisites-install.log"
+	local update_log="${SESSION_DIR}/docker-prerequisites-update.log"
 	command -v apt-get >/dev/null 2>&1 || fail "apt-get is required to install Docker CE"
 	command -v gpg >/dev/null 2>&1 || missing+=(gnupg)
 	[[ -f /etc/ssl/certs/ca-certificates.crt ]] || missing+=(ca-certificates)
 	if ((${#missing[@]})); then
-		printf '[....] Installing Docker CE source prerequisites: %s\n' "${missing[*]}"
-		apt-get "${APT_RETRY_ARGS[@]}" update \
+		printf '%s[....] Installing Docker CE source prerequisites: %s\n' \
+			"$(installation_step_indent)" "${missing[*]}"
+		apt_update_quiet "${update_log}" \
 			|| fail "could not refresh Ubuntu package metadata for Docker CE prerequisites"
 		if ! LC_ALL=C apt-get "${APT_RETRY_ARGS[@]}" --simulate --no-remove --no-upgrade \
 			--no-install-recommends install \
@@ -746,7 +773,8 @@ configure_docker_apt_source() {
 	local gnupg_home="${SESSION_DIR}/gnupg"
 	local fingerprint source_file="${SESSION_DIR}/hyperfilelens-docker.list"
 	mkdir -m 0700 "${gnupg_home}"
-	printf '[....] Configuring %s\n' "${DOCKER_CE_SOURCE_NAME}"
+	printf '%s[....] Configuring %s\n' "$(installation_step_indent)" \
+		"${DOCKER_CE_SOURCE_NAME}"
 	download_file "${DOCKER_CE_GPG_URL}" "${key_ascii}" 120 \
 		|| fail "could not download the Docker CE signing key from ${DOCKER_CE_GPG_URL}"
 	fingerprint="$(GNUPGHOME="${gnupg_home}" gpg --batch --show-keys --with-colons "${key_ascii}" 2>/dev/null \
@@ -760,7 +788,7 @@ configure_docker_apt_source() {
 	printf 'deb [arch=amd64 signed-by=/etc/apt/keyrings/hyperfilelens-docker.gpg] %s %s stable\n' \
 		"${DOCKER_CE_APT_BASE}" "${HOST_UBUNTU_CODENAME}" >"${source_file}"
 	install -m 0644 "${source_file}" /etc/apt/sources.list.d/hyperfilelens-docker.list
-	printf '[ OK ] Docker CE package source is ready\n'
+	printf '%s[ OK ] Docker CE package source is ready\n' "$(installation_step_indent)"
 }
 
 selected_docker_apt_source_present() {
@@ -779,11 +807,13 @@ selected_docker_apt_source_present() {
 ensure_docker_apt_source() {
 	local apt_root="${1:-/etc/apt}"
 	if selected_docker_apt_source_present "${apt_root}"; then
-		printf '[ OK ] Existing %s will be reused\n' "${DOCKER_CE_SOURCE_NAME}"
+		printf '%s[ OK ] Existing %s will be reused\n' \
+			"$(installation_step_indent)" "${DOCKER_CE_SOURCE_NAME}"
 		return 0
 	fi
 	if docker_apt_source_present "${apt_root}"; then
-		printf '[ OK ] Existing Docker CE apt source will be reused\n'
+		printf '%s[ OK ] Existing Docker CE apt source will be reused\n' \
+			"$(installation_step_indent)"
 		return 0
 	fi
 	install_docker_prerequisites
@@ -814,6 +844,7 @@ validate_compose_only_install_plan() {
 install_online_docker_runtime() {
 	local plan="${SESSION_DIR}/docker-apt-plan.log"
 	local install_log="${SESSION_DIR}/docker-apt-install.log"
+	local update_log="${SESSION_DIR}/docker-apt-update.log"
 	local attempt
 	local -a packages=(
 		"docker-ce=${DOCKER_ENGINE_PACKAGE_VERSION}"
@@ -828,8 +859,9 @@ install_online_docker_runtime() {
 	assert_clean_dpkg_state
 	install_docker_prerequisites
 	configure_docker_apt_source
-	printf '[....] Resolving Docker Engine and Docker Compose V2 packages\n'
-	apt-get "${APT_RETRY_ARGS[@]}" update \
+	printf '%s[....] Resolving Docker Engine and Docker Compose V2 packages\n' \
+		"$(installation_step_indent)"
+	apt_update_quiet "${update_log}" \
 		|| fail "could not update the selected Docker CE package source"
 	if ! LC_ALL=C apt-get "${APT_RETRY_ARGS[@]}" --simulate --no-remove --no-upgrade \
 		--no-install-recommends install \
@@ -839,7 +871,8 @@ install_online_docker_runtime() {
 		fail "Docker CE package dependencies could not be resolved"
 	fi
 	validate_apt_install_plan "${plan}" "Docker CE installation"
-	printf '[....] Installing Docker Engine and Docker Compose V2\n'
+	printf '%s[....] Installing Docker Engine and Docker Compose V2\n' \
+		"$(installation_step_indent)"
 	DOCKER_PACKAGE_INSTALL_ATTEMPTED=1
 	if ! apt_install_with_network_retry "${install_log}" \
 		install -y --no-remove \
@@ -849,7 +882,8 @@ install_online_docker_runtime() {
 		fail "Docker Engine and Docker Compose V2 installation failed"
 	fi
 	DOCKER_BOOTSTRAPPED=1
-	printf '[....] Enabling and starting Docker service\n'
+	printf '%s[....] Enabling and starting Docker service\n' \
+		"$(installation_step_indent)"
 	systemctl enable --now docker >/dev/null 2>&1 \
 		|| fail "Docker was installed but docker.service could not be enabled and started"
 	for attempt in {1..30}; do
@@ -869,13 +903,14 @@ install_online_docker_runtime() {
 	docker_version_ge "${DOCKER_COMPOSE_VERSION}" "${MIN_DOCKER_COMPOSE_VERSION}" \
 		|| fail "installed Docker Compose ${DOCKER_COMPOSE_VERSION:-unknown} does not meet the minimum required version ${MIN_DOCKER_COMPOSE_VERSION}"
 	DOCKER_RUNTIME_ACTION="reuse"
-	printf '[ OK ] Docker Engine %s and Docker Compose %s are ready\n' \
-		"${DOCKER_ENGINE_VERSION}" "${DOCKER_COMPOSE_VERSION}"
+	printf '%s[ OK ] Docker Engine %s and Docker Compose %s are ready\n' \
+		"$(installation_step_indent)" "${DOCKER_ENGINE_VERSION}" "${DOCKER_COMPOSE_VERSION}"
 }
 
 install_online_compose_plugin() {
 	local plan="${SESSION_DIR}/compose-apt-plan.log"
 	local install_log="${SESSION_DIR}/compose-apt-install.log"
+	local update_log="${SESSION_DIR}/compose-apt-update.log"
 	local original_engine_version="${DOCKER_ENGINE_VERSION}"
 	[[ -n "${DOCKER_COMPOSE_PACKAGE_VERSION}" ]] \
 		|| fail "Docker Compose V2 package version was not resolved"
@@ -889,8 +924,9 @@ install_online_compose_plugin() {
 		fi
 	fi
 	ensure_docker_apt_source
-	printf '[....] Resolving Docker Compose V2 package\n'
-	apt-get "${APT_RETRY_ARGS[@]}" update \
+	printf '%s[....] Resolving Docker Compose V2 package\n' \
+		"$(installation_step_indent)"
+	apt_update_quiet "${update_log}" \
 		|| fail "could not update the selected Docker CE package source"
 	if ! LC_ALL=C apt-get "${APT_RETRY_ARGS[@]}" --simulate --no-remove --no-upgrade \
 		--no-install-recommends install \
@@ -901,8 +937,10 @@ install_online_compose_plugin() {
 	fi
 	validate_apt_install_plan "${plan}" "Docker Compose V2 installation"
 	validate_compose_only_install_plan "${plan}"
-	printf '[ OK ] Docker Compose V2 package plan is safe\n'
-	printf '[....] Installing Docker Compose V2 plugin\n'
+	printf '%s[ OK ] Docker Compose V2 package plan is safe\n' \
+		"$(installation_step_indent)"
+	printf '%s[....] Installing Docker Compose V2 plugin\n' \
+		"$(installation_step_indent)"
 	COMPOSE_PACKAGE_INSTALL_ATTEMPTED=1
 	if ! apt_install_with_network_retry "${install_log}" \
 		install -y --no-remove --no-upgrade --no-install-recommends \
@@ -920,15 +958,15 @@ install_online_compose_plugin() {
 	docker_version_ge "${DOCKER_COMPOSE_VERSION}" "${MIN_DOCKER_COMPOSE_VERSION}" \
 		|| fail "installed Docker Compose ${DOCKER_COMPOSE_VERSION:-unknown} does not meet the minimum required version ${MIN_DOCKER_COMPOSE_VERSION}"
 	DOCKER_RUNTIME_ACTION="reuse"
-	printf '[ OK ] Docker Compose %s is ready; Docker Engine %s was reused unchanged\n' \
-		"${DOCKER_COMPOSE_VERSION}" "${DOCKER_ENGINE_VERSION}"
+	printf '%s[ OK ] Docker Compose %s is ready; Docker Engine %s was reused unchanged\n' \
+		"$(installation_step_indent)" "${DOCKER_COMPOSE_VERSION}" "${DOCKER_ENGINE_VERSION}"
 }
 
 ensure_online_docker_runtime() {
 	case "${DOCKER_RUNTIME_ACTION}" in
 	reuse)
-		printf '[ OK ] Existing Docker Engine %s and Docker Compose %s are supported\n' \
-			"${DOCKER_ENGINE_VERSION}" "${DOCKER_COMPOSE_VERSION}"
+		printf '%s[ OK ] Existing Docker Engine %s and Docker Compose %s are supported\n' \
+			"$(installation_step_indent)" "${DOCKER_ENGINE_VERSION}" "${DOCKER_COMPOSE_VERSION}"
 		;;
 	install-compose) install_online_compose_plugin ;;
 	install) install_online_docker_runtime ;;

--- a/deploy/online/prepare.py
+++ b/deploy/online/prepare.py
@@ -32,12 +32,6 @@ CN_PREFIX = os.environ.get(
     "HFL_CN_REGISTRY_PREFIX",
     "registry.cn-beijing.aliyuncs.com/oneprolabs",
 ).rstrip("/")
-PUBLIC_GLOBAL_PREFIX = os.environ.get(
-    "HFL_PUBLIC_GLOBAL_REGISTRY_PREFIX", "docker.io/library"
-).rstrip("/")
-PUBLIC_CN_PREFIX = os.environ.get(
-    "HFL_PUBLIC_CN_REGISTRY_PREFIX", "dockerproxy.net/library"
-).rstrip("/")
 
 
 @dataclass(frozen=True)
@@ -241,7 +235,7 @@ def load_sourcelens_runtime(source: pathlib.Path) -> dict[str, Any]:
 
 
 def load_public_runtime_specs(source: pathlib.Path) -> list[ImageSpec]:
-    """Load pinned Docker Library images without evaluating shell code."""
+    """Load pinned shared images delivered through the HFL registries."""
     path = source / "tools/dependencies/versions/runtime-images.env"
     values: dict[str, str] = {}
     for raw_line in path.read_text(encoding="utf-8").splitlines():
@@ -262,13 +256,15 @@ def load_public_runtime_specs(source: pathlib.Path) -> list[ImageSpec]:
         local_ref, separator, digest = pinned.partition("@")
         if not separator or not DIGEST_PATTERN.fullmatch(digest):
             raise ValueError(f"{variable} must contain a pinned sha256 digest")
+        repository, tag = local_ref.rsplit(":", 1)
+        mirror_tag = f"{tag}-{digest.partition(':')[2][:12]}"
         specs.append(
             ImageSpec(
                 component,
                 role,
                 local_ref,
-                f"{PUBLIC_GLOBAL_PREFIX}/{local_ref}",
-                f"{PUBLIC_CN_PREFIX}/{local_ref}",
+                f"{GLOBAL_PREFIX}/{repository}:{mirror_tag}",
+                f"{CN_PREFIX}/{repository}:{mirror_tag}",
                 digest,
             )
         )
@@ -577,9 +573,7 @@ def pull_images(
 ) -> list[ResolvedImage]:
     """Pull all images concurrently with a selective regional fallback."""
     fallback_region = "global" if preferred_region == "cn" else "cn"
-    primary = pull_image_batch(
-        specs, preferred_region, concise_output=concise_output
-    )
+    primary = pull_image_batch(specs, preferred_region, concise_output=concise_output)
     resolved, unresolved = inspect_pulled_images(specs, preferred_region)
 
     if unresolved:

--- a/release/ci/mirror-saas-image.sh
+++ b/release/ci/mirror-saas-image.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
-# Copy an immutable image manifest to the secondary registry and verify its digest.
+# Copy an immutable image manifest to a delivery registry and verify its digest.
 set -euo pipefail
 
-[[ $# -eq 3 ]] || {
-	printf 'Usage: %s SOURCE_REF DIGEST DESTINATION_REF\n' "$0" >&2
+[[ $# -eq 3 || ( $# -eq 4 && $4 == --if-missing ) ]] || {
+	printf 'Usage: %s SOURCE_REF DIGEST DESTINATION_REF [--if-missing]\n' "$0" >&2
 	exit 2
 }
 
 source_ref=$1
 digest=$2
 destination_ref=$3
+if_missing=${4:-}
 [[ "${source_ref}" == */*:* && "${destination_ref}" == */*:* ]]
 [[ "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
 
@@ -33,6 +34,12 @@ mirror_error_is_retryable() {
 		"$@"
 }
 
+mirror_error_is_missing() {
+	grep -Eiq \
+		'manifest unknown|name unknown|not found|(status|response|http)[^[:cntrl:]]*404' \
+		"$@"
+}
+
 wait_before_retry() {
 	local failed_attempt=$1
 	local operation=$2
@@ -47,6 +54,45 @@ wait_before_retry() {
 		"${operation}" "${wait_seconds}" >&2
 	sleep "${wait_seconds}"
 }
+
+if [[ "${if_missing}" == --if-missing ]]; then
+	for ((attempt = 1; attempt <= attempts; attempt++)); do
+		: >"${inspect_log}"
+		: >"${inspect_output}"
+		printf '[....] Checking mirrored image (attempt %s/%s): %s\n' \
+			"${attempt}" "${attempts}" "${destination_ref}"
+		if docker buildx imagetools inspect \
+			"${destination_ref}" --format '{{json .Manifest}}' \
+			>"${inspect_output}" 2>"${inspect_log}"; then
+			destination_digest="$(jq -r '.digest // empty' <"${inspect_output}")"
+			if [[ "${destination_digest}" == "${digest}" ]]; then
+				printf '[SKIP] Mirrored image already available: %s\n' \
+					"${destination_ref}"
+				exit 0
+			fi
+			printf 'ERROR: immutable mirror tag has digest %s, expected %s: %s\n' \
+				"${destination_digest:-missing}" "${digest}" "${destination_ref}" >&2
+			exit 1
+		fi
+		if mirror_error_is_missing "${inspect_output}" "${inspect_log}"; then
+			printf '[INFO] Mirrored image is not present and will be created: %s\n' \
+				"${destination_ref}"
+			break
+		fi
+		[[ ! -s "${inspect_output}" ]] || cat "${inspect_output}" >&2
+		[[ ! -s "${inspect_log}" ]] || cat "${inspect_log}" >&2
+		if ! mirror_error_is_retryable "${inspect_output}" "${inspect_log}"; then
+			printf 'ERROR: registry mirror check failed with a non-retryable error\n' >&2
+			exit 1
+		fi
+		if ((attempt == attempts)); then
+			printf 'ERROR: registry mirror check failed after %s attempts\n' \
+				"${attempts}" >&2
+			exit 1
+		fi
+		wait_before_retry "${attempt}" check
+	done
+fi
 
 copy_status=1
 for ((attempt = 1; attempt <= attempts; attempt++)); do

--- a/release/ci/write-upstream-image-metadata.sh
+++ b/release/ci/write-upstream-image-metadata.sh
@@ -16,6 +16,7 @@ cn_ref=""
 local_ref=""
 digest=""
 role=""
+upstream_ref=""
 
 case "${component}" in
 sourcelens-backend | sourcelens-frontend | sourcelens-lensnode)
@@ -59,8 +60,15 @@ postgres | redis | sourcelens-nginx)
 	esac
 	local_ref=${pinned%@*}
 	digest=${pinned##*@}
-	global_ref="docker.io/library/${local_ref}"
-	cn_ref="dockerproxy.net/library/${local_ref}"
+	repository=${local_ref%:*}
+	tag=${local_ref##*:}
+	digest_short=${digest#sha256:}
+	mirror_tag="${tag}-${digest_short:0:12}"
+	global_prefix=${HFL_GLOBAL_REGISTRY_PREFIX:-docker.io/oneprolabs}
+	cn_prefix=${HFL_CN_REGISTRY_PREFIX:-registry.cn-beijing.aliyuncs.com/oneprolabs}
+	global_ref="${global_prefix%/}/${repository}:${mirror_tag}"
+	cn_ref="${cn_prefix%/}/${repository}:${mirror_tag}"
+	upstream_ref="docker.io/library/${local_ref}"
 	;;
 *)
 	printf 'ERROR: unsupported upstream image component: %s\n' "${component}" >&2
@@ -83,6 +91,7 @@ jq -n \
 	--arg digest "${digest}" \
 	--arg global_ref "${global_ref}" \
 	--arg cn_ref "${cn_ref}" \
+	--arg upstream_ref "${upstream_ref}" \
 	'{
 	  component: $component,
 	  role: $role,
@@ -93,7 +102,8 @@ jq -n \
 	    {region: "cn", ref: $cn_ref},
 	    {region: "global", ref: $global_ref}
 	  ]
-	}' >"${output}"
+	} + if $upstream_ref == "" then {} else {upstream_ref: $upstream_ref} end' \
+	>"${output}"
 
 if [[ "${component}" == "sourcelens-backend" \
 	|| "${component}" == "sourcelens-frontend" \

--- a/tools/quality/test-lifecycle-output-contract.sh
+++ b/tools/quality/test-lifecycle-output-contract.sh
@@ -59,14 +59,29 @@ grep -F 'Admin@123' <<<"${output}" >/dev/null
 grep -F 'adminpassword' <<<"${output}" >/dev/null
 grep -F 'install.sh upgrade --from /path/to/new-release.tar.gz' <<<"${output}" >/dev/null
 grep -F 'install.sh uninstall' <<<"${output}" >/dev/null
+if grep -F 'Online upgrade' <<<"${output}" >/dev/null \
+	|| grep -F 'Offline upgrade' <<<"${output}" >/dev/null; then
+	echo 'Offline summary exposed online-installation upgrade labels' >&2
+	exit 1
+fi
+
+HFL_ONLINE_CHILD=1
+HFL_REGISTRY_REGION=global
+online_upgrade_output="$(print_console_access_summary 2>&1)"
+unset HFL_ONLINE_CHILD HFL_REGISTRY_REGION
+grep -F 'Online upgrade  curl -fsSL https://raw.githubusercontent.com/oneprolabs/hyperfilelens/main/deploy/online/install.sh | sudo bash -s -- --mirror global' \
+	<<<"${online_upgrade_output}" >/dev/null
+grep -F "Offline upgrade sudo ${ROOT}/install.sh upgrade --from /path/to/new-release.tar.gz" \
+	<<<"${online_upgrade_output}" >/dev/null
 
 # A fresh Community online installation exposes only the two user-facing
 # entry points while preserving the existing credential visibility policy.
 SESSION_WARNINGS=()
 HFL_ONLINE_CHILD=1
 HFL_ONLINE_CONSOLE_MARKER=__TEST_ONLINE_CONSOLE__
+HFL_REGISTRY_REGION=cn
 online_output="$(print_online_community_summary 2>&1)"
-unset HFL_ONLINE_CHILD HFL_ONLINE_CONSOLE_MARKER
+unset HFL_ONLINE_CHILD HFL_ONLINE_CONSOLE_MARKER HFL_REGISTRY_REGION
 for heading in 'HyperFileLens · 11443' 'Platform Ops · 11444'; do
 	grep -F "${heading}" <<<"${online_output}" >/dev/null
 done
@@ -74,6 +89,14 @@ grep -F 'linux/amd64' <<<"${online_output}" >/dev/null
 grep -F 'Email          admin@hyperfilelens.com' <<<"${online_output}" >/dev/null
 grep -F 'Password       Admin@123' <<<"${online_output}" >/dev/null
 grep -F 'sudo docker compose -f' <<<"${online_output}" >/dev/null
+grep -F 'Online upgrade  curl -fsSL https://gitee.com/oneprolabs/hyperfilelens/raw/main/deploy/online/install.sh | sudo bash -s -- --mirror cn' \
+	<<<"${online_output}" >/dev/null
+grep -F "Offline upgrade sudo ${ROOT}/install.sh upgrade --from /path/to/new-release.tar.gz" \
+	<<<"${online_output}" >/dev/null
+global_upgrade_command="$(HFL_REGISTRY_REGION=global online_community_upgrade_command)"
+grep -F 'https://raw.githubusercontent.com/oneprolabs/hyperfilelens/main/deploy/online/install.sh' \
+	<<<"${global_upgrade_command}" >/dev/null
+grep -F -- '--mirror global' <<<"${global_upgrade_command}" >/dev/null
 for internal_endpoint in 'Website ·' 'Tenant ·' 'Django Admin' 'Insight Console' \
 	'API / Swagger' 0.0.0.0; do
 	if grep -F "${internal_endpoint}" <<<"${online_output}" >/dev/null; then
@@ -90,8 +113,9 @@ INTERACTIVE_SESSION=0
 SESSION_WARNINGS=()
 HFL_ONLINE_CHILD=1
 HFL_ONLINE_CONSOLE_MARKER=__TEST_ONLINE_CONSOLE__
+HFL_REGISTRY_REGION=cn
 noninteractive_online_output="$(print_online_community_summary 2>&1)"
-unset HFL_ONLINE_CHILD HFL_ONLINE_CONSOLE_MARKER
+unset HFL_ONLINE_CHILD HFL_ONLINE_CONSOLE_MARKER HFL_REGISTRY_REGION
 INTERACTIVE_SESSION=1
 grep -F 'values are hidden in non-interactive logs' \
 	<<<"${noninteractive_online_output}" >/dev/null

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -50,6 +50,7 @@ grep -Fq 'Acquire::http::Timeout=60' "${online}/install.sh"
 grep -Fq 'Acquire::https::Timeout=60' "${online}/install.sh"
 grep -Fq 'DPkg::Lock::Timeout=120' "${online}/install.sh"
 grep -Fq 'apt_install_with_network_retry' "${online}/install.sh"
+grep -Fq 'apt_update_quiet' "${online}/install.sh"
 grep -Fq 'apt_failure_is_transient' "${online}/install.sh"
 grep -Fq 'dpkg_state_clean_for_retry' "${online}/install.sh"
 grep -Fq 'preserve_apt_failure_log' "${online}/install.sh"
@@ -109,12 +110,12 @@ if grep -Eq 'publish-community-channel|community-channel|git push origin HEAD:ma
 fi
 grep -Fq 'write-upstream-image-metadata.sh' "${workflow}"
 grep -Fq 'resolve-upstream-images:' "${workflow}"
-grep -Fq './deploy/online/verify-public-images.sh build/saas-metadata global' "${workflow}"
+grep -Fq 'Verify · Community image delivery · ${{ matrix.name }}' "${workflow}"
+grep -Fq 'build/saas-metadata ${{ matrix.region }}' "${workflow}"
 grep -Fq 'select(.region == "global")' "${workflow}"
-if grep -Fq ".sources[].ref" "${workflow}"; then
-	printf 'ERROR: SaaS workflow still verifies every regional upstream source\n' >&2
-	exit 1
-fi
+grep -Fq "'.upstream_ref'" "${workflow}"
+grep -Fq 'Ensure owned delivery mirrors' "${workflow}"
+grep -Fq '"$destination_ref" --if-missing' "${workflow}"
 if grep -Eq '^  (build-sourcelens-images|publish-runtime-images):' "${workflow}"; then
 	printf 'ERROR: SaaS workflow still publishes rebuilt upstream images\n' >&2
 	exit 1
@@ -152,7 +153,7 @@ actual = {
 if actual != expected:
     raise SystemExit(f"unexpected HFL publish matrix: {sorted(actual)}")
 # One matrix build publishes four HFL tags; the three asset jobs publish one
-# tag each. No third-party image may introduce another push operation.
+# tag each. Shared runtime mirrors copy verified manifests without rebuilding.
 if text.count("          push: true\n") != 4:
     raise SystemExit("SaaS workflow must contain exactly seven effective image publishes")
 if 'has("linux/amd64")' not in text:
@@ -733,6 +734,62 @@ mkdir -p "$(dirname "${apt_retry_saved}")"
 	fi
 	[[ "${APT_FAILURE_DPKG_CLEAN}" -eq 1 ]]
 	cmp -s "${final_log}" "${final_saved}"
+)
+
+apt_update_terminal="${tmp}/apt-update-terminal.log"
+apt_update_log="${tmp}/apt-update.log"
+apt_update_install_log="${tmp}/logs/apt-update-install.log"
+(
+	# Successful package metadata output is retained in the installation log but
+	# does not obscure the concise terminal progress.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	ONLINE_LOG_FILE="${apt_update_install_log}"
+	apt-get() {
+		printf 'Hit:1 https://mirror.example/ubuntu noble InRelease\n'
+		printf 'Reading package lists...\n'
+	}
+	apt_update_quiet "${apt_update_log}"
+) >"${apt_update_terminal}" 2>&1
+[[ ! -s "${apt_update_terminal}" ]]
+grep -Fq 'Hit:1 https://mirror.example/ubuntu noble InRelease' \
+	"${apt_update_install_log}"
+grep -Fq 'Reading package lists...' "${apt_update_install_log}"
+
+apt_update_failure_terminal="${tmp}/apt-update-failure-terminal.log"
+apt_update_failure_log="${tmp}/apt-update-failure.log"
+apt_update_failure_install_log="${tmp}/logs/apt-update-failure-install.log"
+apt_update_failure_saved="${tmp}/logs/apt-update-failure-install-apt.log"
+if (
+	# Failed metadata refreshes retain their complete diagnostics and surface the
+	# useful tail in the terminal.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	ONLINE_LOG_FILE="${apt_update_failure_install_log}"
+	apt-get() {
+		printf 'E: Failed to fetch https://mirror.example/InRelease (Connection timed out)\n'
+		return 100
+	}
+	apt_update_quiet "${apt_update_failure_log}"
+) >"${apt_update_failure_terminal}" 2>&1; then
+	printf 'ERROR: a failed package metadata refresh was accepted\n' >&2
+	exit 1
+fi
+grep -Fq 'E: Failed to fetch https://mirror.example/InRelease' \
+	"${apt_update_failure_terminal}"
+grep -Fq "Full APT output saved to ${apt_update_failure_saved}" \
+	"${apt_update_failure_terminal}"
+cmp -s "${apt_update_failure_log}" "${apt_update_failure_saved}"
+
+(
+	# Fresh-install runtime progress is indented beneath its numbered stage,
+	# while upgrade progress remains top-level.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	INSTALL_ACTION=Install
+	[[ "$(installation_step_indent)" == '  ' ]]
+	INSTALL_ACTION=Upgrade
+	[[ -z "$(installation_step_indent)" ]]
 )
 
 (
@@ -1727,13 +1784,16 @@ for component, local_ref in {
     "redis": "redis:alpine",
     "sourcelens-nginx": "nginx:stable-alpine",
 }.items():
+    digest_short = registry_images[component]["digest"].partition(":")[2][:12]
+    repository, tag = local_ref.rsplit(":", 1)
+    mirror_ref = f"{repository}:{tag}-{digest_short}"
     sources = {
         source["region"]: source["ref"]
         for source in registry_images[component]["sources"]
     }
     assert sources == {
-        "cn": f"dockerproxy.net/library/{local_ref}",
-        "global": f"docker.io/library/{local_ref}",
+        "cn": f"registry.cn-beijing.aliyuncs.com/oneprolabs/{mirror_ref}",
+        "global": f"docker.io/oneprolabs/{mirror_ref}",
     }
 assets = manifest["delivery"]["asset_images"]
 assert {entry["local_ref"] for entry in assets} == {

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -186,6 +186,16 @@ case "${1:-} ${2:-}" in
 		count=$((count + 1))
 		printf '%s\n' "${count}" >"${HFL_TEST_MIRROR_INSPECT_MARKER}"
 		case "${HFL_TEST_MIRROR_INSPECT_MODE:-success}" in
+		missing-once)
+			if [[ "${count}" -eq 1 ]]; then
+				printf 'manifest unknown: manifest unknown\n' >&2
+				exit 1
+			fi
+			;;
+		mismatch)
+			printf '{"digest":"sha256:%s"}\n' "$(printf 'f%.0s' {1..64})"
+			exit 0
+			;;
 		flaky429)
 			if [[ "${count}" -lt 3 ]]; then
 				printf 'unexpected status from HEAD request: 429 Too Many Requests\n' >&2
@@ -280,6 +290,48 @@ HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
 	"${digest}" \
 	registry.example.cn/example/hyperfilelens-backend:1.0.0-ee
 [[ "$(cat "${mirror_marker}")" -eq 1 ]]
+[[ "$(cat "${mirror_inspect_marker}")" -eq 1 ]]
+
+printf '0\n' >"${mirror_marker}"
+printf '0\n' >"${mirror_inspect_marker}"
+HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
+	HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS=0 \
+	"${ROOT}/release/ci/mirror-saas-image.sh" \
+		docker.io/library/postgres:17 \
+		"${digest}" \
+		docker.io/example/postgres:17-aaaaaaaaaaaa \
+		--if-missing
+[[ "$(cat "${mirror_marker}")" -eq 0 ]]
+[[ "$(cat "${mirror_inspect_marker}")" -eq 1 ]]
+
+printf '0\n' >"${mirror_marker}"
+printf '0\n' >"${mirror_inspect_marker}"
+HFL_TEST_MIRROR_INSPECT_MODE=missing-once \
+	HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
+	HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS=0 \
+	"${ROOT}/release/ci/mirror-saas-image.sh" \
+		docker.io/library/postgres:17 \
+		"${digest}" \
+		docker.io/example/postgres:17-aaaaaaaaaaaa \
+		--if-missing
+[[ "$(cat "${mirror_marker}")" -eq 1 ]]
+[[ "$(cat "${mirror_inspect_marker}")" -eq 2 ]]
+
+printf '0\n' >"${mirror_marker}"
+printf '0\n' >"${mirror_inspect_marker}"
+if HFL_TEST_MIRROR_INSPECT_MODE=mismatch \
+	HFL_REGISTRY_MIRROR_RETRY_BASE_SECONDS=0 \
+	HFL_REGISTRY_MIRROR_RETRY_JITTER_SECONDS=0 \
+	"${ROOT}/release/ci/mirror-saas-image.sh" \
+		docker.io/library/postgres:17 \
+		"${digest}" \
+		docker.io/example/postgres:17-aaaaaaaaaaaa \
+		--if-missing \
+		>/dev/null 2>&1; then
+	printf 'ERROR: immutable mirror tag accepted a conflicting digest\n' >&2
+	exit 1
+fi
+[[ "$(cat "${mirror_marker}")" -eq 0 ]]
 [[ "$(cat "${mirror_inspect_marker}")" -eq 1 ]]
 
 printf '0\n' >"${mirror_marker}"


### PR DESCRIPTION
## Summary

- mirror pinned PostgreSQL, Redis, and NGINX images into the owned Docker Hub and Alibaba Cloud registries only when missing
- verify anonymous Community image delivery in both global and CN regions and remove the dockerproxy.net dependency from online installation
- streamline Docker/APT progress output while retaining complete diagnostics in installation logs
- show region-specific online upgrade commands alongside the existing offline upgrade command

## Validation

- Online Community installation contracts
- Lifecycle output contracts
- SaaS registry delivery contracts
- CI release assembly and Enterprise release flow contracts
- SourceLens runtime and release contract checks
- Bash, Python 3.8, YAML, and whitespace validation