### PR TITLE
Tolerate transient Gateway WebSocket failures during SaaS deployment

### DIFF
--- a/.github/actions/deploy-saas/action.yml
+++ b/.github/actions/deploy-saas/action.yml
@@ -177,7 +177,7 @@ runs:
              curl -kfsS https://127.0.0.1:11443/health/ready >/dev/null &&
              curl -kfsS https://127.0.0.1:11444/ >/dev/null &&
              curl -kfsS https://127.0.0.1:11445/ >/dev/null'
-    - name: Reconcile Platform Gateway
+    - name: Verify Platform Gateway
       if: ${{ env.HFL_PLATFORM_GATEWAY_AUTO_DEPLOY == 'true' }}
       shell: bash
       run: |
@@ -186,8 +186,7 @@ runs:
             -o ConnectTimeout=20 -o ServerAliveInterval=30 -o ServerAliveCountMax=20 \
             -o TCPKeepAlive=yes -p "$DEPLOY_SSH_PORT" \
             "$DEPLOY_SSH_USER@$DEPLOY_SSH_HOST" \
-            '/opt/hyperfilelens/install.sh platform-gateway ensure &&
-             /opt/hyperfilelens/install.sh platform-gateway verify --required --timeout 180'
+            '/opt/hyperfilelens/install.sh platform-gateway verify --required --timeout 180'
     - name: Reconcile default AI model
       shell: bash
       run: .github/scripts/reconcile-saas-ai-model.sh agent

--- a/src/agent/internal/enroll/preflight_network.go
+++ b/src/agent/internal/enroll/preflight_network.go
@@ -2,7 +2,9 @@ package enroll
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -89,6 +91,20 @@ func checkConsoleReachable(ctx context.Context, apiBase string) reachResult {
 }
 
 func checkWSSReachable(ctx context.Context, wssURL string) reachResult {
+	return checkWSSReachableWithRetry(
+		ctx,
+		wssURL,
+		30*time.Second,
+		[]time.Duration{2 * time.Second, 4 * time.Second, 8 * time.Second, 8 * time.Second},
+	)
+}
+
+func checkWSSReachableWithRetry(
+	ctx context.Context,
+	wssURL string,
+	retryWindow time.Duration,
+	retryDelays []time.Duration,
+) reachResult {
 	wssURL = strings.TrimSpace(wssURL)
 	if wssURL == "" {
 		return reachResult{
@@ -106,9 +122,6 @@ func checkWSSReachable(ctx context.Context, wssURL string) reachResult {
 	}
 
 	endpoint := parsed.Scheme + "://" + parsed.Host
-	dialCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
-	defer cancel()
-
 	if parsed.Scheme != "ws" && parsed.Scheme != "wss" {
 		return reachResult{
 			Title:  "Control-plane WebSocket scheme is unsupported",
@@ -116,12 +129,38 @@ func checkWSSReachable(ctx context.Context, wssURL string) reachResult {
 		}
 	}
 
+	retryCtx, cancel := context.WithTimeout(ctx, retryWindow)
+	defer cancel()
+	for attempt := 0; ; attempt++ {
+		result, retry := checkWSSReachableOnce(retryCtx, parsed, endpoint)
+		if result.OK || !retry || attempt >= len(retryDelays) || retryCtx.Err() != nil {
+			return result
+		}
+
+		delay := retryDelays[attempt]
+		timer := time.NewTimer(delay)
+		select {
+		case <-retryCtx.Done():
+			timer.Stop()
+			return result
+		case <-timer.C:
+		}
+	}
+}
+
+func checkWSSReachableOnce(
+	ctx context.Context,
+	parsed *url.URL,
+	endpoint string,
+) (reachResult, bool) {
+	dialCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
 	dialer := websocket.Dialer{
 		HandshakeTimeout: 8 * time.Second,
 		Proxy:            http.ProxyFromEnvironment,
 		TLSClientConfig:  tlsclient.Config(),
 	}
-	conn, response, err := dialer.DialContext(dialCtx, wssURL, nil)
+	conn, response, err := dialer.DialContext(dialCtx, parsed.String(), nil)
 	if response != nil && response.Body != nil {
 		_ = response.Body.Close()
 	}
@@ -133,7 +172,7 @@ func checkWSSReachable(ctx context.Context, wssURL string) reachResult {
 			OK:     true,
 			Title:  "Control plane WebSocket endpoint reachable",
 			Detail: endpoint + " accepted the WebSocket handshake",
-		}
+		}, false
 	}
 	if response != nil &&
 		(response.StatusCode == http.StatusBadRequest ||
@@ -147,7 +186,7 @@ func checkWSSReachable(ctx context.Context, wssURL string) reachResult {
 				endpoint,
 				response.StatusCode,
 			),
-		}
+		}, false
 	}
 	detail := fmt.Sprintf("%s - %s", endpoint, shortenErr(err))
 	if response != nil {
@@ -156,7 +195,28 @@ func checkWSSReachable(ctx context.Context, wssURL string) reachResult {
 	return reachResult{
 		Title:  "WebSocket endpoint unreachable",
 		Detail: detail,
+	}, transientWSSFailure(response, err)
+}
+
+func transientWSSFailure(response *http.Response, err error) bool {
+	if response != nil {
+		switch response.StatusCode {
+		case http.StatusBadGateway,
+			http.StatusServiceUnavailable,
+			http.StatusGatewayTimeout:
+			return true
+		default:
+			return false
+		}
 	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return dnsErr.IsTimeout || dnsErr.IsTemporary
+	}
+	var networkErr net.Error
+	return errors.As(err, &networkErr) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF)
 }
 
 func websocketDialAddress(parsed *url.URL) string {

--- a/src/agent/internal/enroll/preflight_network_test.go
+++ b/src/agent/internal/enroll/preflight_network_test.go
@@ -2,11 +2,15 @@ package enroll
 
 import (
 	"context"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestWebsocketDialAddressUsesDefaultPorts(t *testing.T) {
@@ -51,7 +55,11 @@ func TestCheckWSSReachableAcceptsAuthenticationRejection(t *testing.T) {
 
 func TestCheckWSSReachableRejectsMissingRoute(t *testing.T) {
 	t.Parallel()
-	server := httptest.NewServer(http.NotFoundHandler())
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		http.NotFoundHandler().ServeHTTP(writer, request)
+	}))
 	defer server.Close()
 
 	result := checkWSSReachable(
@@ -61,5 +69,88 @@ func TestCheckWSSReachableRejectsMissingRoute(t *testing.T) {
 
 	if result.OK || !strings.Contains(result.Detail, "returned 404") {
 		t.Fatalf("missing WebSocket route was not rejected: %+v", result)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("missing route requests = %d, want 1", got)
+	}
+}
+
+func TestCheckWSSReachableRetriesTransientGatewayFailure(t *testing.T) {
+	t.Parallel()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			http.Error(writer, "upstream unavailable", http.StatusBadGateway)
+			return
+		}
+		http.Error(writer, "authentication required", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	result := checkWSSReachableWithRetry(
+		context.Background(),
+		"ws"+strings.TrimPrefix(server.URL, "http")+"/ws/node/agent/",
+		time.Second,
+		[]time.Duration{0},
+	)
+
+	if !result.OK {
+		t.Fatalf("transient gateway failure should recover: %+v", result)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("transient gateway requests = %d, want 2", got)
+	}
+}
+
+func TestCheckWSSReachableRejectsPersistentGatewayFailure(t *testing.T) {
+	t.Parallel()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		http.Error(writer, "upstream unavailable", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	result := checkWSSReachableWithRetry(
+		context.Background(),
+		"ws"+strings.TrimPrefix(server.URL, "http")+"/ws/node/agent/",
+		time.Second,
+		[]time.Duration{0, 0},
+	)
+
+	if result.OK || !strings.Contains(result.Detail, "returned 502") {
+		t.Fatalf("persistent gateway failure was not rejected: %+v", result)
+	}
+	if got := requests.Load(); got != 3 {
+		t.Fatalf("persistent gateway requests = %d, want 3", got)
+	}
+}
+
+func TestTransientWSSFailureClassification(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		response *http.Response
+		err      error
+		want     bool
+	}{
+		{name: "bad gateway", response: &http.Response{StatusCode: http.StatusBadGateway}, want: true},
+		{name: "service unavailable", response: &http.Response{StatusCode: http.StatusServiceUnavailable}, want: true},
+		{name: "gateway timeout", response: &http.Response{StatusCode: http.StatusGatewayTimeout}, want: true},
+		{name: "internal error", response: &http.Response{StatusCode: http.StatusInternalServerError}, want: false},
+		{name: "missing route", response: &http.Response{StatusCode: http.StatusNotFound}, want: false},
+		{name: "missing DNS name", err: &net.DNSError{Err: "no such host", IsNotFound: true}, want: false},
+		{name: "permanent DNS error", err: &net.DNSError{Err: "invalid DNS response"}, want: false},
+		{name: "temporary network error", err: &net.DNSError{Err: "temporary failure", IsTemporary: true}, want: true},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF, want: true},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := transientWSSFailure(test.response, test.err); got != test.want {
+				t.Fatalf("transientWSSFailure() = %t, want %t", got, test.want)
+			}
+		})
 	}
 }

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -1275,6 +1275,13 @@ if grep -F 'install.sh" platform-gateway ensure' "${remote_deploy}" >/dev/null; 
 	printf 'ERROR: remote deployment must not repeat installer-owned Gateway ensure\n' >&2
 	exit 1
 fi
+saas_deploy_action="${ROOT}/.github/actions/deploy-saas/action.yml"
+if grep -F 'platform-gateway ensure' "${saas_deploy_action}" >/dev/null; then
+	printf 'ERROR: SaaS deployment must not repeat installer-owned Gateway ensure\n' >&2
+	exit 1
+fi
+grep -F 'platform-gateway verify --required --timeout 180' \
+	"${saas_deploy_action}" >/dev/null
 grep -F -- '--public-url) PUBLIC_URL=' "${remote_deploy}" >/dev/null
 grep -F -- '--admin-public-url) ADMIN_PUBLIC_URL=' "${remote_deploy}" >/dev/null
 grep -F -- '--direct-host) DIRECT_HOST=' "${remote_deploy}" >/dev/null

--- a/tools/quality/test-saas-registry-delivery.sh
+++ b/tools/quality/test-saas-registry-delivery.sh
@@ -95,7 +95,12 @@ grep -Fq -- '--expected-tag "$EXPECTED_TAG"' \
 	"${ROOT}/.github/actions/deploy-saas/action.yml"
 grep -Fq 'candidate does not match the requested release tag' \
 	"${ROOT}/.github/scripts/remote-saas-deploy.sh"
-grep -Fq 'platform-gateway ensure' \
+if grep -Fq 'platform-gateway ensure' \
+	"${ROOT}/.github/actions/deploy-saas/action.yml"; then
+	printf 'ERROR: SaaS deployment must not repeat installer-owned Gateway ensure\n' >&2
+	exit 1
+fi
+grep -Fq 'platform-gateway verify --required --timeout 180' \
 	"${ROOT}/.github/actions/deploy-saas/action.yml"
 grep -Fq 'reconcile-saas-ai-model.sh agent' \
 	"${ROOT}/.github/actions/deploy-saas/action.yml"


### PR DESCRIPTION
## Summary

- remove the redundant Platform Gateway ensure step after the installer-owned deployment transaction
- retry transient WebSocket gateway and network failures within a bounded 30-second preflight window
- fail deterministic URL, route, HTTP, and DNS errors immediately
- protect the SaaS deployment sequence with delivery and release contract checks

## Validation

- Agent enrollment unit tests and Go vet
- Linux, Windows, and macOS enrollment test-package compilation
- Platform Gateway auto-deploy contracts
- SaaS registry delivery contracts
- release contracts
- diff and shell syntax checks