### PR TITLE
Fix external access navigation and enrollment link stability

### DIFF
--- a/src/backend/apps/node/api/views/bootstrap.py
+++ b/src/backend/apps/node/api/views/bootstrap.py
@@ -31,6 +31,12 @@ from common.deploy.product import COMMUNITY_EDITION, product_edition
 from common.deploy.site import enrollment_tls_verify, tenant_public_url
 
 
+INVALID_ENROLLMENT_LINK_MESSAGE = (
+    "This enrollment link is invalid, expired, or revoked. "
+    "Return to the console and copy the currently displayed install command."
+)
+
+
 def _api_base_valid(request: Request, api_base: str) -> bool:
     """Return whether enrollment targets a trusted browser-facing origin."""
     try:
@@ -160,7 +166,7 @@ def _parse_enrollment_query(
         ):
             return _bootstrap_error_response(
                 script_type,
-                "invalid or expired enrollment link",
+                INVALID_ENROLLMENT_LINK_MESSAGE,
             )
         return Response({"error": "invalid enrollment token"}, status=401)
 
@@ -290,7 +296,7 @@ def _parse_gateway_bootstrap_query(
     if not token_usable_for_bootstrap(org=org, token=token, role=role):
         return _bootstrap_error_response(
             "linux",
-            "invalid or expired enrollment link",
+            INVALID_ENROLLMENT_LINK_MESSAGE,
         )
 
     return org_key, token, api_base

--- a/src/backend/apps/node/tests/test_bootstrap.py
+++ b/src/backend/apps/node/tests/test_bootstrap.py
@@ -207,7 +207,11 @@ class BootstrapViewTests(TestCase):
         body = response.content.decode("utf-8")
         self.assertTrue(body.startswith("#!/usr/bin/env bash"))
         self.assertIn("[FAIL ]", body)
-        self.assertIn("invalid or expired enrollment link", body)
+        self.assertIn("invalid, expired, or revoked", body)
+        self.assertIn(
+            "copy the currently displayed install command",
+            body,
+        )
 
     def test_missing_token_returns_executable_error_script(self):
         response = self._get("linux", token="")

--- a/src/backend/apps/node/tests/test_bootstrap_gateway.py
+++ b/src/backend/apps/node/tests/test_bootstrap_gateway.py
@@ -79,7 +79,8 @@ class BootstrapGatewayViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         body = response.content.decode("utf-8")
         self.assertIn("[FAIL ]", body)
-        self.assertIn("invalid or expired enrollment link", body)
+        self.assertIn("invalid, expired, or revoked", body)
+        self.assertIn("copy the currently displayed install command", body)
 
     def test_used_gateway_token_still_returns_bootstrap_script(self):
         self.token_row.is_active = False

--- a/src/frontend/src/components/NodeLifecycleCopy.test.ts
+++ b/src/frontend/src/components/NodeLifecycleCopy.test.ts
@@ -70,12 +70,11 @@ describe('Node lifecycle copy', () => {
     expect(locale).toContain('Registers a Private Data Gateway with HyperFileLens')
   })
 
-  it('revokes enrollment tokens discarded by command regeneration', () => {
+  it('revokes only enrollment tokens discarded before their command is displayed', () => {
     const wizard = source('src/components/NodeLifecycleWizard.vue')
 
     expect(wizard).toContain('await revokeIssuedEnrollment(issued.tokenId, platformEnrollment)')
-    expect(wizard).toContain('void revokeIssuedEnrollment(staleTokenId, staleTokenIsPlatform)')
-    expect(wizard).toContain('enrollmentTokenIsPlatform.value')
+    expect(wizard).not.toContain('void revokeIssuedEnrollment(staleTokenId, staleTokenIsPlatform)')
     expect(wizard).toContain('await revokeEnrollmentToken(tokenId).catch(() => undefined)')
     expect(wizard).toContain('fetchNodeMaintenanceRelease')
     expect(wizard).not.toContain('createNodeToken({ role: props.role')

--- a/src/frontend/src/components/NodeLifecycleTokenLifecycle.test.ts
+++ b/src/frontend/src/components/NodeLifecycleTokenLifecycle.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { en } from '../locales/en'
+import NodeLifecycleWizard from './NodeLifecycleWizard.vue'
+
+const mocks = vi.hoisted(() => ({
+  issueEnrollmentInstall: vi.fn(),
+  issueGatewayEnrollmentInstall: vi.fn(),
+  issuePlatformGatewayEnrollmentInstall: vi.fn(),
+  revokeEnrollmentToken: vi.fn(),
+  revokePlatformGatewayEnrollment: vi.fn(),
+  fetchNodeMaintenanceRelease: vi.fn(),
+}))
+
+vi.mock('../lib/nodeApi', () => mocks)
+
+function issued(tokenId: number, command: string) {
+  return {
+    token: `token-${tokenId}`,
+    tokenId,
+    command,
+    tlsVerify: true,
+    expiresAt: '2099-01-01T00:00:00Z',
+  }
+}
+
+function mountWizard() {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en },
+    missingWarn: false,
+    fallbackWarn: false,
+  })
+  return shallowMount(NodeLifecycleWizard, {
+    props: {
+      orgKey: 'tenant-a',
+      role: 'agent',
+      os: 'linux',
+      installOnly: true,
+    },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        ElAlert: true,
+        ElCheckbox: true,
+        ElRadio: true,
+        ElRadioGroup: true,
+      },
+      directives: {
+        loading: () => undefined,
+      },
+    },
+  })
+}
+
+describe('Node lifecycle enrollment token ownership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.revokeEnrollmentToken.mockResolvedValue(undefined)
+    mocks.revokePlatformGatewayEnrollment.mockResolvedValue(undefined)
+  })
+
+  it('keeps an already displayed install command valid when the selected OS changes', async () => {
+    mocks.issueEnrollmentInstall
+      .mockResolvedValueOnce(issued(1, 'install-linux'))
+      .mockResolvedValueOnce(issued(2, 'install-windows'))
+
+    const wrapper = mountWizard()
+    await flushPromises()
+    expect(wrapper.get('.agent-install-wizard__console-pre').text()).toBe('install-linux')
+
+    await wrapper.setProps({ os: 'windows' })
+    await flushPromises()
+
+    expect(wrapper.get('.agent-install-wizard__console-pre').text()).toBe('install-windows')
+    expect(mocks.revokeEnrollmentToken).not.toHaveBeenCalled()
+  })
+
+  it('revokes a token returned by an obsolete request before its command is displayed', async () => {
+    let resolveFirst: ((value: ReturnType<typeof issued>) => void) | undefined
+    const firstRequest = new Promise<ReturnType<typeof issued>>((resolve) => {
+      resolveFirst = resolve
+    })
+    mocks.issueEnrollmentInstall
+      .mockReturnValueOnce(firstRequest)
+      .mockResolvedValueOnce(issued(2, 'install-windows'))
+
+    const wrapper = mountWizard()
+    await wrapper.setProps({ os: 'windows' })
+    await flushPromises()
+    expect(wrapper.get('.agent-install-wizard__console-pre').text()).toBe('install-windows')
+
+    resolveFirst?.(issued(1, 'install-linux'))
+    await flushPromises()
+
+    expect(mocks.revokeEnrollmentToken).toHaveBeenCalledTimes(1)
+    expect(mocks.revokeEnrollmentToken).toHaveBeenCalledWith(1)
+    expect(wrapper.get('.agent-install-wizard__console-pre').text()).toBe('install-windows')
+  })
+
+  it('revokes a pending token that returns after the install page is closed', async () => {
+    let resolveRequest: ((value: ReturnType<typeof issued>) => void) | undefined
+    const request = new Promise<ReturnType<typeof issued>>((resolve) => {
+      resolveRequest = resolve
+    })
+    mocks.issueEnrollmentInstall.mockReturnValueOnce(request)
+
+    const wrapper = mountWizard()
+    wrapper.unmount()
+    resolveRequest?.(issued(3, 'install-after-close'))
+    await flushPromises()
+
+    expect(mocks.revokeEnrollmentToken).toHaveBeenCalledTimes(1)
+    expect(mocks.revokeEnrollmentToken).toHaveBeenCalledWith(3)
+  })
+})

--- a/src/frontend/src/components/NodeLifecycleWizard.vue
+++ b/src/frontend/src/components/NodeLifecycleWizard.vue
@@ -103,8 +103,6 @@ const effectiveInstallationMode = computed<NodeInstallationMode>(() => (
     : 'system'
 ))
 const supportOpen = ref(false)
-const enrollmentTokenId = ref<number | null>(null)
-const enrollmentTokenIsPlatform = ref(false)
 const enrollmentExpiresAt = ref<string | null>(null)
 const tokenClock = ref(Date.now())
 let tokenStatusTimer: ReturnType<typeof setInterval> | null = null
@@ -373,8 +371,6 @@ async function refreshInstallCommand(gen: number) {
     }
     installCommand.value = issued.command
     installGenerated.value = true
-    enrollmentTokenId.value = issued.tokenId
-    enrollmentTokenIsPlatform.value = platformEnrollment
     enrollmentExpiresAt.value = issued.expiresAt
     emit('enrollmentIssued', {
       tokenId: issued.tokenId,
@@ -480,12 +476,7 @@ watch(
     if (isLinuxOnlyRole(props.role) && props.os !== 'linux') {
       emit('update:os', 'linux')
     }
-    const staleTokenId = enrollmentTokenId.value
-    const staleTokenIsPlatform = enrollmentTokenIsPlatform.value
     clearInstallCommand()
-    if (staleTokenId) {
-      void revokeIssuedEnrollment(staleTokenId, staleTokenIsPlatform)
-    }
     refreshAll()
   },
   { immediate: true },
@@ -549,8 +540,6 @@ function clearInstallCommand() {
   installGenerated.value = false
   installCommand.value = ''
   copied.value = false
-  enrollmentTokenId.value = null
-  enrollmentTokenIsPlatform.value = false
   enrollmentExpiresAt.value = null
 }
 
@@ -561,6 +550,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  generation += 1
   if (tokenStatusTimer) clearInterval(tokenStatusTimer)
 })
 

--- a/src/frontend/src/composables/useDeployProfile.test.ts
+++ b/src/frontend/src/composables/useDeployProfile.test.ts
@@ -40,6 +40,10 @@ describe('deploy profile caching', () => {
     const first = fetchDeployProfile(true)
     const second = fetchDeployProfile(true)
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/meta/deploy-profile',
+      { credentials: 'include', cache: 'no-store' },
+    )
 
     resolveResponse?.(new Response(JSON.stringify(deployProfile), { status: 200 }))
     await expect(Promise.all([first, second])).resolves.toEqual([deployProfile, deployProfile])
@@ -55,6 +59,57 @@ describe('deploy profile caching', () => {
     await fetchDeployProfile(false)
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts a new request after cache invalidation while an older request is in flight', async () => {
+    let resolveFirst: ((value: Response) => void) | undefined
+    const firstResponse = new Promise<Response>((resolve) => {
+      resolveFirst = resolve
+    })
+    const updatedProfile = {
+      ...deployProfile,
+      tenant_public_url: 'https://public.example.test:11443',
+    }
+    const fetchMock = vi.fn()
+      .mockReturnValueOnce(firstResponse)
+      .mockResolvedValueOnce(new Response(JSON.stringify(updatedProfile), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const first = fetchDeployProfile(true)
+    clearDeployProfileCache()
+    const refreshed = fetchDeployProfile(true)
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    await expect(refreshed).resolves.toEqual(updatedProfile)
+
+    resolveFirst?.(new Response(JSON.stringify(deployProfile), { status: 200 }))
+    await expect(first).resolves.toEqual(deployProfile)
+    await expect(fetchDeployProfile()).resolves.toEqual(updatedProfile)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let a stale response restore a cache that was invalidated', async () => {
+    let resolveResponse: ((value: Response) => void) | undefined
+    const response = new Promise<Response>((resolve) => {
+      resolveResponse = resolve
+    })
+    const updatedProfile = {
+      ...deployProfile,
+      tenant_public_url: 'https://latest.example.test:11443',
+    }
+    const fetchMock = vi.fn()
+      .mockReturnValueOnce(response)
+      .mockResolvedValueOnce(new Response(JSON.stringify(updatedProfile), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const staleRequest = fetchDeployProfile(true)
+    clearDeployProfileCache()
+    resolveResponse?.(new Response(JSON.stringify(deployProfile), { status: 200 }))
+    await staleRequest
+
+    const freshRequest = fetchDeployProfile()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    await expect(freshRequest).resolves.toEqual(updatedProfile)
   })
 
   it('lands operations staff on the Admin Overview after login', async () => {

--- a/src/frontend/src/composables/useDeployProfile.ts
+++ b/src/frontend/src/composables/useDeployProfile.ts
@@ -31,7 +31,13 @@ export interface DeployProfile {
 export const PLATFORM_OPS_LANDING_PATH = '/platform-ops/engine/ai-settings'
 
 let cachedProfile: DeployProfile | null = null
-let inflight: Promise<DeployProfile | null> | null = null
+let cacheRevision = 0
+let requestSequence = 0
+let inflight: {
+  id: number
+  revision: number
+  promise: Promise<DeployProfile | null>
+} | null = null
 
 function parseDeployProfilePayload(raw: unknown): DeployProfile | null {
   if (!raw || typeof raw !== 'object') return null
@@ -48,23 +54,29 @@ function parseDeployProfilePayload(raw: unknown): DeployProfile | null {
 
 export async function fetchDeployProfile(force = false): Promise<DeployProfile | null> {
   if (!force && cachedProfile) return cachedProfile
-  if (inflight) return inflight
+  const revision = cacheRevision
+  if (inflight?.revision === revision) return inflight.promise
 
-  inflight = (async () => {
+  const requestId = ++requestSequence
+  const request = (async () => {
     try {
-      const res = await fetch('/api/v1/meta/deploy-profile', { credentials: 'include' })
+      const res = await fetch('/api/v1/meta/deploy-profile', {
+        credentials: 'include',
+        ...(force ? { cache: 'no-store' as const } : {}),
+      })
       if (!res.ok) return null
       const payload = parseDeployProfilePayload(await res.json())
-      cachedProfile = payload
+      if (revision === cacheRevision) cachedProfile = payload
       return payload
     } catch {
       return null
     } finally {
-      inflight = null
+      if (inflight?.id === requestId) inflight = null
     }
   })()
+  inflight = { id: requestId, revision, promise: request }
 
-  return inflight
+  return request
 }
 
 export function getCachedDeployProfile(): DeployProfile | null {
@@ -73,6 +85,7 @@ export function getCachedDeployProfile(): DeployProfile | null {
 
 export function clearDeployProfileCache(): void {
   cachedProfile = null
+  cacheRevision += 1
 }
 
 export function shouldForceDeployProfileRefresh(

--- a/src/frontend/src/platform-ops/layout/PlatformOpsShell.vue
+++ b/src/frontend/src/platform-ops/layout/PlatformOpsShell.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, watch, nextTick } from 'vue'
+import { computed, ref, watch, nextTick } from 'vue'
 import { useRoute, RouterView } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { ArrowLeft, Menu } from 'lucide-vue-next'
+import { ElMessage } from 'element-plus'
+import { ArrowLeft, LoaderCircle, Menu } from 'lucide-vue-next'
 import NavUserMenu from '../../components/NavUserMenu.vue'
 import Sidebar from '../../components/Sidebar.vue'
 import { useTheme } from '../../composables/useTheme'
@@ -10,6 +11,7 @@ import { fetchDeployProfile } from '../../composables/useDeployProfile'
 import { applyThemeVars } from '../composables/applyThemeVars'
 import { useResolvedPlatformOpsSideNav } from '../composables/useResolvedPlatformOpsSideNav'
 import { platformOpsRouteViewKey } from '../lib/platformOpsRouteViewKey'
+import { openTenantApplication } from '../lib/tenantApplicationNavigation'
 import MobileNavigationDrawer from '../../components/MobileNavigationDrawer.vue'
 import '../styles/platform-ops-ui.css'
 import '../styles/monitoring.css'
@@ -19,7 +21,7 @@ const { t } = useI18n()
 const route = useRoute()
 const { theme } = useTheme()
 
-const tenantUrl = ref('')
+const returningToTenant = ref(false)
 const themeVersion = ref(0)
 const fallbackSidebarCollapsed = ref(localStorage.getItem('sidebar-collapsed') === 'true')
 const fallbackMenuItems = useResolvedPlatformOpsSideNav()
@@ -35,17 +37,6 @@ const routeSkeletonShowsCards = computed(
     || route.path === '/platform-ops/orgs',
 )
 
-onMounted(async () => {
-  const profile = await fetchDeployProfile()
-  if (profile?.tenant_public_url) {
-    try {
-      tenantUrl.value = new URL(profile.tenant_public_url).toString()
-    } catch {
-      tenantUrl.value = ''
-    }
-  }
-})
-
 watch(
   theme,
   async (mode) => {
@@ -57,9 +48,26 @@ watch(
   { immediate: true },
 )
 
-function goTenantConsole() {
-  if (!tenantUrl.value) return
-  window.location.assign(tenantUrl.value)
+function showTenantNavigationError() {
+  ElMessage.error({
+    message: `${t('platformOps.settings.loadFailed')}: ${t('platformOps.settings.externalAccess.urlLabel')}`,
+    grouping: true,
+  })
+}
+
+async function goTenantConsole() {
+  if (returningToTenant.value) return
+  returningToTenant.value = true
+  try {
+    const navigated = await openTenantApplication(() => fetchDeployProfile(true))
+    if (!navigated) {
+      showTenantNavigationError()
+    }
+  } catch {
+    showTenantNavigationError()
+  } finally {
+    returningToTenant.value = false
+  }
 }
 
 function toggleFallbackSidebar() {
@@ -109,10 +117,18 @@ watch(
           type="button"
           class="platform-ops-return"
           :aria-label="t('platformOps.nav.backToConsole')"
-          :disabled="!tenantUrl"
+          :aria-busy="returningToTenant"
+          :disabled="returningToTenant"
           @click="goTenantConsole"
         >
+          <LoaderCircle
+            v-if="returningToTenant"
+            class="platform-ops-return__spinner"
+            :size="16"
+            aria-hidden="true"
+          />
           <ArrowLeft
+            v-else
             :size="16"
             aria-hidden="true"
           />
@@ -299,9 +315,24 @@ watch(
   white-space: nowrap;
 }
 
-.platform-ops-return:hover {
+.platform-ops-return:not(:disabled):hover {
   border-color: var(--color-primary, #6d5ef6);
   color: var(--nav-item-hover-color, #fff);
+}
+
+.platform-ops-return:disabled {
+  cursor: wait;
+  opacity: 0.62;
+}
+
+.platform-ops-return__spinner {
+  animation: platform-ops-return-spin 0.8s linear infinite;
+}
+
+@keyframes platform-ops-return-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .platform-ops-main {

--- a/src/frontend/src/platform-ops/lib/tenantApplicationNavigation.test.ts
+++ b/src/frontend/src/platform-ops/lib/tenantApplicationNavigation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { DeployProfile } from '../../composables/useDeployProfile'
+import shellSource from '../layout/PlatformOpsShell.vue?raw'
+import { openTenantApplication, tenantApplicationUrl } from './tenantApplicationNavigation'
+
+function profile(tenantPublicUrl: string): DeployProfile {
+  return {
+    site_role: 'ops',
+    email_signup_enabled: false,
+    email_code_login_available: false,
+    platform_ops_enabled: true,
+    password_reset_available: true,
+    tenant_public_url: tenantPublicUrl,
+    admin_console_url: 'https://admin.example.test:11444',
+    landing_path: '/platform-ops/overview',
+    admin_console_landing_path: '/platform-ops/overview',
+    admin_console_entry_visible: false,
+    platform_ops_access_allowed: true,
+  }
+}
+
+describe('Admin Console tenant application navigation', () => {
+  it('forces a live profile refresh when Back to Application is clicked', () => {
+    expect(shellSource).toContain('openTenantApplication(() => fetchDeployProfile(true))')
+    expect(shellSource).not.toContain("onMounted(async () => {\n  const profile = await fetchDeployProfile()")
+  })
+
+  it('navigates with the URL returned by the latest profile request', async () => {
+    const loadProfile = vi.fn().mockResolvedValue(profile('https://public.example.test:11443'))
+    const navigate = vi.fn()
+
+    await expect(openTenantApplication(loadProfile, navigate)).resolves.toBe(true)
+
+    expect(loadProfile).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith('https://public.example.test:11443/')
+  })
+
+  it('does not navigate when the refreshed profile is unavailable', async () => {
+    const navigate = vi.fn()
+
+    await expect(openTenantApplication(async () => null, navigate)).resolves.toBe(false)
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid and non-HTTP application URLs', () => {
+    expect(tenantApplicationUrl(profile('not-a-url'))).toBe('')
+    expect(tenantApplicationUrl(profile('javascript:alert(1)'))).toBe('')
+  })
+})

--- a/src/frontend/src/platform-ops/lib/tenantApplicationNavigation.ts
+++ b/src/frontend/src/platform-ops/lib/tenantApplicationNavigation.ts
@@ -1,0 +1,22 @@
+import type { DeployProfile } from '../../composables/useDeployProfile'
+
+export function tenantApplicationUrl(profile: DeployProfile | null): string {
+  const value = profile?.tenant_public_url
+  if (!value) return ''
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : ''
+  } catch {
+    return ''
+  }
+}
+
+export async function openTenantApplication(
+  loadProfile: () => Promise<DeployProfile | null>,
+  navigate: (url: string) => void = (url) => window.location.assign(url),
+): Promise<boolean> {
+  const url = tenantApplicationUrl(await loadProfile())
+  if (!url) return false
+  navigate(url)
+  return true
+}


### PR DESCRIPTION
## Summary

- refresh the deployment profile before returning from the Admin Console so the latest external access URL is used immediately
- prevent stale deployment profile requests from overwriting an invalidated cache
- keep displayed enrollment commands valid across wizard selection changes while revoking tokens from obsolete undisplayed requests
- provide clearer recovery guidance for invalid, expired, or revoked enrollment links

## Validation

- frontend production build
- frontend ESLint and Vue type checking
- focused frontend tests: 24 passed
- full frontend suite: 1,544 passed; three unrelated timeout cases passed when rerun independently
- backend Ruff checks
- focused backend bootstrap tests: 19 passed before final main alignment
- git diff --check