### PR TITLE
Streamline installer status and access output

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -349,6 +349,8 @@ print_status_value() {
 	printf '  %-17s %s\n' "${label}" "${value}"
 }
 
+print_spaced_section() { printf '\n%s\n\n' "$1"; }
+
 print_result() {
 	printf '\n%s\n%s\n%s\n' \
 		'================================================================' "$1" \
@@ -392,7 +394,9 @@ finish_session() {
 	if [[ "${SESSION_STARTED}" -eq 1 ]]; then
 		SESSION_STARTED=0
 		if [[ "${rc}" -eq 0 ]]; then
-			ok "HyperFileLens ${SESSION_ACTION} completed"
+			if [[ "${SESSION_ACTION}" != "status" ]]; then
+				ok "HyperFileLens ${SESSION_ACTION} completed"
+			fi
 		else
 			printf '[FAIL] HyperFileLens %s exited with status %s.\n' "${SESSION_ACTION}" "${rc}" >&2
 			printf '       Full log: %s\n' "${LOG_FILE}" >&2
@@ -810,7 +814,9 @@ materialize_to_install_dir() {
 	source="$(safe_normalize_dir "${source}")"
 	INSTALL_DIR="$(safe_normalize_dir "${INSTALL_DIR}")"
 	if [[ "${source}" == "${INSTALL_DIR}" ]]; then
-		log "already in install directory ${INSTALL_DIR}"
+		if [[ "${SESSION_ACTION}" != "status" ]]; then
+			log "already in install directory ${INSTALL_DIR}"
+		fi
 		return 0
 	fi
 	step "Copying release package ${source} -> ${INSTALL_DIR} ..."
@@ -4060,8 +4066,8 @@ print_online_community_summary() {
 	print_value "Config file" "${env_file}"
 	print_value "Log file" "${LOG_FILE}"
 
-	print_section "Access"
-	printf '  HyperFileLens · %s\n' "${tenant_port}"
+	print_spaced_section "Access"
+	printf '  HyperFileLens\n'
 	print_nested_value "URL" "https://${host}:${tenant_port}/"
 	if [[ "${seed}" == "1" ]]; then
 		if [[ "${show_credentials}" -eq 1 ]]; then
@@ -4073,7 +4079,7 @@ print_online_community_summary() {
 		print_nested_value "Organization" "${seed_org}"
 	fi
 
-	printf '\n  Platform Ops · %s\n' "${admin_port}"
+	printf '\n  Platform Ops\n'
 	print_nested_value "URL" "https://${host}:${admin_port}/"
 	if [[ "${seed}" == "1" ]]; then
 		if [[ "${show_credentials}" -eq 1 ]]; then
@@ -5651,6 +5657,7 @@ cmd_restart() {
 }
 
 cmd_status() {
+	printf '%s\n\n' "HyperFileLens Status"
 	init_install_root
 	if [[ ! -f "${ROOT}/.env" ]]; then
 		warn "missing .env; install has not been run"
@@ -5694,21 +5701,20 @@ cmd_status() {
 		fi
 	fi
 
-	print_section "HyperFileLens"
 	print_status_value "Version" "${version}"
 	print_status_value "Edition" "$(display_edition_from_dir "${ROOT}")"
 	print_status_value "Status" "${hfl_status}"
 	print_status_value "Install path" "${ROOT}"
 
-	print_section "Access"
+	print_spaced_section "Access"
 	print_status_value "HyperFileLens" "https://${host}:${tenant_port}/"
 	print_status_value "Platform Ops" "https://${host}:${admin_port}/"
 
-	print_section "Services"
+	print_spaced_section "Services"
 	print_status_value "Insight" "${insight_status}"
 	print_status_value "Platform Gateway" "${gateway_status}"
 
-	print_section "Management"
+	print_spaced_section "Management"
 	print_status_value "Logs" "sudo docker compose -f ${ROOT}/docker-compose.yml logs -f"
 	print_status_value "Restart" "sudo ${ROOT}/install.sh restart"
 }
@@ -7411,7 +7417,9 @@ main() {
 	SESSION_STARTED=1
 	trap finish_session EXIT
 	trap 'exit 130' INT TERM
-	print_banner "${banner_title}"
+	if [[ "${requested_cmd}" != "status" ]]; then
+		print_banner "${banner_title}"
+	fi
 
 	if [[ $# -eq 0 ]]; then
 		cmd_install

--- a/tools/quality/test-lifecycle-output-contract.sh
+++ b/tools/quality/test-lifecycle-output-contract.sh
@@ -82,12 +82,16 @@ HFL_ONLINE_CONSOLE_MARKER=__TEST_ONLINE_CONSOLE__
 HFL_REGISTRY_REGION=cn
 online_output="$(print_online_community_summary 2>&1)"
 unset HFL_ONLINE_CHILD HFL_ONLINE_CONSOLE_MARKER HFL_REGISTRY_REGION
-for heading in 'HyperFileLens · 11443' 'Platform Ops · 11444'; do
-	grep -F "${heading}" <<<"${online_output}" >/dev/null
+for heading in '  HyperFileLens' '  Platform Ops'; do
+	grep -Fx "${heading}" <<<"${online_output}" >/dev/null
 done
+[[ "${online_output}" == *$'Access\n\n  HyperFileLens'* ]]
 grep -F 'linux/amd64' <<<"${online_output}" >/dev/null
-grep -F 'Email          admin@hyperfilelens.com' <<<"${online_output}" >/dev/null
-grep -F 'Password       Admin@123' <<<"${online_output}" >/dev/null
+grep -F 'URL            https://192.0.2.10:11443/' <<<"${online_output}" >/dev/null
+grep -F 'URL            https://192.0.2.10:11444/' <<<"${online_output}" >/dev/null
+[[ "$(grep -Fc 'Email          admin@hyperfilelens.com' <<<"${online_output}")" -eq 2 ]]
+[[ "$(grep -Fc 'Password       Admin@123' <<<"${online_output}")" -eq 2 ]]
+[[ "$(grep -Fc 'Organization   HyperFileLens' <<<"${online_output}")" -eq 1 ]]
 grep -F 'sudo docker compose -f' <<<"${online_output}" >/dev/null
 grep -F 'Online upgrade  curl -fsSL https://gitee.com/oneprolabs/hyperfilelens/raw/main/deploy/online/install.sh | sudo bash -s -- --mirror cn' \
 	<<<"${online_output}" >/dev/null
@@ -97,8 +101,8 @@ global_upgrade_command="$(HFL_REGISTRY_REGION=global online_community_upgrade_co
 grep -F 'https://raw.githubusercontent.com/oneprolabs/hyperfilelens/main/deploy/online/install.sh' \
 	<<<"${global_upgrade_command}" >/dev/null
 grep -F -- '--mirror global' <<<"${global_upgrade_command}" >/dev/null
-for internal_endpoint in 'Website ·' 'Tenant ·' 'Django Admin' 'Insight Console' \
-	'API / Swagger' 0.0.0.0; do
+for internal_endpoint in 'Website ·' 'Tenant ·' 'HyperFileLens ·' \
+	'Platform Ops ·' 'Django Admin' 'Insight Console' 'API / Swagger' 0.0.0.0; do
 	if grep -F "${internal_endpoint}" <<<"${online_output}" >/dev/null; then
 		echo "Online summary exposed internal endpoint detail: ${internal_endpoint}" >&2
 		exit 1
@@ -158,7 +162,8 @@ sourcelens_installed() { return 0; }
 
 # Compact status resolves service health without emitting Compose tables or
 # internal-only entry points.
-status_output="$(
+status_output="$({
+	configure_logging() { :; }
 	init_install_root() { :; }
 	require_docker() { :; }
 	read_active_color() { printf 'blue'; }
@@ -171,20 +176,39 @@ status_output="$(
 		[[ "${1:-}" == ps ]]
 		printf 'fixture-gateway-container\n'
 	}
-	cmd_status
-)"
+	main status
+} 2>&1)"
+grep -Fx 'HyperFileLens Status' <<<"${status_output}" >/dev/null
 grep -F 'Status            Healthy' <<<"${status_output}" >/dev/null
 grep -F 'HyperFileLens     https://192.0.2.10:11443/' <<<"${status_output}" >/dev/null
 grep -F 'Platform Ops      https://192.0.2.10:11444/' <<<"${status_output}" >/dev/null
 grep -F 'Insight           Healthy' <<<"${status_output}" >/dev/null
 grep -F 'Platform Gateway  Running' <<<"${status_output}" >/dev/null
+[[ "${status_output}" == *$'Access\n\n  HyperFileLens'* ]]
+[[ "${status_output}" == *$'Services\n\n  Insight'* ]]
+[[ "${status_output}" == *$'Management\n\n  Logs'* ]]
 for hidden_status_detail in 11442 '/admin/' 11445 swagger 0.0.0.0 'Active color' \
-	'Deployment phase' 'Agent releases'; do
+	'Deployment phase' 'Agent releases' INSTALLER 'status completed' \
+	'already in install directory'; do
 	if grep -F "${hidden_status_detail}" <<<"${status_output}" >/dev/null; then
 		echo "Compact status exposed unnecessary detail: ${hidden_status_detail}" >&2
 		exit 1
 	fi
 done
+
+# Routine status output omits installer-only progress messages.
+status_materialize_output="$(
+	INSTALL_DIR="${fixture}"
+	SESSION_ACTION=status
+	materialize_to_install_dir "${fixture}" 2>&1
+)"
+[[ -z "${status_materialize_output}" ]]
+status_finish_output="$(
+	SESSION_STARTED=1
+	SESSION_ACTION=status
+	finish_session 0 2>&1
+)"
+[[ -z "${status_finish_output}" ]]
 
 # Immediate health inspection requires every requested service to exist and be
 # running or healthy.


### PR DESCRIPTION
## Summary

- present routine status checks without the installer banner or redundant lifecycle messages
- improve spacing and hierarchy in the compact status summary
- simplify Community installation access headings while keeping credentials associated with each console
- retain complete URLs and existing interactive credential visibility rules

## Validation

- `./tools/quality/test-lifecycle-output-contract.sh`
- `./tools/quality/check-release-contracts.sh`
- `./tools/quality/test-online-community-install.sh`
- Bash syntax and `git diff --check`