### PR TITLE
Fix Chinese storage translation

### DIFF
--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -6764,7 +6764,7 @@
       "groupMonitoringDiagnostics": "监控",
       "groupAlertCenter": "告警中心",
       "groupIdentityAccess": "账户管理",
-      "groupStorage": "贮存",
+      "groupStorage": "存储",
       "groupPlatform": "平台",
       "groupAuditCenter": "审核中心",
       "groupEngine": "AI 引擎",


### PR DESCRIPTION
## Summary

- replace the uncommon Chinese storage label “贮存” with “存储” in the administration navigation
- cover an additional occurrence discovered while investigating #1064
- leave the screenshot-specific Proxy Host detail tab correction to #1106

## Testing

- `./language-packs/tooling/build-all.sh --version 0.0.0`
- `git diff --check origin/main...HEAD`

Related to #1064