### PR TITLE
Scope restore tasks to the current backup configuration

### DIFF
--- a/src/backend/apps/source/services/internal/backup_selectable.py
+++ b/src/backend/apps/source/services/internal/backup_selectable.py
@@ -845,12 +845,32 @@ def _attach_runtime_expansion(
                 backup_tasks_by_source[key].append(task)
 
     records_by_source: dict[str, list[RestoreRecord]] = defaultdict(list)
+    current_config_ids = BackupConfig.objects.filter(
+        organization_id=organization_id,
+    ).filter(source_query).values_list("id", flat=True)
+    current_snapshot_ids = (
+        BackupSourceSnapshot.objects.filter(
+            organization_id=organization_id,
+            deleted_at__isnull=True,
+            backup_config_id__in=current_config_ids,
+        )
+        .exclude(status=BackupSourceSnapshot.Status.DELETED)
+        .filter(source_query)
+        .values_list("id", flat=True)
+    )
     restore_records = (
         RestoreRecord.objects.filter(
             organization_id=organization_id,
             purpose=RestoreRecord.Purpose.USER_DATA,
         )
         .filter(source_query)
+        .filter(
+            Q(backup_config_id__in=current_config_ids)
+            | Q(
+                backup_config_id__isnull=True,
+                source_snapshot_id__in=current_snapshot_ids,
+            )
+        )
         .prefetch_related("items")
         .order_by("-created_at", "-id")
     )

--- a/src/backend/apps/source/services/internal/source_pipeline.py
+++ b/src/backend/apps/source/services/internal/source_pipeline.py
@@ -138,19 +138,51 @@ def _backup_config_exists(
     ).exists()
 
 
-def _latest_user_restore_task(tasks, *, organization_id: int):
-    """Return the latest Protection restore without projecting Insight work."""
+def _latest_user_restore_task(
+    tasks,
+    *,
+    organization_id: int,
+    source_kind: str,
+    ref_id: int,
+):
+    """Return the latest restore owned by the source's current backup config."""
+    from django.db.models import Q
+
+    from apps.protection.models import BackupConfig, BackupSourceSnapshot
     from apps.restore.models import RestoreRecord
     from apps.task.models import Task
 
-    insight_task_ids = RestoreRecord.objects.filter(
+    source_type = "agent" if source_kind == SelectableSourceKind.AGENT else source_kind
+    current_config_ids = BackupConfig.objects.filter(
         organization_id=organization_id,
-        purpose=RestoreRecord.Purpose.LENS_WORKSPACE,
+        source_type=source_type,
+        source_ref_id=ref_id,
+    ).values_list("id", flat=True)
+    current_snapshot_ids = (
+        BackupSourceSnapshot.objects.filter(
+            organization_id=organization_id,
+            source_type=source_type,
+            source_ref_id=ref_id,
+            backup_config_id__in=current_config_ids,
+            deleted_at__isnull=True,
+        )
+        .exclude(status=BackupSourceSnapshot.Status.DELETED)
+        .values_list("id", flat=True)
+    )
+    restore_task_ids = RestoreRecord.objects.filter(
+        organization_id=organization_id,
+        purpose=RestoreRecord.Purpose.USER_DATA,
+        source_type=source_type,
+        source_ref_id=ref_id,
+    ).filter(
+        Q(backup_config_id__in=current_config_ids)
+        | Q(
+            backup_config_id__isnull=True,
+            source_snapshot_id__in=current_snapshot_ids,
+        )
     ).values_list("task_id", flat=True)
     return (
-        tasks.filter(task_type=Task.Type.RESTORE)
-        .exclude(id__in=insight_task_ids)
-        .first()
+        tasks.filter(task_type=Task.Type.RESTORE, id__in=restore_task_ids).first()
     )
 
 
@@ -184,7 +216,12 @@ def _source_and_tasks(*, organization_id: int, source_kind: str, ref_id: int):
     return (
         source,
         tasks.filter(task_type=Task.Type.BACKUP).first(),
-        _latest_user_restore_task(tasks, organization_id=organization_id),
+        _latest_user_restore_task(
+            tasks,
+            organization_id=organization_id,
+            source_kind=source_kind,
+            ref_id=ref_id,
+        ),
     )
 
 
@@ -291,6 +328,8 @@ def sync_pipeline_projection(
             restore_task=_latest_user_restore_task(
                 tasks,
                 organization_id=organization_id,
+                source_kind=source_kind,
+                ref_id=ref_id,
             ),
         )
         current_step = (

--- a/src/backend/apps/source/tests/test_api.py
+++ b/src/backend/apps/source/tests/test_api.py
@@ -119,6 +119,36 @@ class SourceResourceApiTests(TestCase):
             status=status_value,
         )
 
+    def _create_restore_record_for_agent(
+        self,
+        *,
+        agent: Node,
+        task: Task,
+        restore_uid: str,
+        backup_config_id: int | None,
+        source_snapshot_id: int,
+    ) -> RestoreRecord:
+        return RestoreRecord.objects.create(
+            organization_id=self.org.id,
+            requesting_organization_id=self.org.id,
+            target_execution_organization_id=self.org.id,
+            target_execution_node_id=agent.id,
+            purpose=RestoreRecord.Purpose.USER_DATA,
+            restore_uid=restore_uid,
+            source_mode=RestoreRecord.SourceMode.MANUAL,
+            task_id=task.id,
+            task_uuid=task.task_uuid,
+            source_type=RestoreRecord.EndpointType.AGENT,
+            source_ref_id=agent.id,
+            backup_config_id=backup_config_id,
+            source_snapshot_id=source_snapshot_id,
+            target_type=RestoreRecord.EndpointType.AGENT,
+            target_ref_id=agent.id,
+            target_path="/restore",
+            scope=RestoreRecord.Scope.PATHS,
+            conflict_mode=RestoreRecord.ConflictMode.OVERWRITE,
+        )
+
     def test_create_list_statistics(self):
         create = self.client.post(
             "/api/v1/source/resources/",
@@ -1261,24 +1291,22 @@ class SourceResourceApiTests(TestCase):
             status=Task.Status.RUNNING,
             trigger_type=Task.TriggerType.MANUAL,
         )
-        user_record = RestoreRecord.objects.create(
-            organization_id=self.org.id,
-            requesting_organization_id=self.org.id,
-            target_execution_organization_id=self.org.id,
-            target_execution_node_id=agent.id,
-            purpose=RestoreRecord.Purpose.USER_DATA,
-            restore_uid="source-runtime-user-restore",
-            source_mode=RestoreRecord.SourceMode.MANUAL,
+        backup_config = self._create_backup_config_for_agent(
+            agent,
+            name="runtime-restore-purpose",
+        )
+        source_snapshot = self._create_source_snapshot(
+            backup_config,
+            uid="runtime-restore-purpose-snapshot",
+            status_value=BackupSourceSnapshot.Status.AVAILABLE,
             task_id=user_task.id,
-            task_uuid=user_task.task_uuid,
-            source_type=RestoreRecord.EndpointType.AGENT,
-            source_ref_id=agent.id,
-            source_snapshot_id=302,
-            target_type=RestoreRecord.EndpointType.AGENT,
-            target_ref_id=agent.id,
-            target_path="/restore",
-            scope=RestoreRecord.Scope.PATHS,
-            conflict_mode=RestoreRecord.ConflictMode.OVERWRITE,
+        )
+        user_record = self._create_restore_record_for_agent(
+            agent=agent,
+            task=user_task,
+            restore_uid="source-runtime-user-restore",
+            backup_config_id=backup_config.id,
+            source_snapshot_id=source_snapshot.id,
         )
 
         response = self.client.get(
@@ -1294,6 +1322,135 @@ class SourceResourceApiTests(TestCase):
         self.assertEqual(runtime["latest_task"]["id"], user_task.id)
         self.assertEqual(runtime["latest_record"]["id"], user_record.id)
         self.assertEqual(runtime["latest_record"]["task_uuid"], str(user_task.task_uuid))
+
+    def test_backup_selectable_runtime_uses_only_current_config_restore_records(self):
+        agent = Node.objects.create(
+            organization=self.org,
+            name="agent-runtime-current-restore",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            ip_address="10.0.0.31",
+        )
+        old_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.RESTORE,
+            display_name="Restore from reset config",
+            status=Task.Status.SUCCESS,
+            trigger_type=Task.TriggerType.MANUAL,
+        )
+        old_config = self._create_backup_config_for_agent(
+            agent,
+            name="runtime-old-restore",
+        )
+        old_snapshot = self._create_source_snapshot(
+            old_config,
+            uid="runtime-old-restore-snapshot",
+            status_value=BackupSourceSnapshot.Status.AVAILABLE,
+            task_id=old_task.id,
+        )
+        old_record = self._create_restore_record_for_agent(
+            agent=agent,
+            task=old_task,
+            restore_uid="runtime-old-restore",
+            backup_config_id=old_config.id,
+            source_snapshot_id=old_snapshot.id,
+        )
+
+        old_snapshot_id = old_snapshot.id
+        old_snapshot.delete()
+        old_config.delete()
+        current_config = self._create_backup_config_for_agent(
+            agent,
+            name="runtime-current-restore",
+        )
+
+        response = self.client.get(
+            f"/api/v1/source/backup-selectable/?ids=agent:{agent.id}&expand=runtime",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        runtime = response.data["results"][0]["runtime"]["restore"]
+        self.assertEqual(runtime["total"], 0)
+        self.assertIsNone(runtime["latest_task"])
+        self.assertIsNone(runtime["latest_record"])
+        self.assertTrue(RestoreRecord.objects.filter(id=old_record.id).exists())
+
+        current_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.RESTORE,
+            display_name="Restore from current config",
+            status=Task.Status.RUNNING,
+            trigger_type=Task.TriggerType.MANUAL,
+        )
+        current_record = self._create_restore_record_for_agent(
+            agent=agent,
+            task=current_task,
+            restore_uid="runtime-current-restore",
+            backup_config_id=current_config.id,
+            source_snapshot_id=old_snapshot_id,
+        )
+
+        response = self.client.get(
+            f"/api/v1/source/backup-selectable/?ids=agent:{agent.id}&expand=runtime",
+            **self._headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        runtime = response.data["results"][0]["runtime"]["restore"]
+        self.assertEqual(runtime["total"], 1)
+        self.assertEqual(runtime["latest_task"]["id"], current_task.id)
+        self.assertEqual(runtime["latest_record"]["id"], current_record.id)
+
+    def test_backup_selectable_runtime_supports_legacy_restore_snapshot_ownership(self):
+        agent = Node.objects.create(
+            organization=self.org,
+            name="agent-runtime-legacy-restore",
+            role=Node.Role.AGENT,
+            status=Node.Status.ACTIVE,
+            availability=Node.Availability.ONLINE,
+            ip_address="10.0.0.32",
+        )
+        restore_task = Task.objects.create(
+            organization_id=self.org.id,
+            task_type=Task.Type.RESTORE,
+            display_name="Legacy restore",
+            status=Task.Status.SUCCESS,
+            trigger_type=Task.TriggerType.MANUAL,
+        )
+        config = self._create_backup_config_for_agent(
+            agent,
+            name="runtime-legacy-restore",
+        )
+        snapshot = self._create_source_snapshot(
+            config,
+            uid="runtime-legacy-restore-snapshot",
+            status_value=BackupSourceSnapshot.Status.AVAILABLE,
+            task_id=restore_task.id,
+        )
+        self._create_restore_record_for_agent(
+            agent=agent,
+            task=restore_task,
+            restore_uid="runtime-legacy-restore",
+            backup_config_id=None,
+            source_snapshot_id=snapshot.id,
+        )
+
+        response = self.client.get(
+            f"/api/v1/source/backup-selectable/?ids=agent:{agent.id}&expand=runtime",
+            **self._headers(),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"][0]["runtime"]["restore"]["total"], 1)
+
+        snapshot.delete()
+        response = self.client.get(
+            f"/api/v1/source/backup-selectable/?ids=agent:{agent.id}&expand=runtime",
+            **self._headers(),
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"][0]["runtime"]["restore"]["total"], 0)
 
     def test_backup_selectable_runtime_reports_historical_restorable_snapshot(self):
         agent = Node.objects.create(

--- a/src/backend/apps/source/tests/test_source_pipeline_projection.py
+++ b/src/backend/apps/source/tests/test_source_pipeline_projection.py
@@ -10,6 +10,7 @@ from apps.iam.models import Organization
 from apps.node import conf as node_conf
 from apps.node.models import Node, NodeTask
 from apps.node.services.internal.task import complete_task as complete_node_task
+from apps.protection.models import BackupConfig, BackupSourceSnapshot
 from apps.restore.models import RestoreRecord
 from apps.source.constants import PipelineStep, ResourceType, SelectableSourceKind
 from apps.source.models import SourceBackupPipelineEntry, SourceResource
@@ -21,6 +22,7 @@ from apps.source.services.internal.source_pipeline import (
 )
 from apps.task.models import Task, TaskResource
 from apps.task.services.interface import complete_task, create_task, start_task
+from apps.storage.repositories.models import Repository
 
 
 class SourcePipelineProjectionTests(TestCase):
@@ -36,6 +38,64 @@ class SourcePipelineProjectionTests(TestCase):
             availability=Node.Availability.ONLINE,
             connection_ip_address="198.51.100.10",
             metadata={"inventory": {"hostname": "agent-reported"}},
+        )
+
+    def _create_current_backup_context(self, *, suffix: str):
+        repository = Repository.objects.create(
+            organization_id=self.org.id,
+            name=f"pipeline-{suffix}-repo",
+            repo_type=Repository.Type.S3,
+            status=Repository.Status.CREATED,
+            health=Repository.Health.ONLINE,
+            s3_bucket=f"pipeline-{suffix}-bucket",
+        )
+        config = BackupConfig.objects.create(
+            organization_id=self.org.id,
+            name=f"pipeline-{suffix}",
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            repository_id=repository.id,
+        )
+        snapshot = BackupSourceSnapshot.objects.create(
+            organization_id=self.org.id,
+            snapshot_uid=f"pipeline-{suffix}-snapshot",
+            idempotency_key=f"pipeline-{suffix}-snapshot-idem",
+            source_type="agent",
+            source_ref_id=self.agent.id,
+            backup_config_id=config.id,
+            repository_id=repository.id,
+            task_id=0,
+            status=BackupSourceSnapshot.Status.AVAILABLE,
+        )
+        return config, snapshot
+
+    def _create_user_restore_record(
+        self,
+        *,
+        task: Task,
+        config: BackupConfig,
+        snapshot: BackupSourceSnapshot,
+        restore_uid: str,
+    ) -> RestoreRecord:
+        return RestoreRecord.objects.create(
+            organization_id=self.org.id,
+            requesting_organization_id=self.org.id,
+            target_execution_organization_id=self.org.id,
+            target_execution_node_id=self.agent.id,
+            purpose=RestoreRecord.Purpose.USER_DATA,
+            restore_uid=restore_uid,
+            source_mode=RestoreRecord.SourceMode.MANUAL,
+            task_id=task.id,
+            task_uuid=task.task_uuid,
+            source_type=RestoreRecord.EndpointType.AGENT,
+            source_ref_id=self.agent.id,
+            backup_config_id=config.id,
+            source_snapshot_id=snapshot.id,
+            target_type=RestoreRecord.EndpointType.AGENT,
+            target_ref_id=self.agent.id,
+            target_path="/tmp/restore",
+            scope=RestoreRecord.Scope.PATHS,
+            conflict_mode=RestoreRecord.ConflictMode.OVERWRITE,
         )
 
     @mock.patch("apps.source.services.internal.source_pipeline.time.sleep")
@@ -261,6 +321,7 @@ class SourcePipelineProjectionTests(TestCase):
         self.assertEqual(entry.last_backup_status, "running")
 
     def test_legacy_insight_restore_is_not_projected_as_user_restore(self):
+        config, snapshot = self._create_current_backup_context(suffix="legacy-insight")
         user_restore = create_task(
             organization_id=self.org.id,
             task_type=Task.Type.RESTORE,
@@ -273,6 +334,12 @@ class SourcePipelineProjectionTests(TestCase):
                     "is_primary": True,
                 }
             ],
+        )
+        self._create_user_restore_record(
+            task=user_restore,
+            config=config,
+            snapshot=snapshot,
+            restore_uid="pipeline-user-restore",
         )
         insight_restore = create_task(
             organization_id=self.org.id,
@@ -318,7 +385,51 @@ class SourcePipelineProjectionTests(TestCase):
         self.assertEqual(entry.last_restore_task_id, user_restore.id)
         self.assertEqual(entry.last_restore_status, "queued")
 
+    def test_reset_config_restore_is_removed_from_current_projection(self):
+        config, snapshot = self._create_current_backup_context(suffix="reset-restore")
+        restore_task = create_task(
+            organization_id=self.org.id,
+            task_type=Task.Type.RESTORE,
+            display_name="Restore before reset",
+            resources=[
+                {
+                    "resource_type": TaskResource.Type.BACKUP_SOURCE,
+                    "resource_subtype": "agent",
+                    "resource_id": self.agent.id,
+                    "is_primary": True,
+                }
+            ],
+        )
+        restore_record = self._create_user_restore_record(
+            task=restore_task,
+            config=config,
+            snapshot=snapshot,
+            restore_uid="pipeline-reset-restore",
+        )
+        entry = ensure_pipeline_entry(
+            organization_id=self.org.id,
+            source_kind=SelectableSourceKind.AGENT,
+            ref_id=self.agent.id,
+        )
+        self.assertEqual(entry.last_restore_task_id, restore_task.id)
+
+        snapshot.delete()
+        config.delete()
+        self._create_current_backup_context(suffix="after-reset")
+        entry = ensure_pipeline_entry(
+            organization_id=self.org.id,
+            source_kind=SelectableSourceKind.AGENT,
+            ref_id=self.agent.id,
+        )
+
+        self.assertIsNone(entry.last_restore_task_id)
+        self.assertEqual(entry.last_restore_status, "none")
+        self.assertTrue(RestoreRecord.objects.filter(id=restore_record.id).exists())
+
     def test_classified_insight_task_recomputes_stale_restore_projection(self):
+        config, snapshot = self._create_current_backup_context(
+            suffix="classified-insight"
+        )
         user_restore = create_task(
             organization_id=self.org.id,
             task_type=Task.Type.RESTORE,
@@ -331,6 +442,12 @@ class SourcePipelineProjectionTests(TestCase):
                     "is_primary": True,
                 }
             ],
+        )
+        self._create_user_restore_record(
+            task=user_restore,
+            config=config,
+            snapshot=snapshot,
+            restore_uid="pipeline-classified-user-restore",
         )
         insight_restore = create_task(
             organization_id=self.org.id,
@@ -345,6 +462,12 @@ class SourcePipelineProjectionTests(TestCase):
                 }
             ],
         )
+        insight_record = self._create_user_restore_record(
+            task=insight_restore,
+            config=config,
+            snapshot=snapshot,
+            restore_uid="pipeline-classified-insight",
+        )
         entry = ensure_pipeline_entry(
             organization_id=self.org.id,
             source_kind=SelectableSourceKind.AGENT,
@@ -352,26 +475,10 @@ class SourcePipelineProjectionTests(TestCase):
         )
         self.assertEqual(entry.last_restore_task_id, insight_restore.id)
 
-        RestoreRecord.objects.create(
-            organization_id=self.org.id,
-            requesting_organization_id=self.org.id,
-            target_execution_organization_id=self.org.id,
-            target_execution_node_id=self.agent.id,
+        RestoreRecord.objects.filter(id=insight_record.id).update(
             purpose=RestoreRecord.Purpose.LENS_WORKSPACE,
             idempotency_key="pipeline-classified-insight",
             workspace_binding_id=101,
-            restore_uid="pipeline-classified-insight",
-            source_mode=RestoreRecord.SourceMode.MANUAL,
-            task_id=insight_restore.id,
-            task_uuid=insight_restore.task_uuid,
-            source_type=RestoreRecord.EndpointType.AGENT,
-            source_ref_id=self.agent.id,
-            source_snapshot_id=101,
-            target_type=RestoreRecord.EndpointType.AGENT,
-            target_ref_id=self.agent.id,
-            target_path="/tmp/insight-classified",
-            scope=RestoreRecord.Scope.PATHS,
-            conflict_mode=RestoreRecord.ConflictMode.OVERWRITE,
         )
         insight_restore.task_type = Task.Type.INSIGHT_WORKSPACE_RESTORE
         insight_restore.save(update_fields=["task_type", "updated_at"])

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -802,10 +802,17 @@ function restoreRecordsForSource(sourceId: string) {
   const endpoint = parseEndpointUiId(sourceId)
   if (!endpoint) return []
   const configIds = new Set(sourceBackupConfigIds(sourceId))
+  if (!configIds.size) return []
+  const currentSnapshotIds = new Set(
+    backupSnapshotRows.value
+      .filter((snapshot) => configIds.has(Number(snapshot.backup_config_id)))
+      .map((snapshot) => Number(snapshot.id)),
+  )
   return restoreRecordRows.value.filter((record) => {
-    if (endpointUiId(record.source_type, record.source_ref_id) === sourceId) return true
+    if (endpointUiId(record.source_type, record.source_ref_id) !== sourceId) return false
     const configId = Number(record.backup_config_id || 0)
-    return configId > 0 && configIds.has(configId)
+    if (configId > 0) return configIds.has(configId)
+    return currentSnapshotIds.has(Number(record.source_snapshot_id))
   })
 }
 

--- a/src/frontend/src/pages/protection/DataProtectionResetBackupConfigList.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionResetBackupConfigList.test.ts
@@ -13,6 +13,20 @@ function sourceBetween(startMarker: string, endMarker: string) {
 }
 
 describe('backup wizard reset → Backup Configuration list (#362)', () => {
+  it('does not reuse restore history from a reset backup configuration', () => {
+    const records = sourceBetween(
+      'function restoreRecordsForSource(sourceId: string)',
+      'function restoreRecordIsRunning(record: RestoreRecord)',
+    )
+
+    expect(records).toContain('if (!configIds.size) return []')
+    expect(records).toContain('const currentSnapshotIds = new Set(')
+    expect(records).toContain('if (endpointUiId(record.source_type, record.source_ref_id) !== sourceId) return false')
+    expect(records).toContain('if (configId > 0) return configIds.has(configId)')
+    expect(records).toContain('return currentSnapshotIds.has(Number(record.source_snapshot_id))')
+    expect(records).not.toContain('=== sourceId) return true')
+  })
+
   it('shows step=2 API rows on Backup Configuration without filtering by stale step-3 caches', () => {
     const pendingList = sourceBetween(
       'const step2PendingSourceList = computed(() => {',


### PR DESCRIPTION
## Summary

- scope Backup Wizard restore runtime state to the source's current backup configuration
- keep legacy restore records compatible when their snapshot still belongs to the current configuration
- prevent reset configuration history from reappearing in current pipeline projections and frontend status

## Validation

- 95 source API tests
- 19 source pipeline and targeted runtime tests
- 6 frontend reset-flow tests
- Ruff and diff checks

Fixes #1101