### PR TITLE
Retry image pulls within the selected registry

### DIFF
--- a/.github/scripts/remote-saas-deploy.sh
+++ b/.github/scripts/remote-saas-deploy.sh
@@ -193,35 +193,44 @@ print(value, end="")
 PY
 }
 
-registry_login_count=0
-fallback_region="global"
-[[ "${registry_region}" == "cn" ]] || fallback_region="cn"
-for prefix in "${registry_region}" "${fallback_region}"; do
-	host="$(read_credential "${prefix}_host")"
-	username="$(read_credential "${prefix}_username")"
-	password="$(read_credential "${prefix}_password")"
-	[[ "${host}" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?$ && -n "${username}" && -n "${password}" ]]
-	if printf '%s' "${password}" | DOCKER_CONFIG="${docker_config}" docker login \
-		--username "${username}" --password-stdin "${host}" >/dev/null 2>&1; then
-		registry_login_count=$((registry_login_count + 1))
-		printf '[ OK ] Authenticated registry source: %s\n' "${host}"
-	else
-		printf '[WARN] Registry source is temporarily unavailable: %s\n' "${host}" >&2
-	fi
-	unset password
-done
-((registry_login_count > 0)) || {
-	printf 'ERROR: neither registry source is available\n' >&2
+registry_host="$(read_credential "${registry_region}_host")"
+registry_username="$(read_credential "${registry_region}_username")"
+registry_password="$(read_credential "${registry_region}_password")"
+registry_name="Docker Hub"
+[[ "${registry_region}" == "cn" ]] && registry_name="Alibaba Cloud"
+[[ "${registry_host}" =~ ^[a-z0-9][a-z0-9.-]*(:[0-9]+)?$ \
+	&& -n "${registry_username}" && -n "${registry_password}" ]]
+if ! printf '%s' "${registry_password}" | DOCKER_CONFIG="${docker_config}" docker login \
+	--username "${registry_username}" --password-stdin "${registry_host}" >/dev/null 2>&1; then
+	printf 'ERROR: selected registry is unavailable: %s\n' "${registry_host}" >&2
 	exit 1
-}
+fi
+unset registry_password
+printf '[ OK ] Authenticated registry source: %s\n' "${registry_host}"
 
 export DOCKER_CONFIG="${docker_config}"
-registry_pull_retry_delay="${HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS:-15}"
-if [[ ! "${registry_pull_retry_delay}" =~ ^[0-9]+$ ]] \
-	|| ((registry_pull_retry_delay > 300)); then
+registry_pull_retry_delay_config="${HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS:-15}"
+if [[ ! "${registry_pull_retry_delay_config}" =~ ^[0-9]+$ ]] \
+	|| ((registry_pull_retry_delay_config > 300)); then
 	printf 'ERROR: HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS must be an integer from 0 to 300\n' >&2
 	exit 2
 fi
+registry_pull_retry_delay=${registry_pull_retry_delay_config}
+((registry_pull_retry_delay <= 60)) || registry_pull_retry_delay=60
+registry_pull_attempts=5
+
+registry_retry_delay_for_attempt() {
+	local completed_attempt=$1 delay=${registry_pull_retry_delay} count=1
+	while ((count < completed_attempt)); do
+		delay=$((delay * 2))
+		((delay < 60)) || {
+			delay=60
+			break
+		}
+		count=$((count + 1))
+	done
+	printf '%s' "${delay}"
+}
 
 registry_pull_is_transient() {
 	grep -Eiq \
@@ -230,9 +239,9 @@ registry_pull_is_transient() {
 }
 
 pull_registry_image() {
-	local immutable_ref=$1 attempts=$2 attempt=1 rc=1
+	local immutable_ref=$1 attempt=1 rc=1 delay
 	local diagnostics="${stage_dir}/registry-pull.log"
-	while ((attempt <= attempts)); do
+	while ((attempt <= registry_pull_attempts)); do
 		: >"${diagnostics}"
 		if docker pull --platform linux/amd64 "${immutable_ref}" 2>&1 \
 			| tee "${diagnostics}"; then
@@ -241,10 +250,13 @@ pull_registry_image() {
 		else
 			rc=$?
 		fi
-		if ((attempt < attempts)) && registry_pull_is_transient "${diagnostics}"; then
-			printf '[WARN] Temporary container registry error; retrying the preferred source in %s seconds\n' \
-				"${registry_pull_retry_delay}" >&2
-			sleep "${registry_pull_retry_delay}"
+		if ((attempt < registry_pull_attempts)) \
+			&& registry_pull_is_transient "${diagnostics}"; then
+			delay="$(registry_retry_delay_for_attempt "${attempt}")"
+			printf '[WARN] Temporary %s image download error; retrying in %s seconds (%s/%s)\n' \
+				"${registry_name}" "${delay}" "$((attempt + 1))" \
+				"${registry_pull_attempts}" >&2
+			sleep "${delay}"
 			attempt=$((attempt + 1))
 			continue
 		fi
@@ -257,8 +269,7 @@ pull_registry_image() {
 python3 - "${candidate_root}/MANIFEST.json" "${registry_region}" >"${stage_dir}/assets.tsv" <<'PY'
 import json, pathlib, re, sys
 manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-preferred_region = sys.argv[2]
-fallback_region = "global" if preferred_region == "cn" else "cn"
+selected_region = sys.argv[2]
 delivery = manifest.get("delivery") or {}
 if delivery.get("mode") != "registry":
     raise SystemExit("candidate is not registry-backed")
@@ -284,41 +295,30 @@ for image in asset_images:
     sources_by_region = {str(item.get("region") or ""): item for item in sources}
     if len(sources) != 2 or set(sources_by_region) != {"cn", "global"}:
         raise SystemExit("candidate asset sources must contain cn and global regions")
-    refs = [
-        str(sources_by_region[region].get("ref") or "")
-        for region in (preferred_region, fallback_region)
-    ]
+    refs = {
+        region: str(sources_by_region[region].get("ref") or "")
+        for region in ("cn", "global")
+    }
     if any(
         not re.fullmatch(
             r"[a-z0-9][a-z0-9.-]*(?::[0-9]+)?/[a-z0-9._/-]+:[A-Za-z0-9][A-Za-z0-9._-]{0,127}",
             ref,
         )
-        for ref in refs
+        for ref in refs.values()
     ):
         raise SystemExit("candidate contains invalid asset sources")
-    print("\t".join([kind, digest, local_ref, *refs]))
+    print("\t".join([kind, digest, local_ref, refs[selected_region]]))
 PY
 
-while IFS=$'\t' read -r kind digest local_ref source_one source_two; do
+while IFS=$'\t' read -r kind digest local_ref source_ref; do
 	[[ -n "${kind}" ]] || continue
-	pulled=""
-	source_index=0
-	for source_ref in "${source_one}" "${source_two}"; do
-		[[ -n "${source_ref}" ]] || continue
-		immutable_ref="${source_ref%:*}@${digest}"
-		attempts=1
-		((source_index == 0)) && attempts=2
-		if pull_registry_image "${immutable_ref}" "${attempts}"; then
-			pulled="${immutable_ref}"
-			break
-		fi
-		source_index=$((source_index + 1))
-	done
-	[[ -n "${pulled}" ]] || {
-		printf 'ERROR: could not pull %s asset image\n' "${kind}" >&2
+	immutable_ref="${source_ref%:*}@${digest}"
+	if ! pull_registry_image "${immutable_ref}"; then
+		printf 'ERROR: could not pull %s asset image from selected %s registry (%s)\n' \
+			"${kind}" "${registry_name}" "${registry_host}" >&2
 		exit 1
-	}
-	docker tag "${pulled}" "${local_ref}"
+	fi
+	docker tag "${immutable_ref}" "${local_ref}"
 	asset_extract="${stage_dir}/asset-${kind}"
 	rm -rf -- "${asset_extract}"
 	install -d -m 0700 "${asset_extract}"

--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -2595,8 +2595,10 @@ delivery_mode = str(delivery.get("mode") or "offline")
 online_child = os.environ.get("HFL_ONLINE_CHILD") == "1"
 registry_retry_delay = os.environ.get("HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS", "15")
 registry_retry_delay_seconds = (
-    min(int(registry_retry_delay), 300) if registry_retry_delay.isdecimal() else 15
+    min(int(registry_retry_delay), 60) if registry_retry_delay.isdecimal() else 15
 )
+registry_pull_attempts = 5
+registry_retry_max_delay_seconds = 60
 transient_registry_error = re.compile(
     r"network is unreachable|no route to host|connection (?:refused|reset|timed out)"
     r"|i/o timeout|context deadline exceeded|tls handshake timeout|client\.timeout"
@@ -2660,11 +2662,22 @@ def has_expected_digest(ref: str, digest: str) -> bool:
     )
 
 
+def registry_retry_delay_for_attempt(completed_attempt: int) -> int:
+    return min(
+        registry_retry_delay_seconds * (2 ** (completed_attempt - 1)),
+        registry_retry_max_delay_seconds,
+    )
+
+
+def registry_display_name(region: str) -> str:
+    return "Alibaba Cloud" if region == "cn" else "Docker Hub"
+
+
 if delivery_mode == "registry":
-    preferred_region = os.environ.get("HFL_REGISTRY_REGION", "").strip()
-    if preferred_region not in {"cn", "global"}:
+    selected_region = os.environ.get("HFL_REGISTRY_REGION", "").strip()
+    if selected_region not in {"cn", "global"}:
         raise SystemExit("registry delivery requires HFL_REGISTRY_REGION=cn or global")
-    fallback_region = "global" if preferred_region == "cn" else "cn"
+    registry_name = registry_display_name(selected_region)
     registry_images = [
         image
         for image in (delivery.get("registry_images") or [])
@@ -2684,10 +2697,7 @@ if delivery_mode == "registry":
             raise SystemExit(
                 f"registry image sources must contain cn and global regions: {local_ref}"
             )
-        sources = [
-            sources_by_region[preferred_region],
-            sources_by_region[fallback_region],
-        ]
+        source = sources_by_region[selected_region]
         pulled = ""
         errors = []
         if online_child:
@@ -2710,38 +2720,39 @@ if delivery_mode == "registry":
             else:
                 print(f"[ OK ] Reusing registry image: {local_ref}@{digest}")
             continue
-        for source_index, source in enumerate(sources):
-            source_ref = str(source.get("ref") or "")
-            repository = source_ref.rsplit(":", 1)[0]
-            immutable_ref = f"{repository}@{digest}"
-            attempts = 2 if source_index == 0 else 1
-            for attempt in range(1, attempts + 1):
-                completed = subprocess.run(
-                    ["docker", "pull", "--platform", "linux/amd64", immutable_ref],
-                    check=False,
-                    text=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
+        source_ref = str(source.get("ref") or "")
+        repository = source_ref.rsplit(":", 1)[0]
+        immutable_ref = f"{repository}@{digest}"
+        for attempt in range(1, registry_pull_attempts + 1):
+            completed = subprocess.run(
+                ["docker", "pull", "--platform", "linux/amd64", immutable_ref],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            if completed.returncode == 0:
+                pulled = immutable_ref
+                break
+            output = completed.stdout.strip()
+            errors.append(f"{immutable_ref}: {output[-500:]}")
+            if (
+                attempt < registry_pull_attempts
+                and transient_registry_error.search(output)
+            ):
+                delay = registry_retry_delay_for_attempt(attempt)
+                print(
+                    f"[WARN] Temporary {registry_name} image download error; "
+                    f"retrying in {delay} seconds "
+                    f"({attempt + 1}/{registry_pull_attempts})"
                 )
-                if completed.returncode == 0:
-                    pulled = immutable_ref
-                    break
-                output = completed.stdout.strip()
-                errors.append(f"{immutable_ref}: {output[-500:]}")
-                if attempt < attempts and transient_registry_error.search(output):
-                    print(
-                        "[WARN] Temporary container registry error; "
-                        f"retrying the preferred source in "
-                        f"{registry_retry_delay_seconds} seconds"
-                    )
-                    time.sleep(registry_retry_delay_seconds)
-                    continue
-                break
-            if pulled:
-                break
+                time.sleep(delay)
+                continue
+            break
         if not pulled:
             print(
-                f"[install.sh] ERROR: no registry source could provide {local_ref}",
+                f"[install.sh] ERROR: selected {registry_name} registry "
+                f"could not provide {local_ref}",
                 file=sys.stderr,
             )
             for error in errors:

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -1388,7 +1388,7 @@ prepare_status=0
 python3 "${SESSION_DIR}/source/deploy/online/prepare.py" "${prepare_args[@]}" \
 	|| prepare_status=$?
 if ((prepare_status == 75)); then
-	fail "Container image downloads could not be completed after retrying the preferred registry and trying the fallback; wait briefly, check registry connectivity, and rerun the same command"
+	fail "Container image downloads could not be completed after 5 attempts from the selected registry; check registry connectivity and rerun the same command"
 fi
 if ((prepare_status != 0)); then
 	fail_with_tag_guidance "Community tag ${TAG} is incomplete or unavailable"

--- a/deploy/online/prepare.py
+++ b/deploy/online/prepare.py
@@ -26,10 +26,12 @@ VERSION_PATTERN = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
 DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
 REVISION_PATTERN = re.compile(r"[0-9a-f]{40}")
 PULL_PARALLELISM = 5
+PULL_ATTEMPTS = 5
 _PULL_RETRY_DELAY = os.environ.get("HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS", "15")
 PULL_RETRY_DELAY_SECONDS = (
-    min(int(_PULL_RETRY_DELAY), 300) if _PULL_RETRY_DELAY.isdecimal() else 15
+    min(int(_PULL_RETRY_DELAY), 60) if _PULL_RETRY_DELAY.isdecimal() else 15
 )
+PULL_RETRY_MAX_DELAY_SECONDS = 60
 GLOBAL_PREFIX = os.environ.get(
     "HFL_GLOBAL_REGISTRY_PREFIX", "docker.io/oneprolabs"
 ).rstrip("/")
@@ -589,64 +591,53 @@ def registry_failure_is_transient(output: str) -> bool:
     return bool(TRANSIENT_REGISTRY_ERROR.search(output))
 
 
-def wait_before_registry_retry() -> None:
-    """Pause before one same-registry retry."""
-    time.sleep(PULL_RETRY_DELAY_SECONDS)
+def registry_retry_delay(completed_attempt: int) -> int:
+    """Return the capped delay before the next same-registry attempt."""
+    return min(
+        PULL_RETRY_DELAY_SECONDS * (2 ** (completed_attempt - 1)),
+        PULL_RETRY_MAX_DELAY_SECONDS,
+    )
+
+
+def registry_display_name(region: str) -> str:
+    """Return the user-facing name of one configured registry region."""
+    return "Alibaba Cloud" if region == "cn" else "Docker Hub"
 
 
 def pull_images(
     specs: list[ImageSpec],
-    preferred_region: str,
+    selected_region: str,
     *,
     concise_output: bool = False,
 ) -> list[ResolvedImage]:
-    """Pull all images concurrently with a selective regional fallback."""
-    fallback_region = "global" if preferred_region == "cn" else "cn"
-    primary = pull_image_batch(specs, preferred_region, concise_output=concise_output)
-    pull_outputs = [primary.stdout or ""]
-    resolved, unresolved = inspect_pulled_images(specs, preferred_region)
-
-    if unresolved and registry_failure_is_transient(primary.stdout or ""):
+    """Pull all images concurrently from the selected registry region."""
+    registry_name = registry_display_name(selected_region)
+    pull_outputs: list[str] = []
+    resolved: dict[str, ResolvedImage] = {}
+    unresolved = specs
+    for attempt in range(1, PULL_ATTEMPTS + 1):
+        pull = pull_image_batch(
+            unresolved, selected_region, concise_output=concise_output
+        )
+        output = pull.stdout or ""
+        pull_outputs.append(output)
+        attempt_resolved, unresolved = inspect_pulled_images(
+            unresolved, selected_region
+        )
+        resolved.update(attempt_resolved)
+        if not unresolved:
+            break
+        if attempt >= PULL_ATTEMPTS or not registry_failure_is_transient(output):
+            break
+        delay = registry_retry_delay(attempt)
         prefix = "  " if concise_output else ""
         print(
-            f"{prefix}[WARN] Temporary container registry error; "
-            f"retrying {len(unresolved)} image(s) from the preferred registry "
-            f"in {PULL_RETRY_DELAY_SECONDS} seconds",
+            f"{prefix}[WARN] Temporary {registry_name} image download error; "
+            f"retrying {len(unresolved)} image(s) in {delay} seconds "
+            f"({attempt + 1}/{PULL_ATTEMPTS})",
             flush=True,
         )
-        wait_before_registry_retry()
-        retry = pull_image_batch(
-            unresolved, preferred_region, concise_output=concise_output
-        )
-        pull_outputs.append(retry.stdout or "")
-        retry_resolved, unresolved = inspect_pulled_images(
-            unresolved, preferred_region
-        )
-        resolved.update(retry_resolved)
-
-    if unresolved:
-        prefix = "  " if concise_output else ""
-        print(
-            f"{prefix}[WARN] {len(unresolved)} installation image(s) were not "
-            "available from the preferred registry",
-            flush=True,
-        )
-
-    if unresolved:
-        prefix = "  " if concise_output else ""
-        print(
-            f"{prefix}[....] Retrying {len(unresolved)} installation image(s) "
-            "from the fallback registry",
-            flush=True,
-        )
-        fallback = pull_image_batch(
-            unresolved, fallback_region, concise_output=concise_output
-        )
-        pull_outputs.append(fallback.stdout or "")
-        fallback_resolved, unresolved = inspect_pulled_images(
-            unresolved, fallback_region
-        )
-        resolved.update(fallback_resolved)
+        time.sleep(delay)
 
     if unresolved:
         details = (
@@ -660,12 +651,12 @@ def pull_images(
         )
         if details:
             details = f"; Docker output: {details[-1000:]}"
-        failures = "; ".join(
-            f"{spec.source_ref(preferred_region)} or {spec.source_ref(fallback_region)}"
-            for spec in unresolved
+        failures = "; ".join(spec.source_ref(selected_region) for spec in unresolved)
+        message = (
+            f"the selected {registry_name} registry could not provide: "
+            f"{failures}{details}"
         )
-        message = f"neither public registry could provide: {failures}{details}"
-        if any(registry_failure_is_transient(output) for output in pull_outputs):
+        if registry_failure_is_transient(pull_outputs[-1]):
             raise RegistryNetworkError(message)
         raise RuntimeError(message)
 

--- a/tools/quality/test-online-community-install.sh
+++ b/tools/quality/test-online-community-install.sh
@@ -10,6 +10,19 @@ export PYTHONDONTWRITEBYTECODE=1
 
 bash -n "${online}/install.sh"
 PYTHONPYCACHEPREFIX="${tmp}/pycache" python3 -m py_compile "${online}/prepare.py"
+HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS=15 python3 - "${online}/prepare.py" <<'PY'
+import runpy
+import sys
+
+module = runpy.run_path(sys.argv[1], run_name="hfl_prepare_retry_test")
+assert [module["registry_retry_delay"](attempt) for attempt in range(1, 5)] == [
+    15,
+    30,
+    60,
+    60,
+]
+assert module["PULL_ATTEMPTS"] == 5
+PY
 
 help_output="$("${online}/install.sh" --help)"
 grep -Fq -- '--mirror cn|global' <<<"${help_output}"
@@ -29,7 +42,7 @@ grep -Fq 'gitee.com/api/v5/repos/oneprolabs/hyperfilelens/tags?per_page=100&page
 	"${online}/install.sh"
 grep -Fq 'recent fallback tags:' "${online}/install.sh"
 grep -Fq 'prepare_status == 75' "${online}/install.sh"
-grep -Fq 'Container image downloads could not be completed after retrying the preferred registry and trying the fallback' \
+grep -Fq 'Container image downloads could not be completed after 5 attempts from the selected registry' \
 	"${online}/install.sh"
 grep -Fq 'prepared Community image revision does not match the published release' \
 	"${online}/install.sh"
@@ -480,7 +493,7 @@ case "${1:-} ${2:-}" in
 	if [[ -n "${HFL_TEST_DOCKER_PRIMARY_FAIL_COMPONENT:-}" ]] \
 		&& grep -Fq "docker.io/oneprolabs/${HFL_TEST_DOCKER_PRIMARY_FAIL_COMPONENT}:" \
 			"${compose_file}"; then
-		printf 'preferred registry rejected test image: access denied\n' >&2
+		printf 'selected registry rejected test image: access denied\n' >&2
 		exit 23
 	fi
 	exit 0
@@ -1810,9 +1823,8 @@ grep -Fx 'Release package' "${upgrade_prepare_log}" >/dev/null
 grep -F '[ OK ] Community release package prepared ·' \
 	"${upgrade_prepare_log}" >/dev/null
 
-fallback_candidate="${tmp}/fallback-candidate"
-fallback_prepare_log="${tmp}/prepare-fallback.log"
-PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
+selected_failure_log="${tmp}/prepare-selected-failure.log"
+if PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 	HFL_ONLINE_NATIVE_PROGRESS=1 \
 	HFL_TEST_DOCKER_PRIMARY_FAIL_COMPONENT=hyperfilelens-backend \
 	python3 "${online}/prepare.py" \
@@ -1820,13 +1832,17 @@ PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 		--version v1.2.3 \
 		--region global \
 		--concise-output \
-		--output "${fallback_candidate}" >"${fallback_prepare_log}" 2>&1
-grep -F '[WARN] 1 installation image(s) were not available from the preferred registry' \
-	"${fallback_prepare_log}" >/dev/null
-grep -F '[....] Retrying 1 installation image(s) from the fallback registry' \
-	"${fallback_prepare_log}" >/dev/null
-grep -F 'Docker Compose native pull progress: parallel=5 images=1' \
-	"${fallback_prepare_log}" >/dev/null
+		--output "${tmp}/selected-failure-candidate" \
+		>"${selected_failure_log}" 2>&1; then
+	printf 'ERROR: selected-registry rejection used another registry\n' >&2
+	exit 1
+fi
+grep -F 'selected registry rejected test image: access denied' \
+	"${selected_failure_log}" >/dev/null
+if grep -Fq 'registry.cn-beijing.aliyuncs.com' "${selected_failure_log}"; then
+	printf 'ERROR: Global preparation contacted the CN registry\n' >&2
+	exit 1
+fi
 
 retry_marker="${tmp}/preferred-registry-retries"
 retry_candidate="${tmp}/retry-candidate"
@@ -1843,31 +1859,35 @@ PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 		--concise-output \
 		--output "${retry_candidate}" >"${retry_prepare_log}" 2>&1
 [[ "$(cat "${retry_marker}")" -eq 2 ]]
-grep -F 'retrying 1 image(s) from the preferred registry in 0 seconds' \
+grep -F 'Temporary Docker Hub image download error; retrying 1 image(s) in 0 seconds (2/5)' \
 	"${retry_prepare_log}" >/dev/null
-if grep -Fq 'from the fallback registry' "${retry_prepare_log}"; then
-	printf 'ERROR: successful preferred-registry retry used the fallback registry\n' >&2
+if grep -Fq 'registry.cn-beijing.aliyuncs.com' "${retry_prepare_log}"; then
+	printf 'ERROR: successful Docker Hub retry contacted the CN registry\n' >&2
 	exit 1
 fi
 
-retry_fallback_marker="${tmp}/preferred-registry-fallback-retries"
-retry_fallback_candidate="${tmp}/retry-fallback-candidate"
-retry_fallback_log="${tmp}/prepare-retry-fallback.log"
+five_attempt_marker="${tmp}/selected-registry-five-attempts"
+five_attempt_candidate="${tmp}/five-attempt-candidate"
+five_attempt_log="${tmp}/prepare-five-attempt.log"
 PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 	HFL_ONLINE_NATIVE_PROGRESS=1 \
 	HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS=0 \
 	HFL_TEST_DOCKER_TRANSIENT_FAIL_COMPONENT=hyperfilelens-backend \
-	HFL_TEST_DOCKER_TRANSIENT_FAILURES=2 \
-	HFL_TEST_DOCKER_PULL_MARKER="${retry_fallback_marker}" \
+	HFL_TEST_DOCKER_TRANSIENT_FAILURES=4 \
+	HFL_TEST_DOCKER_PULL_MARKER="${five_attempt_marker}" \
 	python3 "${online}/prepare.py" \
 		--source-root "${ROOT}" \
 		--version v1.2.3 \
 		--region global \
 		--concise-output \
-		--output "${retry_fallback_candidate}" >"${retry_fallback_log}" 2>&1
-[[ "$(cat "${retry_fallback_marker}")" -eq 2 ]]
-grep -F 'Retrying 1 installation image(s) from the fallback registry' \
-	"${retry_fallback_log}" >/dev/null
+		--output "${five_attempt_candidate}" >"${five_attempt_log}" 2>&1
+[[ "$(cat "${five_attempt_marker}")" -eq 5 ]]
+grep -F 'Temporary Docker Hub image download error; retrying 1 image(s) in 0 seconds (5/5)' \
+	"${five_attempt_log}" >/dev/null
+if grep -Fq 'registry.cn-beijing.aliyuncs.com' "${five_attempt_log}"; then
+	printf 'ERROR: five-attempt Docker Hub retry contacted the CN registry\n' >&2
+	exit 1
+fi
 
 failed_prepare_log="${tmp}/prepare-failed.log"
 if PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
@@ -1884,8 +1904,10 @@ if PATH="${fake_bin}:${PATH}" HFL_TEST_VERSION=1.2.3 \
 fi
 grep -Fq 'registry rejected test image: access denied' "${failed_prepare_log}"
 grep -Fq 'docker.io/oneprolabs/hyperfilelens-backend:1.2.3' "${failed_prepare_log}"
-grep -Fq 'registry.cn-beijing.aliyuncs.com/oneprolabs/hyperfilelens-backend:1.2.3' \
-	"${failed_prepare_log}"
+if grep -Fq 'registry.cn-beijing.aliyuncs.com' "${failed_prepare_log}"; then
+	printf 'ERROR: failed Global preparation contacted the CN registry\n' >&2
+	exit 1
+fi
 
 network_prepare_log="${tmp}/prepare-network-failed.log"
 set +e
@@ -1904,6 +1926,12 @@ network_prepare_status=$?
 set -e
 [[ "${network_prepare_status}" -eq 75 ]]
 grep -Fq '[ERROR] Temporary container registry failure:' "${network_prepare_log}"
+grep -Fq 'the selected Docker Hub registry could not provide:' \
+	"${network_prepare_log}"
+if grep -Fq 'registry.cn-beijing.aliyuncs.com' "${network_prepare_log}"; then
+	printf 'ERROR: failed Docker Hub retries contacted the CN registry\n' >&2
+	exit 1
+fi
 if grep -Eq 'incomplete or unavailable|recommended retry:' \
 	"${network_prepare_log}"; then
 	printf 'ERROR: registry network failure was reported as a release-tag failure\n' >&2

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -35,14 +35,58 @@ grep -Fq 'HFL_REGISTRY_REGION: ${{ vars.PROD_REGISTRY_REGION }}' \
 	"${ROOT}/.github/workflows/enterprise_saas_upgrade.yml"
 grep -Fq -- '--registry-region "$HFL_REGISTRY_REGION"' \
 	"${ROOT}/.github/actions/deploy-saas/action.yml"
-grep -Fq 'registry_login_count > 0' \
+grep -Fq 'read_credential "${registry_region}_host"' \
 	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
-grep -Fq 'pull_registry_image "${immutable_ref}" "${attempts}"' \
+grep -Fq 'registry_pull_attempts=5' \
+	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
+grep -Fq 'pull_registry_image "${immutable_ref}"' \
 	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
 grep -Fq 'HFL_REGISTRY_PULL_RETRY_DELAY_SECONDS:-15' \
 	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
-grep -Fq 'for prefix in "${registry_region}" "${fallback_region}"' \
-	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
+if grep -Fq 'fallback_region' "${ROOT}/.github/scripts/remote-saas-deploy.sh"; then
+	printf 'ERROR: SaaS deployment still contains a cross-region fallback\n' >&2
+	exit 1
+fi
+retry_delay_function="$(awk '
+	/^registry_retry_delay_for_attempt\(\) \{/ { capture = 1 }
+	capture { print }
+	capture && /^}$/ { exit }
+' "${ROOT}/.github/scripts/remote-saas-deploy.sh")"
+registry_pull_retry_delay=15
+eval "${retry_delay_function}"
+[[ "$(registry_retry_delay_for_attempt 1)" -eq 15 ]]
+[[ "$(registry_retry_delay_for_attempt 2)" -eq 30 ]]
+[[ "$(registry_retry_delay_for_attempt 3)" -eq 60 ]]
+[[ "$(registry_retry_delay_for_attempt 4)" -eq 60 ]]
+for function_name in registry_pull_is_transient pull_registry_image; do
+	function_definition="$(awk -v name="${function_name}" '
+		$0 ~ "^" name "\\(\\) \\{" { capture = 1 }
+		capture { print }
+		capture && /^}$/ { exit }
+	' "${ROOT}/.github/scripts/remote-saas-deploy.sh")"
+	eval "${function_definition}"
+done
+registry_pull_retry_delay=0
+registry_pull_attempts=5
+registry_name="Docker Hub"
+stage_dir="${tmp}/saas-pull-retry"
+saas_pull_marker="${tmp}/saas-pull-attempts"
+mkdir -p "${stage_dir}"
+docker() {
+	local count=0
+	[[ ! -f "${saas_pull_marker}" ]] || count="$(cat "${saas_pull_marker}")"
+	count=$((count + 1))
+	printf '%s\n' "${count}" >"${saas_pull_marker}"
+	if ((count < 5)); then
+		printf 'short read: unexpected EOF\n' >&2
+		return 1
+	fi
+	return 0
+}
+pull_registry_image \
+	"docker.io/example/hyperfilelens-agent-assets@${digest}" >/dev/null 2>&1
+unset -f docker
+[[ "$(cat "${saas_pull_marker}")" -eq 5 ]]
 grep -Fq 'Enterprise SaaS deployment action:' \
 	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
 grep -Fq 'deployment_args+=(--from "${candidate_root}")' \
@@ -433,14 +477,19 @@ fi
 [[ "$(cat "${mirror_marker}")" -eq 1 ]]
 [[ "$(cat "${mirror_inspect_marker}")" -eq 0 ]]
 source "${ROOT}/deploy/installer/install.sh"
-HFL_TEST_FAIL_REGION=cn HFL_REGISTRY_REGION=cn \
-	load_images_from_manifest 0 "${package_root}"
-[[ -f "${tag_marker}" ]]
-[[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
+if HFL_TEST_FAIL_REGION=cn HFL_REGISTRY_REGION=cn \
+	load_images_from_manifest 0 "${package_root}" >/dev/null 2>&1; then
+	printf 'ERROR: CN registry failure used another registry\n' >&2
+	exit 1
+fi
+[[ ! -e "${tag_marker}" ]]
+[[ "$(wc -l <"${pull_marker}")" -eq 1 ]]
 [[ "$(sed -n '1p' "${pull_marker}")" == registry.example.cn/* ]]
-[[ "$(sed -n '2p' "${pull_marker}")" == docker.io/* ]]
+
+: >"${pull_marker}"
 HFL_REGISTRY_REGION=cn load_images_from_manifest 0 "${package_root}"
-[[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
+[[ -f "${tag_marker}" ]]
+[[ "$(wc -l <"${pull_marker}")" -eq 1 ]]
 online_registry_output="$(
 	HFL_ONLINE_CHILD=1 HFL_REGISTRY_REGION=cn \
 		load_images_from_manifest 0 "${package_root}"
@@ -461,12 +510,14 @@ HFL_REGISTRY_REGION=global load_images_from_manifest 0 "${package_root}"
 
 rm -f "${tag_marker}"
 : >"${pull_marker}"
-HFL_TEST_FAIL_REGION=global HFL_REGISTRY_REGION=global \
-	load_images_from_manifest 0 "${package_root}"
-[[ -f "${tag_marker}" ]]
-[[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
+if HFL_TEST_FAIL_REGION=global HFL_REGISTRY_REGION=global \
+	load_images_from_manifest 0 "${package_root}" >/dev/null 2>&1; then
+	printf 'ERROR: Global registry failure used another registry\n' >&2
+	exit 1
+fi
+[[ ! -e "${tag_marker}" ]]
+[[ "$(wc -l <"${pull_marker}")" -eq 1 ]]
 [[ "$(sed -n '1p' "${pull_marker}")" == docker.io/* ]]
-[[ "$(sed -n '2p' "${pull_marker}")" == registry.example.cn/* ]]
 
 transient_marker="${tmp}/transient-pulls"
 rm -f "${tag_marker}" "${transient_marker}"
@@ -489,17 +540,17 @@ HFL_TEST_TRANSIENT_REGION=cn HFL_TEST_TRANSIENT_FAILURES=2 \
 [[ "$(wc -l <"${pull_marker}")" -eq 3 ]]
 [[ "$(sed -n '1p' "${pull_marker}")" == registry.example.cn/* ]]
 [[ "$(sed -n '2p' "${pull_marker}")" == registry.example.cn/* ]]
-[[ "$(sed -n '3p' "${pull_marker}")" == docker.io/* ]]
+[[ "$(sed -n '3p' "${pull_marker}")" == registry.example.cn/* ]]
 
 rm -f "${tag_marker}"
 : >"${pull_marker}"
 if HFL_TEST_FAIL_REGION=both HFL_REGISTRY_REGION=cn \
 	load_images_from_manifest 0 "${package_root}" >/dev/null 2>&1; then
-	printf 'ERROR: registry delivery accepted two unavailable sources\n' >&2
+	printf 'ERROR: registry delivery accepted an unavailable selected source\n' >&2
 	exit 1
 fi
 [[ ! -e "${tag_marker}" ]]
-[[ "$(wc -l <"${pull_marker}")" -eq 2 ]]
+[[ "$(wc -l <"${pull_marker}")" -eq 1 ]]
 
 export DEPLOY_SSH_HOST=test.example.com
 export DEPLOY_SSH_PORT=22


### PR DESCRIPTION
## Summary

- keep Community online installation and Enterprise SaaS deployment on the selected regional registry
- retry transient image download failures up to five times with capped exponential backoff
- preserve immutable digest, platform, and dual-region release contract validation
- report selected-registry network failures without recommending another release tag

## Validation

- `tools/quality/test-online-community-install.sh`
- `tools/quality/test-saas-registry-delivery.sh`
- `tools/quality/test-lifecycle-output-contract.sh`
- `tools/quality/check-release-contracts.sh`
- Bash syntax checks
- Ruff lint and format checks
- `git diff --check`