### PR TITLE
Reuse compatible existing Docker runtimes

### DIFF
--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -465,16 +465,6 @@ docker_package_payload_present() {
 	[[ -n "${state}" && "${state}" != n && "${state}" != c ]]
 }
 
-foreign_docker_runtime_present() {
-	local package docker_path
-	for package in docker.io moby-engine moby-cli moby-containerd moby-compose podman-docker; do
-		docker_package_installed "${package}" && return 0
-	done
-	docker_path="$(command -v docker 2>/dev/null || true)"
-	[[ "${docker_path}" == /snap/* ]] && return 0
-	return 1
-}
-
 docker_package_installed() {
 	local status
 	status="$(dpkg-query -W -f='${db:Status-Abbrev}' "$1" 2>/dev/null || true)"
@@ -484,6 +474,13 @@ docker_package_installed() {
 docker_ce_runtime_present() {
 	docker_package_installed docker-ce \
 		&& docker_package_installed docker-ce-cli
+}
+
+unsupported_docker_runtime_present() {
+	local docker_path
+	docker_package_installed podman-docker && return 0
+	docker_path="$(command -v docker 2>/dev/null || true)"
+	[[ "${docker_path}" == /snap/* ]]
 }
 
 docker_residual_state_present() {
@@ -583,8 +580,8 @@ inspect_docker_runtime() {
 	DOCKER_ENGINE_VERSION=""
 	DOCKER_COMPOSE_VERSION=""
 	if command -v docker >/dev/null 2>&1; then
-		if foreign_docker_runtime_present || ! docker_ce_runtime_present; then
-			fail "the existing Docker runtime is not a Docker CE installation; install Docker CE and Compose V2 manually, then rerun this installer"
+		if unsupported_docker_runtime_present; then
+			fail "the existing Docker command is provided by Podman or Snap, which is not supported; install Docker Engine and Compose V2 manually, then rerun this installer"
 		fi
 		docker info >/dev/null 2>&1 \
 			|| fail "Docker is installed but its daemon is unavailable; start or repair Docker manually, then rerun this installer"
@@ -595,6 +592,9 @@ inspect_docker_runtime() {
 			|| fail "Docker Engine ${DOCKER_ENGINE_VERSION} does not meet the minimum required version ${MIN_DOCKER_ENGINE_VERSION}; upgrade Docker manually, then rerun this installer"
 		DOCKER_COMPOSE_VERSION="$(docker_compose_version)"
 		if [[ -z "${DOCKER_COMPOSE_VERSION}" ]]; then
+			if ! docker_ce_runtime_present; then
+				fail "the existing Docker runtime does not provide Docker Compose V2; install a compatible Compose V2 plugin manually, then rerun this installer"
+			fi
 			if ! selected_docker_apt_source_present && docker_apt_source_present; then
 				DOCKER_CE_SOURCE_NAME="Existing Docker CE apt source"
 			fi

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -42,8 +42,8 @@ grep -Fq 'DOCKER_PACKAGE_INSTALL_ATTEMPTED' "${online}/install.sh"
 grep -Fq 'COMPOSE_PACKAGE_INSTALL_ATTEMPTED' "${online}/install.sh"
 grep -Fq 'validate_compose_only_install_plan' "${online}/install.sh"
 grep -Fq 'selected_docker_apt_source_present' "${online}/install.sh"
-grep -Fq 'foreign_docker_runtime_present' "${online}/install.sh"
 grep -Fq 'docker_ce_runtime_present' "${online}/install.sh"
+grep -Fq 'unsupported_docker_runtime_present' "${online}/install.sh"
 grep -Fq 'docker_apt_source_present' "${online}/install.sh"
 grep -Fq 'Acquire::Retries=3' "${online}/install.sh"
 grep -Fq 'Acquire::http::Timeout=60' "${online}/install.sh"
@@ -1067,11 +1067,73 @@ if (
 	printf 'ERROR: foreign Docker runtime was accepted for Compose-only bootstrap\n' >&2
 	exit 1
 fi
-grep -Fq 'not a Docker CE installation' "${foreign_runtime_log}"
-foreign_complete_runtime_log="${tmp}/foreign-complete-runtime.log"
+grep -Fq 'existing Docker runtime does not provide Docker Compose V2' \
+	"${foreign_runtime_log}"
+(
+	# A complete compatible runtime is reused based on its capabilities rather
+	# than its package source. Version strings may include distribution suffixes.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	docker() {
+		case "${1:-} ${2:-}" in
+		"info ") return 0 ;;
+		"version --format") printf '29.1.3\n' ;;
+		"compose version") printf '2.40.3+ds1-0ubuntu1~24.04.1\n' ;;
+		esac
+		return 1
+	}
+	dpkg-query() {
+		[[ "${*: -1}" == docker.io ]] || return 1
+		printf 'ii '
+	}
+	inspect_docker_runtime
+	[[ "${DOCKER_RUNTIME_ACTION}" == reuse ]]
+	[[ "${DOCKER_ENGINE_VERSION}" == 29.1.3 ]]
+	[[ "${DOCKER_COMPOSE_VERSION}" == '2.40.3+ds1-0ubuntu1~24.04.1' ]]
+)
+unsupported_complete_runtime_log="${tmp}/unsupported-complete-runtime.log"
 if (
-	# A non-Docker-CE runtime is rejected even when it already exposes Compose;
-	# the online installer only supports Docker CE for its managed contract.
+	# Supporting Ubuntu's Docker Engine package must not implicitly accept other
+	# Docker-compatible runtimes such as Podman.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	docker() {
+		case "${1:-} ${2:-}" in
+		"info ") return 0 ;;
+		"version --format") printf '29.1.3\n' ;;
+		"compose version") printf '2.40.3\n' ;;
+		esac
+		return 1
+	}
+	dpkg-query() {
+		[[ "${*: -1}" == podman-docker ]] || return 1
+		printf 'ii '
+	}
+	inspect_docker_runtime
+) >"${unsupported_complete_runtime_log}" 2>&1; then
+	printf 'ERROR: unsupported Docker-compatible runtime was accepted\n' >&2
+	exit 1
+fi
+grep -Fq 'Docker command is provided by Podman or Snap' \
+	"${unsupported_complete_runtime_log}"
+(
+	# Snap Docker remains unsupported because confinement can block deployment
+	# bind mounts even when its client reports compatible versions.
+	# shellcheck disable=SC1090
+	source "${online_functions}"
+	dpkg-query() { return 1; }
+	command() {
+		if [[ "${1:-}" == -v && "${2:-}" == docker ]]; then
+			printf '/snap/bin/docker\n'
+			return 0
+		fi
+		builtin command "$@"
+	}
+	unsupported_docker_runtime_present
+)
+(
+	# A complete compatible static or otherwise unrecognized Docker runtime is
+	# reused without relying on package-manager ownership.
 	# shellcheck disable=SC1090
 	source "${online_functions}"
 	docker() {
@@ -1082,20 +1144,14 @@ if (
 		esac
 		return 1
 	}
-	dpkg-query() {
-		[[ "${*: -1}" == docker.io ]] || return 1
-		printf 'ii '
-	}
+	dpkg-query() { return 1; }
 	inspect_docker_runtime
-) >"${foreign_complete_runtime_log}" 2>&1; then
-	printf 'ERROR: complete foreign Docker runtime was accepted\n' >&2
-	exit 1
-fi
-grep -Fq 'not a Docker CE installation' "${foreign_complete_runtime_log}"
+	[[ "${DOCKER_RUNTIME_ACTION}" == reuse ]]
+)
 unrecognized_runtime_log="${tmp}/unrecognized-runtime-compose.log"
 if (
-	# A healthy static or otherwise unrecognized Docker binary is not sufficient
-	# evidence that the Docker CE apt plugin can be added safely.
+	# An otherwise compatible runtime without Compose cannot receive a Docker CE
+	# package unless the Engine is itself a complete Docker CE installation.
 	# shellcheck disable=SC1090
 	source "${online_functions}"
 	docker() {
@@ -1109,28 +1165,11 @@ if (
 	dpkg-query() { return 1; }
 	inspect_docker_runtime
 ) >"${unrecognized_runtime_log}" 2>&1; then
-	printf 'ERROR: unrecognized Docker runtime was accepted for Compose-only bootstrap\n' >&2
+	printf 'ERROR: unrecognized Docker runtime received Compose-only bootstrap\n' >&2
 	exit 1
 fi
-grep -Fq 'not a Docker CE installation' "${unrecognized_runtime_log}"
-(
-	# A removed docker.io package with residual configuration (dpkg "rc") does
-	# not identify the active Docker Engine as Ubuntu's runtime.
-	# shellcheck disable=SC1090
-	source "${online_functions}"
-	dpkg-query() {
-		[[ "${*: -1}" == docker.io ]] || return 1
-		printf 'rc '
-	}
-	command() {
-		if [[ "${1:-}" == -v && "${2:-}" == docker ]]; then
-			printf '/usr/bin/docker\n'
-			return 0
-		fi
-		builtin command "$@"
-	}
-	! foreign_docker_runtime_present
-)
+grep -Fq 'existing Docker runtime does not provide Docker Compose V2' \
+	"${unrecognized_runtime_log}"
 compose_target_log="${tmp}/compose-target.log"
 (
 	# shellcheck disable=SC1090


### PR DESCRIPTION
## Summary

- reuse existing Docker runtimes based on daemon, Engine, and Compose capabilities instead of package origin
- retain managed Compose installation only for complete Docker CE installations
- reject Podman and Snap while preserving manual guidance for compatible runtimes without Compose V2

## Validation

- Online Community installation contract tests
- Release contract checks
- Bash syntax and whitespace validation