### PR TITLE
fix(frontend): avoid cancelling backup step requests

### DIFF
--- a/src/frontend/src/pages/protection/BackupConfigurationFastTransition.test.ts
+++ b/src/frontend/src/pages/protection/BackupConfigurationFastTransition.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { transpile } from 'typescript'
 
 const page = readFileSync(resolve(process.cwd(), 'src/pages/protection/DataProtection.vue'), 'utf8')
 const wizard = readFileSync(resolve(process.cwd(), 'src/pages/protection/BackupCreateWizard.vue'), 'utf8')
@@ -15,6 +16,37 @@ function sourceBetween(source: string, startMarker: string, endMarker: string) {
 }
 
 describe('backup configuration fast transition', () => {
+  it.each(['success', 'failure', 'leave'] as const)('coordinates delayed reconciliation: %s', async (outcome) => {
+    let settle!: () => void
+    let fail!: (error: Error) => void
+    const pending = new Promise<void>((resolve, reject) => { settle = resolve; fail = reject })
+    const refresh = vi.fn().mockReturnValue(pending)
+    const normalLoad = vi.fn().mockResolvedValue(undefined)
+    const activeStep = { value: 2 }
+    const initialLoad = { value: true }
+    const source = sourceBetween(page, 'let createdBackupRefresh:', 'function finishCreateAndGoToStep3')
+    const createHarness = new Function(
+      'refreshStep3AfterMoreAction', 'refreshFlowStepData', 'flowMainStep',
+      'step3InitialLoadPending', 'pageRequests', 'showApiError',
+      transpile(source) + '\nreturn { reconcileCreatedBackupConfigs, refreshEnteredFlowStep };',
+    )
+    const harness = createHarness(refresh, normalLoad, activeStep, initialLoad,
+      { isAbortError: () => false }, vi.fn())
+    harness.reconcileCreatedBackupConfigs(['agent:1'])
+    const entry = harness.refreshEnteredFlowStep(2)
+    expect(refresh).toHaveBeenCalledOnce()
+    expect(normalLoad).not.toHaveBeenCalled()
+    if (outcome === 'success') initialLoad.value = false
+    if (outcome === 'leave') activeStep.value = 1
+    if (outcome === 'failure') fail(new Error('Count request failed'))
+    else settle()
+    await entry
+    expect(normalLoad).toHaveBeenCalledTimes(outcome === 'failure' ? 1 : 0)
+    activeStep.value = 2
+    await harness.refreshEnteredFlowStep(2)
+    expect(normalLoad).toHaveBeenCalledTimes(outcome === 'failure' ? 2 : 1)
+  })
+
   it('uses the authoritative create response without repeating the pipeline update', () => {
     const create = sourceBetween(wizard, 'async function runCreateBackup', 'function editableGroupPayloads')
 
@@ -36,7 +68,7 @@ describe('backup configuration fast transition', () => {
     expect(complete).not.toContain('await refreshStep3AfterMoreAction')
     expect(reconcile).toContain('showLoading: true')
     expect(page).not.toContain('skipNextFlowStepRefresh')
-    expect(page).toContain('void refreshFlowStepData(step)')
+    expect(page).toContain('void refreshEnteredFlowStep(step)')
   })
 
   it('shows Step 3 loading for the full post-create refresh chain', () => {

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -2326,14 +2326,28 @@ function mergeCreatedBackupConfigs({ items }: BackupCreateResultPayload) {
   return sourceIds
 }
 
+let createdBackupRefresh: Promise<unknown> | null = null
+
+async function refreshEnteredFlowStep(step: 0 | 1 | 2) {
+  if (step === 2 && createdBackupRefresh) {
+    await createdBackupRefresh
+    // A failed or interrupted reconciliation must not suppress the initial load.
+    if (!step3InitialLoadPending.value) return
+  }
+  if (flowMainStep.value === step) await refreshFlowStepData(step)
+}
+
 function reconcileCreatedBackupConfigs(sourceIds: string[]) {
-  void refreshStep3AfterMoreAction({
+  const request = refreshStep3AfterMoreAction({
     focusIds: sourceIds,
     showLoading: true,
     preserveExpandedState: true,
   }).catch((err) => {
     if (!pageRequests.isAbortError(err)) showApiError(err)
+  }).finally(() => {
+    if (createdBackupRefresh === request) createdBackupRefresh = null
   })
+  createdBackupRefresh = request
 }
 
 function finishCreateAndGoToStep3(payload: BackupCreateResultPayload) {
@@ -2824,11 +2838,8 @@ watch(flowMainStep, (step) => {
   nextTick(() => {
     updateFlowTableMaxHeight()
     if (!flowBootstrapping.value) {
-      // Always perform the normal step load after entering a step.  The
-      // create/edit reconciliation may have started first, but it uses the
-      // same request scope and can otherwise leave Step 3 empty when it is
-      // cancelled by a transition or a transient API failure.
-      void refreshFlowStepData(step)
+      // Reuse post-create reconciliation instead of aborting its count requests.
+      void refreshEnteredFlowStep(step)
     }
     if (step === 0) syncSourceTableSelection()
     if (step === 1) syncStep2TableSelection()


### PR DESCRIPTION
## Problem and root cause

Creating a backup configuration and entering Start Backup started two Step 3 refresh paths. They shared one request scope, so the later refresh aborted valid Step 2 and Step 3 count requests.

## Solution

Reuse the post-create Step 3 reconciliation from the step-entry watcher. If reconciliation is interrupted or fails, the watcher falls back to the normal initial load. Added delayed success, failure, and navigation regression coverage.

## Validation

- Manual testing: passed
- `npm run test -- src/pages/protection/BackupConfigurationFastTransition.test.ts src/pages/protection/DataProtectionInitialStepLoadRecovery.test.ts src/pages/protection/DataProtectionStep3MoreActions.test.ts`
- `NODE_OPTIONS=--no-experimental-webstorage HFL_EXTENSIONS= HFL_FRONTEND_TEST_SCOPE=host npm run test:ci` (273 files, 1589 tests)
- `HFL_EXTENSIONS= npm run build`
- `python3 tools/quality/check-english-source.py`
- `git diff --check`

## Risks and compatibility

This changes request coordination in the Backup Wizard only. Existing cancellation on navigation, filtering, and unmount remains intact.

Fixes #1100
