### PR TITLE
Retry transient registry pulls during installation

### DIFF
--- a/.github/scripts/remote-saas-deploy.sh
+++ b/.github/scripts/remote-saas-deploy.sh
@@ -111,6 +111,7 @@ cleanup() {
 		"${stage_dir}/asset-language"
 	rm -f -- \
 		"${stage_dir}/assets.tsv" \
+		"${stage_dir}/registry-pull.log" \
 		"${stage_dir}/previous-MANIFEST.json" \
 		"${registry_credentials}" \
 		"${runtime_env_file}" \
@@ -215,6 +216,44 @@ done
 }
 
 export DOCKER_CONFIG="${docker_config}"
+registry_pull_retry_delay="${HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS:-15}"
+if [[ ! "${registry_pull_retry_delay}" =~ ^[0-9]+$ ]] \
+	|| ((registry_pull_retry_delay > 300)); then
+	printf 'ERROR: HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS must be an integer from 0 to 300\n' >&2
+	exit 2
+fi
+
+registry_pull_is_transient() {
+	grep -Eiq \
+		'network is unreachable|no route to host|connection (refused|reset|timed out)|i/o timeout|context deadline exceeded|tls handshake timeout|client\.timeout|request canceled|unexpected eof|short read|unexpected commit digest|too many requests|(http (response )?status|status( code)?( from [^:]+)?)[^0-9]{0,16}(429|5[0-9][0-9])' \
+		"$1"
+}
+
+pull_registry_image() {
+	local immutable_ref=$1 attempts=$2 attempt=1 rc=1
+	local diagnostics="${stage_dir}/registry-pull.log"
+	while ((attempt <= attempts)); do
+		: >"${diagnostics}"
+		if docker pull --platform linux/amd64 "${immutable_ref}" 2>&1 \
+			| tee "${diagnostics}"; then
+			rm -f -- "${diagnostics}"
+			return 0
+		else
+			rc=$?
+		fi
+		if ((attempt < attempts)) && registry_pull_is_transient "${diagnostics}"; then
+			printf '[WARN] Temporary container registry error; retrying the preferred source in %s seconds\n' \
+				"${registry_pull_retry_delay}" >&2
+			sleep "${registry_pull_retry_delay}"
+			attempt=$((attempt + 1))
+			continue
+		fi
+		break
+	done
+	rm -f -- "${diagnostics}"
+	return "${rc}"
+}
+
 python3 - "${candidate_root}/MANIFEST.json" "${registry_region}" >"${stage_dir}/assets.tsv" <<'PY'
 import json, pathlib, re, sys
 manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
@@ -263,13 +302,17 @@ PY
 while IFS=$'\t' read -r kind digest local_ref source_one source_two; do
 	[[ -n "${kind}" ]] || continue
 	pulled=""
+	source_index=0
 	for source_ref in "${source_one}" "${source_two}"; do
 		[[ -n "${source_ref}" ]] || continue
 		immutable_ref="${source_ref%:*}@${digest}"
-		if docker pull --platform linux/amd64 "${immutable_ref}"; then
+		attempts=1
+		((source_index == 0)) && attempts=2
+		if pull_registry_image "${immutable_ref}" "${attempts}"; then
 			pulled="${immutable_ref}"
 			break
 		fi
+		source_index=$((source_index + 1))
 	done
 	[[ -n "${pulled}" ]] || {
 		printf 'ERROR: could not pull %s asset image\n' "${kind}" >&2

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -2581,8 +2581,10 @@ import hashlib
 import json
 import os
 import pathlib
+import re
 import subprocess
 import sys
+import time
 
 root = pathlib.Path(sys.argv[1])
 skip_sourcelens = sys.argv[2] == "1"
@@ -2591,6 +2593,19 @@ with (root / "MANIFEST.json").open(encoding="utf-8") as fh:
 delivery = manifest.get("delivery") or {"mode": "offline"}
 delivery_mode = str(delivery.get("mode") or "offline")
 online_child = os.environ.get("HFL_ONLINE_CHILD") == "1"
+registry_retry_delay = os.environ.get("HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS", "15")
+registry_retry_delay_seconds = (
+    min(int(registry_retry_delay), 300) if registry_retry_delay.isdecimal() else 15
+)
+transient_registry_error = re.compile(
+    r"network is unreachable|no route to host|connection (?:refused|reset|timed out)"
+    r"|i/o timeout|context deadline exceeded|tls handshake timeout|client\.timeout"
+    r"|request canceled|unexpected eof|short read|unexpected commit digest"
+    r"|too many requests"
+    r"|(?:http (?:response )?status|status(?: code)?(?: from [^:\n]+)?)"
+    r"[^0-9\n]{0,16}(?:429|5[0-9]{2})",
+    re.IGNORECASE,
+)
 
 
 def sha256_file(path: pathlib.Path) -> str:
@@ -2695,21 +2710,35 @@ if delivery_mode == "registry":
             else:
                 print(f"[ OK ] Reusing registry image: {local_ref}@{digest}")
             continue
-        for source in sources:
+        for source_index, source in enumerate(sources):
             source_ref = str(source.get("ref") or "")
             repository = source_ref.rsplit(":", 1)[0]
             immutable_ref = f"{repository}@{digest}"
-            completed = subprocess.run(
-                ["docker", "pull", "--platform", "linux/amd64", immutable_ref],
-                check=False,
-                text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-            )
-            if completed.returncode == 0:
-                pulled = immutable_ref
+            attempts = 2 if source_index == 0 else 1
+            for attempt in range(1, attempts + 1):
+                completed = subprocess.run(
+                    ["docker", "pull", "--platform", "linux/amd64", immutable_ref],
+                    check=False,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
+                if completed.returncode == 0:
+                    pulled = immutable_ref
+                    break
+                output = completed.stdout.strip()
+                errors.append(f"{immutable_ref}: {output[-500:]}")
+                if attempt < attempts and transient_registry_error.search(output):
+                    print(
+                        "[WARN] Temporary container registry error; "
+                        f"retrying the preferred source in "
+                        f"{registry_retry_delay_seconds} seconds"
+                    )
+                    time.sleep(registry_retry_delay_seconds)
+                    continue
                 break
-            errors.append(f"{immutable_ref}: {completed.stdout.strip()[-500:]}")
+            if pulled:
+                break
         if not pulled:
             print(
                 f"[install.sh] ERROR: no registry source could provide {local_ref}",

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -1384,8 +1384,13 @@ prepare_args=(
 if [[ "${INSTALL_ACTION}" == "Install" ]]; then
 	prepare_args+=(--concise-output)
 fi
-if ! python3 "${SESSION_DIR}/source/deploy/online/prepare.py" \
-	"${prepare_args[@]}"; then
+prepare_status=0
+python3 "${SESSION_DIR}/source/deploy/online/prepare.py" "${prepare_args[@]}" \
+	|| prepare_status=$?
+if ((prepare_status == 75)); then
+	fail "Container image downloads could not be completed after retrying the preferred registry and trying the fallback; wait briefly, check registry connectivity, and rerun the same command"
+fi
+if ((prepare_status != 0)); then
 	fail_with_tag_guidance "Community tag ${TAG} is incomplete or unavailable"
 fi
 if ! verify_candidate_release; then

--- a/deploy/online/prepare.py
+++ b/deploy/online/prepare.py
@@ -17,6 +17,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,6 +26,10 @@ VERSION_PATTERN = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
 DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
 REVISION_PATTERN = re.compile(r"[0-9a-f]{40}")
 PULL_PARALLELISM = 5
+_PULL_RETRY_DELAY = os.environ.get("HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS", "15")
+PULL_RETRY_DELAY_SECONDS = (
+    min(int(_PULL_RETRY_DELAY), 300) if _PULL_RETRY_DELAY.isdecimal() else 15
+)
 GLOBAL_PREFIX = os.environ.get(
     "HFL_GLOBAL_REGISTRY_PREFIX", "docker.io/oneprolabs"
 ).rstrip("/")
@@ -32,6 +37,20 @@ CN_PREFIX = os.environ.get(
     "HFL_CN_REGISTRY_PREFIX",
     "registry.cn-beijing.aliyuncs.com/oneprolabs",
 ).rstrip("/")
+
+TRANSIENT_REGISTRY_ERROR = re.compile(
+    r"network is unreachable|no route to host|connection (?:refused|reset|timed out)"
+    r"|i/o timeout|context deadline exceeded|tls handshake timeout|client\.timeout"
+    r"|request canceled|unexpected eof|short read|unexpected commit digest"
+    r"|too many requests"
+    r"|(?:http (?:response )?status|status(?: code)?(?: from [^:\n]+)?)"
+    r"[^0-9\n]{0,16}(?:429|5[0-9]{2})",
+    re.IGNORECASE,
+)
+
+
+class RegistryNetworkError(RuntimeError):
+    """Report a registry failure caused by a retryable transport condition."""
 
 
 @dataclass(frozen=True)
@@ -565,6 +584,16 @@ def inspect_pulled_images(
     return resolved, unresolved
 
 
+def registry_failure_is_transient(output: str) -> bool:
+    """Return whether Docker reported a retryable registry transport failure."""
+    return bool(TRANSIENT_REGISTRY_ERROR.search(output))
+
+
+def wait_before_registry_retry() -> None:
+    """Pause before one same-registry retry."""
+    time.sleep(PULL_RETRY_DELAY_SECONDS)
+
+
 def pull_images(
     specs: list[ImageSpec],
     preferred_region: str,
@@ -574,7 +603,26 @@ def pull_images(
     """Pull all images concurrently with a selective regional fallback."""
     fallback_region = "global" if preferred_region == "cn" else "cn"
     primary = pull_image_batch(specs, preferred_region, concise_output=concise_output)
+    pull_outputs = [primary.stdout or ""]
     resolved, unresolved = inspect_pulled_images(specs, preferred_region)
+
+    if unresolved and registry_failure_is_transient(primary.stdout or ""):
+        prefix = "  " if concise_output else ""
+        print(
+            f"{prefix}[WARN] Temporary container registry error; "
+            f"retrying {len(unresolved)} image(s) from the preferred registry "
+            f"in {PULL_RETRY_DELAY_SECONDS} seconds",
+            flush=True,
+        )
+        wait_before_registry_retry()
+        retry = pull_image_batch(
+            unresolved, preferred_region, concise_output=concise_output
+        )
+        pull_outputs.append(retry.stdout or "")
+        retry_resolved, unresolved = inspect_pulled_images(
+            unresolved, preferred_region
+        )
+        resolved.update(retry_resolved)
 
     if unresolved:
         prefix = "  " if concise_output else ""
@@ -584,7 +632,6 @@ def pull_images(
             flush=True,
         )
 
-    fallback_output = ""
     if unresolved:
         prefix = "  " if concise_output else ""
         print(
@@ -595,7 +642,7 @@ def pull_images(
         fallback = pull_image_batch(
             unresolved, fallback_region, concise_output=concise_output
         )
-        fallback_output = fallback.stdout or ""
+        pull_outputs.append(fallback.stdout or "")
         fallback_resolved, unresolved = inspect_pulled_images(
             unresolved, fallback_region
         )
@@ -606,7 +653,7 @@ def pull_images(
             re.sub(
                 r"\x1b\[[0-9;?]*[ -/]*[@-~]",
                 "",
-                "\n".join((primary.stdout or "", fallback_output)),
+                "\n".join(pull_outputs),
             )
             .replace("\r", "\n")
             .strip()
@@ -617,9 +664,10 @@ def pull_images(
             f"{spec.source_ref(preferred_region)} or {spec.source_ref(fallback_region)}"
             for spec in unresolved
         )
-        raise RuntimeError(
-            f"neither public registry could provide: {failures}{details}"
-        )
+        message = f"neither public registry could provide: {failures}{details}"
+        if any(registry_failure_is_transient(output) for output in pull_outputs):
+            raise RegistryNetworkError(message)
+        raise RuntimeError(message)
 
     result: list[ResolvedImage] = []
     total = len(specs)
@@ -1017,6 +1065,9 @@ def main() -> int:
 if __name__ == "__main__":
     try:
         raise SystemExit(main())
+    except RegistryNetworkError as error:
+        print(f"[ERROR] Temporary container registry failure: {error}", file=sys.stderr)
+        raise SystemExit(75) from error
     except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
         print(f"[FAIL] {error}", file=sys.stderr)
         raise SystemExit(1) from error

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -28,6 +28,9 @@ grep -Fq 'api.github.com/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1
 grep -Fq 'gitee.com/api/v5/repos/oneprolabs/hyperfilelens/tags?per_page=100&page=1' \
 	"${online}/install.sh"
 grep -Fq 'recent fallback tags:' "${online}/install.sh"
+grep -Fq 'prepare_status == 75' "${online}/install.sh"
+grep -Fq 'Container image downloads could not be completed after retrying the preferred registry and trying the fallback' \
+	"${online}/install.sh"
 grep -Fq 'prepared Community image revision does not match the published release' \
 	"${online}/install.sh"
 grep -Fq 'run this command through sudo' "${online}/install.sh"
@@ -233,6 +236,20 @@ if spec is None or spec.loader is None:
 module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = module
 spec.loader.exec_module(module)
+
+for message in (
+    "dial tcp [::1]:443: network is unreachable",
+    "short read: unexpected EOF",
+    "unexpected commit digest; expected sha256:test",
+    "received unexpected HTTP status: 503 Service Unavailable",
+):
+    assert module.registry_failure_is_transient(message), message
+for message in (
+    "manifest unknown: manifest unknown",
+    "pull access denied",
+    "no matching manifest for linux/amd64",
+):
+    assert not module.registry_failure_is_transient(message), message
 
 runtime = json.loads(
     (root / "deploy/online/sourcelens/runtime.json").read_text(encoding="utf-8")
@@ -440,8 +457,25 @@ case "${1:-} ${2:-}" in
 	printf '\rDocker Compose native pull progress: parallel=%s images=%s\n' \
 		"${3}" "${image_count}"
 	if [[ "${HFL_TEST_DOCKER_PULL_FAIL:-0}" == "1" ]]; then
-		printf 'registry rejected test image: access denied\n' >&2
+		if [[ "${HFL_TEST_DOCKER_PULL_ERROR:-denied}" == network ]]; then
+			printf 'short read: unexpected EOF\n' >&2
+		else
+			printf 'registry rejected test image: access denied\n' >&2
+		fi
 		exit 23
+	fi
+	if [[ -n "${HFL_TEST_DOCKER_TRANSIENT_FAIL_COMPONENT:-}" ]] \
+		&& grep -Fq "docker.io/oneprolabs/${HFL_TEST_DOCKER_TRANSIENT_FAIL_COMPONENT}:" \
+			"${compose_file}"; then
+		count=0
+		[[ ! -f "${HFL_TEST_DOCKER_PULL_MARKER}" ]] \
+			|| count="$(cat "${HFL_TEST_DOCKER_PULL_MARKER}")"
+		count=$((count + 1))
+		printf '%s\n' "${count}" >"${HFL_TEST_DOCKER_PULL_MARKER}"
+		if ((count <= ${HFL_TEST_DOCKER_TRANSIENT_FAILURES:-1})); then
+			printf 'short read: unexpected EOF\n' >&2
+			exit 23
+		fi
 	fi
 	if [[ -n "${HFL_TEST_DOCKER_PRIMARY_FAIL_COMPONENT:-}" ]] \
 		&& grep -Fq "docker.io/oneprolabs/${HFL_TEST_DOCKER_PRIMARY_FAIL_COMPONENT}:" \
@@ -461,6 +495,15 @@ case "${1:-} ${2:-}" in
 	if [[ -n "${HFL_TEST_DOCKER_PRIMARY_FAIL_COMPONENT:-}" \
 		&& "${ref}" == "docker.io/oneprolabs/${HFL_TEST_DOCKER_PRIMARY_FAIL_COMPONENT}:"* ]]; then
 		exit 1
+	fi
+	if [[ -n "${HFL_TEST_DOCKER_TRANSIENT_FAIL_COMPONENT:-}" \
+		&& "${ref}" == "docker.io/oneprolabs/${HFL_TEST_DOCKER_TRANSIENT_FAIL_COMPONENT}:"* ]]; then
+		count=0
+		[[ ! -f "${HFL_TEST_DOCKER_PULL_MARKER}" ]] \
+			|| count="$(cat "${HFL_TEST_DOCKER_PULL_MARKER}")"
+		if ((count <= ${HFL_TEST_DOCKER_TRANSIENT_FAILURES:-1})); then
+			exit 1
+		fi
 	fi
 	if [[ "${format}" == *RepoDigests* ]]; then
 		repository=${ref%%@*}
@@ -1717,14 +1760,17 @@ fi
 grep -Fq 'repeated page 2' "${repeated_page_log}"
 
 prepare_log="${tmp}/prepare.log"
-PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
+if ! PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 	HFL_ONLINE_NATIVE_PROGRESS=1 \
 	python3 "${online}/prepare.py" \
 		--source-root "${ROOT}" \
 		--version v1.2.3 \
 		--region global \
 		--concise-output \
-		--output "${candidate}" >"${prepare_log}" 2>&1
+		--output "${candidate}" >"${prepare_log}" 2>&1; then
+	cat "${prepare_log}" >&2
+	exit 1
+fi
 grep -F 'Docker Compose native pull progress: parallel=5 images=10' \
 	"${prepare_log}" >/dev/null
 grep -F '[....] Pulling 10 container images · up to 5 concurrent downloads' \
@@ -1781,6 +1827,48 @@ grep -F '[....] Retrying 1 installation image(s) from the fallback registry' \
 	"${fallback_prepare_log}" >/dev/null
 grep -F 'Docker Compose native pull progress: parallel=5 images=1' \
 	"${fallback_prepare_log}" >/dev/null
+
+retry_marker="${tmp}/preferred-registry-retries"
+retry_candidate="${tmp}/retry-candidate"
+retry_prepare_log="${tmp}/prepare-retry.log"
+PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
+	HFL_ONLINE_NATIVE_PROGRESS=1 \
+	HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS=0 \
+	HFL_TEST_DOCKER_TRANSIENT_FAIL_COMPONENT=hyperfilelens-backend \
+	HFL_TEST_DOCKER_PULL_MARKER="${retry_marker}" \
+	python3 "${online}/prepare.py" \
+		--source-root "${ROOT}" \
+		--version v1.2.3 \
+		--region global \
+		--concise-output \
+		--output "${retry_candidate}" >"${retry_prepare_log}" 2>&1
+[[ "$(cat "${retry_marker}")" -eq 2 ]]
+grep -F 'retrying 1 image(s) from the preferred registry in 0 seconds' \
+	"${retry_prepare_log}" >/dev/null
+if grep -Fq 'from the fallback registry' "${retry_prepare_log}"; then
+	printf 'ERROR: successful preferred-registry retry used the fallback registry\n' >&2
+	exit 1
+fi
+
+retry_fallback_marker="${tmp}/preferred-registry-fallback-retries"
+retry_fallback_candidate="${tmp}/retry-fallback-candidate"
+retry_fallback_log="${tmp}/prepare-retry-fallback.log"
+PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
+	HFL_ONLINE_NATIVE_PROGRESS=1 \
+	HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS=0 \
+	HFL_TEST_DOCKER_TRANSIENT_FAIL_COMPONENT=hyperfilelens-backend \
+	HFL_TEST_DOCKER_TRANSIENT_FAILURES=2 \
+	HFL_TEST_DOCKER_PULL_MARKER="${retry_fallback_marker}" \
+	python3 "${online}/prepare.py" \
+		--source-root "${ROOT}" \
+		--version v1.2.3 \
+		--region global \
+		--concise-output \
+		--output "${retry_fallback_candidate}" >"${retry_fallback_log}" 2>&1
+[[ "$(cat "${retry_fallback_marker}")" -eq 2 ]]
+grep -F 'Retrying 1 installation image(s) from the fallback registry' \
+	"${retry_fallback_log}" >/dev/null
+
 failed_prepare_log="${tmp}/prepare-failed.log"
 if PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 	HFL_ONLINE_NATIVE_PROGRESS=1 HFL_TEST_DOCKER_PULL_FAIL=1 \
@@ -1798,6 +1886,29 @@ grep -Fq 'registry rejected test image: access denied' "${failed_prepare_log}"
 grep -Fq 'docker.io/oneprolabs/hyperfilelens-backend:1.2.3' "${failed_prepare_log}"
 grep -Fq 'registry.cn-beijing.aliyuncs.com/oneprolabs/hyperfilelens-backend:1.2.3' \
 	"${failed_prepare_log}"
+
+network_prepare_log="${tmp}/prepare-network-failed.log"
+set +e
+PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
+	HFL_ONLINE_NATIVE_PROGRESS=1 \
+	HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS=0 \
+	HFL_TEST_DOCKER_PULL_FAIL=1 HFL_TEST_DOCKER_PULL_ERROR=network \
+	python3 "${online}/prepare.py" \
+		--source-root "${ROOT}" \
+		--version v1.2.3 \
+		--region global \
+		--concise-output \
+		--output "${tmp}/network-failed-candidate" \
+		>"${network_prepare_log}" 2>&1
+network_prepare_status=$?
+set -e
+[[ "${network_prepare_status}" -eq 75 ]]
+grep -Fq '[ERROR] Temporary container registry failure:' "${network_prepare_log}"
+if grep -Eq 'incomplete or unavailable|recommended retry:' \
+	"${network_prepare_log}"; then
+	printf 'ERROR: registry network failure was reported as a release-tag failure\n' >&2
+	exit 1
+fi
 [[ -r "${candidate}/payload/runtime/compose-runtime.sh" ]]
 [[ ! -x "${candidate}/payload/runtime/compose-runtime.sh" ]]
 "${candidate}/install.sh" --help >/dev/null

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -37,6 +37,10 @@ grep -Fq -- '--registry-region "$HFL_REGISTRY_REGION"' \
 	"${ROOT}/.github/actions/deploy-saas/action.yml"
 grep -Fq 'registry_login_count > 0' \
 	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
+grep -Fq 'pull_registry_image "${immutable_ref}" "${attempts}"' \
+	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
+grep -Fq 'HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS:-15' \
+	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
 grep -Fq 'for prefix in "${registry_region}" "${fallback_region}"' \
 	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
 grep -Fq 'Enterprise SaaS deployment action:' \
@@ -217,6 +221,24 @@ case "${1:-} ${2:-}" in
 "pull --platform")
 	ref="${4:-}"
 	printf '%s\n' "${ref}" >>"${HFL_TEST_PULL_MARKER}"
+	transient_match=0
+	case "${HFL_TEST_TRANSIENT_REGION:-}" in
+	cn) [[ "${ref}" == registry.example.cn/* ]] && transient_match=1 ;;
+	global) [[ "${ref}" == docker.io/* ]] && transient_match=1 ;;
+	"") ;;
+	*) exit 2 ;;
+	esac
+	if ((transient_match == 1)); then
+		count=0
+		[[ ! -f "${HFL_TEST_TRANSIENT_MARKER}" ]] \
+			|| count="$(cat "${HFL_TEST_TRANSIENT_MARKER}")"
+		count=$((count + 1))
+		printf '%s\n' "${count}" >"${HFL_TEST_TRANSIENT_MARKER}"
+		if ((count <= ${HFL_TEST_TRANSIENT_FAILURES:-1})); then
+			printf 'short read: unexpected EOF\n' >&2
+			exit 1
+		fi
+	fi
 	case "${HFL_TEST_FAIL_REGION:-}" in
 	cn) [[ "${ref}" == registry.example.cn/* ]] && exit 1 ;;
 	global) [[ "${ref}" == docker.io/* ]] && exit 1 ;;
@@ -445,6 +467,29 @@ HFL_TEST_FAIL_REGION=global HFL_REGISTRY_REGION=global \
 [[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
 [[ "$(sed -n '1p' "${pull_marker}")" == docker.io/* ]]
 [[ "$(sed -n '2p' "${pull_marker}")" == registry.example.cn/* ]]
+
+transient_marker="${tmp}/transient-pulls"
+rm -f "${tag_marker}" "${transient_marker}"
+: >"${pull_marker}"
+HFL_TEST_TRANSIENT_REGION=cn HFL_TEST_TRANSIENT_MARKER="${transient_marker}" \
+	HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS=0 HFL_REGISTRY_REGION=cn \
+	load_images_from_manifest 0 "${package_root}"
+[[ -f "${tag_marker}" ]]
+[[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
+[[ "$(sed -n '1p' "${pull_marker}")" == registry.example.cn/* ]]
+[[ "$(sed -n '2p' "${pull_marker}")" == registry.example.cn/* ]]
+
+rm -f "${tag_marker}" "${transient_marker}"
+: >"${pull_marker}"
+HFL_TEST_TRANSIENT_REGION=cn HFL_TEST_TRANSIENT_FAILURES=2 \
+	HFL_TEST_TRANSIENT_MARKER="${transient_marker}" \
+	HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS=0 HFL_REGISTRY_REGION=cn \
+	load_images_from_manifest 0 "${package_root}"
+[[ -f "${tag_marker}" ]]
+[[ "$(wc -l <"${pull_marker}")" -eq 3 ]]
+[[ "$(sed -n '1p' "${pull_marker}")" == registry.example.cn/* ]]
+[[ "$(sed -n '2p' "${pull_marker}")" == registry.example.cn/* ]]
+[[ "$(sed -n '3p' "${pull_marker}")" == docker.io/* ]]
 
 rm -f "${tag_marker}"
 : >"${pull_marker}"


### PR DESCRIPTION
## Summary

- retry unresolved images once from the preferred registry after transient transport or registry failures
- retain the existing regional fallback order for Community installs, managed upgrades, and SaaS asset delivery
- distinguish registry network failures from incomplete Community release tags
- preserve digest, platform, revision, and release identity validation

## Retry policy

- preferred registry: one initial attempt
- transient failure: wait 15 seconds and retry unresolved images once
- fallback registry: one final attempt
- deterministic failures such as authorization errors or missing manifests skip the same-registry retry

## Validation

- `tools/quality/test-online-community-install.sh`
- `tools/quality/test-saas-registry-delivery.sh`
- `tools/quality/test-installer-image-refresh.sh`
- `tools/quality/check-release-contracts.sh`
- `ruff check deploy/online/prepare.py`
- shell syntax and `git diff --check`