### PR TITLE
Fix Proxy storage tab translation

### DIFF
--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -2655,7 +2655,7 @@
         "unmounted": "未挂载",
         "error": "挂载错误"
       },
-      "detailTabStorage": "贮存",
+      "detailTabStorage": "存储",
       "colRepositories": "存储仓库",
       "localStorageTitle": "本地存储",
       "localStorageHint": "此 Proxy Host 可用本地文件系统。网络挂载不计入列表容量。",


### PR DESCRIPTION
## Summary

- replace “贮存” with the common Chinese label “存储” in the Proxy Host detail tab shown in #1064
- keep this screenshot-specific correction separate from the additional navigation occurrence fixed by #1104

## Testing

- `./language-packs/tooling/build-all.sh --version 0.0.0`
- `git diff --check origin/main...HEAD`

Closes #1064