### PR TITLE
Increase the default Chat queue capacity to 20

### DIFF
--- a/src/backend/apps/lens_bridge/migrations/0042_alter_lensgatewaylink_chat_queue_capacity.py
+++ b/src/backend/apps/lens_bridge/migrations/0042_alter_lensgatewaylink_chat_queue_capacity.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("lens_bridge", "0041_gateway_organization_ownership"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="lensgatewaylink",
+            name="chat_queue_capacity",
+            field=models.PositiveIntegerField(default=20),
+        ),
+    ]

--- a/src/backend/apps/lens_bridge/models/links.py
+++ b/src/backend/apps/lens_bridge/models/links.py
@@ -236,7 +236,7 @@ class LensGatewayLink(OrganizationScopedModel):
     capacity_bytes = models.BigIntegerField(default=-1)
     # Heavy Chat preparation (restore + conversion) is scheduled per Gateway.
     chat_prepare_concurrency = models.PositiveSmallIntegerField(default=1)
-    chat_queue_capacity = models.PositiveIntegerField(default=10)
+    chat_queue_capacity = models.PositiveIntegerField(default=20)
 
     class Meta:
         db_table = "lens_bridge_gateway_link"

--- a/src/backend/apps/lens_bridge/services/gateway_chat_queue.py
+++ b/src/backend/apps/lens_bridge/services/gateway_chat_queue.py
@@ -19,7 +19,7 @@ from apps.lens_bridge.models import (
 )
 
 DEFAULT_CHAT_PREPARE_CONCURRENCY = 1
-DEFAULT_CHAT_QUEUE_CAPACITY = 10
+DEFAULT_CHAT_QUEUE_CAPACITY = 20
 MAX_CHAT_PREPARE_CONCURRENCY = 32
 MAX_CHAT_QUEUE_CAPACITY = 1000
 # Slot release/configuration changes wake eligible sessions immediately. This

--- a/src/backend/apps/lens_bridge/tests/test_gateway_chat_queue.py
+++ b/src/backend/apps/lens_bridge/tests/test_gateway_chat_queue.py
@@ -54,6 +54,24 @@ class GatewayChatQueueTests(TestCase):
             gateway_queue_entered_at=timezone.now(),
         )
 
+    def test_new_gateway_uses_default_waiting_queue_capacity(self):
+        gateway = Node.objects.create(
+            organization=self.organization,
+            name="default-queue-gateway",
+            role=Node.Role.GATEWAY,
+        )
+
+        gateway_link = LensGatewayLink.objects.create(
+            organization=self.organization,
+            gateway=gateway,
+            owner_user=self.user,
+            scope=LensGatewayLink.GatewayScope.USER,
+            origin=LensGatewayLink.Origin.USER,
+        )
+
+        self.assertEqual(gateway_link.chat_queue_capacity, 20)
+        self.assertEqual(gateway_chat_queue.DEFAULT_CHAT_QUEUE_CAPACITY, 20)
+
     def test_same_gateway_is_fifo_and_reports_running_chat_ahead(self):
         first = self._session()
         second = self._session()


### PR DESCRIPTION
## Summary

- increase the default per-Data-Gateway Chat waiting queue capacity from 10 to 20
- keep Chat preparation concurrency unchanged at 1
- add a state-only migration without modifying existing Gateway settings
- cover the new default for newly created private Data Gateways

## Compatibility

- existing Data Gateway queue settings remain unchanged
- Public and Private Data Gateways continue to share the same configurable queue model
- no SourceLens concurrency, Chat lifecycle, or quota behavior changes

## Validation

- Core and Enterprise queue regression tests (17 tests)
- Django migration consistency check
- Ruff checks
- git diff check

## Companion PR

- oneprolabs/hyperfilelens-ee#40