### PR TITLE
Use canonical GitHub organization references

### DIFF
--- a/.github/scripts/remote-deploy.sh
+++ b/.github/scripts/remote-deploy.sh
@@ -2,7 +2,7 @@
 # Download one published HFL release on the target host and install or upgrade it.
 set -euo pipefail
 
-REPOSITORY="HyperBDR/hyperfilelens"
+REPOSITORY="oneprolabs/hyperfilelens"
 TAG=""
 CHANNEL="release"
 INSTALL_DIR="/opt/hyperfilelens"
@@ -17,7 +17,7 @@ usage() {
 	cat <<'USAGE'
 Usage: remote-deploy.sh --tag vX.Y.Z --channel release --direct-host HOST [options]
 
-  --repository OWNER/REPO  Public GitHub repository (default: HyperBDR/hyperfilelens)
+  --repository OWNER/REPO  Public GitHub repository (default: oneprolabs/hyperfilelens)
 	--channel CHANNEL       Artifact channel: release (default: release)
   --install-dir DIR        HFL install directory (default: /opt/hyperfilelens)
   --direct-host HOST       SSH-reachable host used for direct listener URLs

--- a/release/ci/write-sbom.py
+++ b/release/ci/write-sbom.py
@@ -41,7 +41,7 @@ def main() -> None:
                     "referenceCategory": "OTHER",
                     "referenceType": "vcs",
                     "referenceLocator": (
-                        "https://github.com/HyperBDR/hyperfilelens@" + commit
+                        "https://github.com/oneprolabs/hyperfilelens@" + commit
                     ),
                 }
             ],
@@ -117,7 +117,7 @@ def main() -> None:
         "SPDXID": "SPDXRef-DOCUMENT",
         "name": f"hyperfilelens-{version}",
         "documentNamespace": (
-            "https://github.com/HyperBDR/hyperfilelens/releases/"
+            "https://github.com/oneprolabs/hyperfilelens/releases/"
             f"spdx/{version}/{namespace_seed}"
         ),
         "creationInfo": {

--- a/tools/kopia/prepare.sh
+++ b/tools/kopia/prepare.sh
@@ -286,7 +286,7 @@ build_matrix() {
 				go build -trimpath -ldflags "-s -w \
 				-X github.com/kopia/kopia/repo.BuildVersion=${KOPIA_VERSION} \
 				-X github.com/kopia/kopia/repo.BuildInfo=${build_info} \
-				-X github.com/kopia/kopia/repo.BuildGitHubRepo=HyperBDR/hyperfilelens" \
+				-X github.com/kopia/kopia/repo.BuildGitHubRepo=oneprolabs/hyperfilelens" \
 				-o "${output}.part" github.com/kopia/kopia
 		)
 		mv -f "${output}.part" "${output}"

--- a/tools/quality/test-main-release-cleanup.sh
+++ b/tools/quality/test-main-release-cleanup.sh
@@ -87,7 +87,7 @@ run_cleanup() {
 			GH_MOCK_RELEASES="${releases}" \
 			GH_MOCK_GIT_REPO="${tmp}/seed" \
 			GH_MOCK_COMPARE_FAIL="${compare_fail}" \
-			GITHUB_REPOSITORY=HyperBDR/hyperfilelens \
+			GITHUB_REPOSITORY=oneprolabs/hyperfilelens \
 			GITHUB_STEP_SUMMARY="${tmp}/summary.md" \
 			ARTIFACT_ID="${artifact_id}" \
 			MAIN_COMMIT="${main_commit}" \
@@ -171,7 +171,7 @@ if ARTIFACT_ID=invalid \
 	MAIN_COMMIT="${second_commit}" \
 	BUILD_REQUIRED=true \
 	PUBLISH_RESULT=success \
-	GITHUB_REPOSITORY=HyperBDR/hyperfilelens \
+	GITHUB_REPOSITORY=oneprolabs/hyperfilelens \
 	"${ROOT}/.github/scripts/cleanup-main-builds.sh" >/dev/null 2>&1; then
 	printf 'ERROR: invalid Main artifact identifier was accepted\n' >&2
 	exit 1


### PR DESCRIPTION
## Summary

- replace stale `HyperBDR/hyperfilelens` references with `oneprolabs/hyperfilelens`
- update remote deployment defaults, SBOM repository metadata, and Kopia build metadata
- align Main release cleanup test fixtures with the canonical repository

## Validation

- `./tools/quality/test-main-release-cleanup.sh`
- `./tools/quality/test-release-download-proxy.sh`
- `./tools/quality/test-shared-host-guard.sh`
- `./tools/quality/check-python38-runtime.py`
- `./tools/quality/check-release-contracts.sh`
- Shell and Python syntax checks
- `git diff --check`

Resolves #1095.