### PR TITLE
Improve control plane task reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -587,6 +587,13 @@ GOSUMDB=sum.golang.org
 # Backup task activity lease in seconds. Renewed by task.alive/task.progress.
 # PROTECTION_BACKUP_ACTIVITY_LEASE_SECONDS=300
 
+# Maximum restore directories dispatched concurrently per restore record.
+# Values below 1 fall back to the default of 4.
+# PROTECTION_RESTORE_DIRECTORY_CONCURRENCY=4
+
+# Restore task activity lease in seconds. Renewed by task.alive/task.progress.
+# PROTECTION_RESTORE_ACTIVITY_LEASE_SECONDS=300
+
 # Keep a user-cancelled Agent task in "stopping" while awaiting confirmation.
 # NODE_TASK_CANCEL_GRACE_SECONDS=300
 

--- a/src/backend/apps/node/services/internal/node_registry.py
+++ b/src/backend/apps/node/services/internal/node_registry.py
@@ -14,7 +14,6 @@ from apps.node.models import Node
 from apps.node.models.base import NodeRole
 from apps.node import conf as node_conf
 from apps.node.services.internal import redis_store
-from apps.node.services.internal.task import fail_active_tasks_for_node
 
 logger = logging.getLogger(__name__)
 
@@ -347,11 +346,9 @@ def reconcile_stale_online_nodes(*, limit: int = 200) -> dict[str, int]:
     """
     Mark available nodes without fresh Redis routing as unavailable.
 
-    Fails in-flight ``NodeTask`` rows on affected nodes (ghost-task cleanup).
+    Active tasks are finalized separately after the full reconnect grace.
     """
     nodes_marked_offline = 0
-    tasks_failed = 0
-    task_failure_held = not redis_store.offline_task_finalization_ready()
 
     node_ids = list(
         Node.objects.filter(availability=Node.Availability.ONLINE)
@@ -389,22 +386,14 @@ def reconcile_stale_online_nodes(*, limit: int = 200) -> dict[str, int]:
             except Exception:
                 logger.debug("agent source-host sync failed node_id=%s", node.id, exc_info=True)
 
-            failed = 0
-            if not task_failure_held:
-                failed = fail_active_tasks_for_node(
-                    node_id=node.id,
-                    reason="agent heartbeat expired (registry reconcile)",
-                )
-            tasks_failed += failed
             logger.info(
-                "node %s marked offline (stale agent_loc); failed_tasks=%s",
+                "node %s marked offline (stale agent_loc); active tasks retained for reconnect grace",
                 node.id,
-                failed,
             )
 
     return {
         "nodes_marked_offline": nodes_marked_offline,
-        "tasks_failed": tasks_failed,
-        "task_failure_held": task_failure_held,
+        "tasks_failed": 0,
+        "task_failure_held": True,
         "checked_at": timezone.now().isoformat(),
     }

--- a/src/backend/apps/node/services/internal/task.py
+++ b/src/backend/apps/node/services/internal/task.py
@@ -150,6 +150,20 @@ def _is_protection_backup_task(task: NodeTask) -> bool:
     )
 
 
+def _is_restore_task(*, correlation_type: str, kind: str) -> bool:
+    return correlation_type == "restore.record" and kind in {
+        "restore.run",
+        "kopia.restore",
+    }
+
+
+def _restore_watchdog_deadline(*, from_time: datetime | None = None) -> datetime:
+    from apps.restore import conf as restore_conf
+
+    base = from_time or timezone.now()
+    return base + timezone.timedelta(seconds=restore_conf.ACTIVITY_LEASE_SECONDS)
+
+
 def _is_source_nas_probe(*, correlation_type: str, kind: str) -> bool:
     return correlation_type == "source.connection_probe" and kind == "nas.test"
 
@@ -281,6 +295,8 @@ def _initial_watchdog_deadline(
     from_time: datetime | None = None,
     kind: str = "",
 ) -> datetime:
+    if _is_restore_task(correlation_type=correlation_type, kind=kind):
+        return _restore_watchdog_deadline(from_time=from_time)
     if _is_repository_initialize_task(
         correlation_type=correlation_type,
         kind=kind,

--- a/src/backend/apps/node/tests/test_backup_task_watchdog.py
+++ b/src/backend/apps/node/tests/test_backup_task_watchdog.py
@@ -6,9 +6,25 @@ from django.utils import timezone
 from apps.node import conf as node_conf
 from apps.node.services.internal.task import _initial_watchdog_deadline
 from apps.protection import conf as protection_conf
+from apps.restore import conf as restore_conf
 
 
 class BackupTaskWatchdogTests(SimpleTestCase):
+    def test_restore_uses_restore_activity_lease(self):
+        started_at = timezone.now()
+
+        deadline = _initial_watchdog_deadline(
+            correlation_type="restore.record",
+            kind="restore.run",
+            from_time=started_at,
+        )
+
+        self.assertEqual(
+            deadline,
+            started_at
+            + timezone.timedelta(seconds=restore_conf.ACTIVITY_LEASE_SECONDS),
+        )
+
     def test_prepared_snapshot_uses_backup_watchdog(self):
         started_at = timezone.now()
 

--- a/src/backend/apps/node/tests/test_node_online_status.py
+++ b/src/backend/apps/node/tests/test_node_online_status.py
@@ -445,6 +445,31 @@ class AgentNodeOnlineStatusTests(TestCase):
         self.assertEqual(self.node.availability, Node.Availability.OFFLINE)
         self.assertEqual(summary["nodes_marked_offline"], 1)
 
+    def test_reconcile_retains_active_task_for_offline_grace(self):
+        self._mark_ws_alive()
+        on_agent_connected(node_id=self.node.id, session_id="session-a")
+        self.redis.delete(redis_store.agent_loc_key(self.node.id))
+        stale_at = timezone.now() - timezone.timedelta(
+            seconds=node_conf.AGENT_LOC_TTL_SECONDS + 5,
+        )
+        Node.objects.filter(pk=self.node.id).update(last_seen_at=stale_at)
+        node_task = NodeTask.objects.create(
+            organization=self.org,
+            node=self.node,
+            kind="backup.snapshot.create",
+            correlation_type="protection.backup",
+            correlation_id="backup-reconnect-grace",
+            status=NodeTask.Status.RUNNING,
+            watchdog_deadline_at=timezone.now() + timezone.timedelta(minutes=5),
+        )
+
+        summary = reconcile_stale_online_nodes(limit=10)
+
+        node_task.refresh_from_db()
+        self.assertEqual(node_task.status, NodeTask.Status.RUNNING)
+        self.assertEqual(summary["tasks_failed"], 0)
+        self.assertTrue(summary["task_failure_held"])
+
     def test_reconcile_marks_bound_repository_offline_with_stale_proxy(self):
         self.node.role = NodeRole.PROXY
         self.node.save(update_fields=["role", "updated_at"])

--- a/src/backend/apps/restore/conf.py
+++ b/src/backend/apps/restore/conf.py
@@ -1,6 +1,22 @@
-"""Runtime settings for direct NAS mount cleanup."""
+"""Runtime settings for restore orchestration."""
 
 from project.settings.env import env_int
+
+
+_DEFAULT_DIRECTORY_CONCURRENCY = 4
+_configured_directory_concurrency = env_int(
+    "PROTECTION_RESTORE_DIRECTORY_CONCURRENCY",
+    _DEFAULT_DIRECTORY_CONCURRENCY,
+)
+DIRECTORY_CONCURRENCY = (
+    _configured_directory_concurrency
+    if _configured_directory_concurrency >= 1
+    else _DEFAULT_DIRECTORY_CONCURRENCY
+)
+ACTIVITY_LEASE_SECONDS = max(
+    1,
+    env_int("PROTECTION_RESTORE_ACTIVITY_LEASE_SECONDS", 300),
+)
 
 
 DIRECT_NAS_MOUNT_CLEANUP_GRACE_SECONDS = max(

--- a/src/backend/apps/restore/services/interface.py
+++ b/src/backend/apps/restore/services/interface.py
@@ -45,6 +45,7 @@ from apps.protection.models import (
     BackupSourceSnapshot,
     BackupSourceSnapshotDirectory,
 )
+from apps.restore import conf as restore_conf
 from apps.restore.models import RestorePlan, RestoreRecord, RestoreRecordItem
 from apps.restore.services.task_events import (
     RESTORE_EVENT_SCHEMA_KEY,
@@ -1876,12 +1877,14 @@ def _dispatch_restore_items(
 
         target_nas_payload = {"nas": nas_payload_for_resource(target_nas)}
     all_items = list(record.items.all())
-    if record.purpose == RestoreRecord.Purpose.LENS_WORKSPACE and any(
-        item.node_task_id is not None
+    active_items = [
+        item
+        for item in all_items
+        if item.node_task_id is not None
         and item.status
         in {RestoreRecordItem.Status.PENDING, RestoreRecordItem.Status.RUNNING}
-        for item in all_items
-    ):
+    ]
+    if record.purpose == RestoreRecord.Purpose.LENS_WORKSPACE and active_items:
         # The completion callback and periodic reconciler can both request a
         # continuation.  Keep this guard at the shared dispatch boundary so a
         # second caller cannot start the next directory while one is active.
@@ -1903,11 +1906,22 @@ def _dispatch_restore_items(
         # One Chat is one Gateway scheduling unit. Dispatching every selected
         # directory at once would let a single Chat bypass the Gateway limit.
         items = items[:1]
+    else:
+        available_slots = max(
+            0,
+            restore_conf.DIRECTORY_CONCURRENCY - len(active_items),
+        )
+        items = items[:available_slots]
     if not items:
         logger.info(
-            "restore dispatch skipped restore_record_id=%s task_uuid=%s reason=no_pending_items",
+            "restore dispatch skipped restore_record_id=%s task_uuid=%s "
+            "reason=no_available_items active_items=%s concurrency=%s",
             record.id,
             record.task_uuid,
+            len(active_items),
+            1
+            if record.purpose == RestoreRecord.Purpose.LENS_WORKSPACE
+            else restore_conf.DIRECTORY_CONCURRENCY,
         )
         return
     if task.status == Task.Status.PENDING:
@@ -2117,11 +2131,22 @@ def _dispatch_restore_items(
                         "object_name": item.source_path,
                     },
                 )
+        has_pending_dispatch = record.items.filter(
+            node_task_id__isnull=True,
+            status__in=(
+                RestoreRecordItem.Status.PENDING,
+                RestoreRecordItem.Status.RUNNING,
+            ),
+        ).exists()
         _set_step_status(
             task=task,
             step_name="dispatch_agent",
-            status=TaskStep.Status.SUCCESS,
-            progress=100,
+            status=(
+                TaskStep.Status.RUNNING
+                if has_pending_dispatch
+                else TaskStep.Status.SUCCESS
+            ),
+            progress=10 if has_pending_dispatch else 100,
             task_progress=RESTORE_ESTIMATE_END,
             current_step="restore",
         )
@@ -2135,7 +2160,7 @@ def _dispatch_restore_items(
         append_restore_execution_started_event(
             task=task,
             record=record,
-            items=items,
+            items=all_items,
         )
         logger.info(
             "restore dispatch ok restore_record_id=%s task_uuid=%s item_count=%s target_node_id=%s",
@@ -2155,8 +2180,14 @@ def _dispatch_restore_items(
             correlation_id=str(record.task_uuid),
             restore_record_id=record.id,
         )
+        # Seal only work that never received a NodeTask. A later bounded batch
+        # can fail while sibling items are still running; those Agent tasks
+        # keep their existing terminal projection path and resource leases.
         RestoreRecordItem.objects.filter(
-            restore_record=record, status=RestoreRecordItem.Status.RUNNING
+            restore_record=record,
+            id__in=[item.id for item in items],
+            node_task_id__isnull=True,
+            status=RestoreRecordItem.Status.RUNNING,
         ).update(
             status=RestoreRecordItem.Status.FAILED,
             error_code="RESTORE_DISPATCH_FAILED",
@@ -2174,6 +2205,19 @@ def _dispatch_restore_items(
                 error_message=(
                     "A previous Chat workspace restore item did not complete."
                 ),
+                terminal_projection_at=timezone.now(),
+            )
+        else:
+            # Bounded user restores may still have undispatched items. They
+            # must not remain pending once dispatch can no longer continue.
+            RestoreRecordItem.objects.filter(
+                restore_record=record,
+                node_task_id__isnull=True,
+                status=RestoreRecordItem.Status.PENDING,
+            ).update(
+                status=RestoreRecordItem.Status.FAILED,
+                error_code="RESTORE_DISPATCH_FAILED",
+                error_message=error_message,
                 terminal_projection_at=timezone.now(),
             )
         append_task_step_event(
@@ -2195,6 +2239,22 @@ def _dispatch_restore_items(
             task_progress=RESTORE_ESTIMATE_END,
             current_step="dispatch_agent",
         )
+        has_active_dispatched_items = RestoreRecordItem.objects.filter(
+            restore_record=record,
+            node_task_id__isnull=False,
+            status__in=(
+                RestoreRecordItem.Status.PENDING,
+                RestoreRecordItem.Status.RUNNING,
+            ),
+        ).exists()
+        if has_active_dispatched_items:
+            logger.warning(
+                "restore dispatch failure finalization deferred "
+                "restore_record_id=%s task_uuid=%s reason=active_items",
+                record.id,
+                record.task_uuid,
+            )
+            return
         complete_task(
             task_uuid=task.task_uuid,
             organization_id=organization_id,

--- a/src/backend/apps/restore/services/reconciliation.py
+++ b/src/backend/apps/restore/services/reconciliation.py
@@ -7,11 +7,17 @@ import logging
 from django.db import transaction
 from django.db.models import CharField, Exists, OuterRef, Subquery
 from django.db.models.functions import Cast
+from django.utils import timezone
 
-from apps.node.models import NodeTask
+from apps.node.models import Node, NodeTask
+from apps.node.services.internal.task_offline_reconcile import is_node_offline_stale
 from apps.restore.models import RestoreRecord, RestoreRecordItem
+from apps.restore.services.restore_progress import sync_restore_record_progress
 from apps.restore.services.task_classification import normalize_restore_task_type
-from apps.restore.signals import sync_restore_record_from_node_task
+from apps.restore.signals import (
+    _finalize_record_if_done,
+    sync_restore_record_from_node_task,
+)
 from apps.task.constants import RESTORE_TASK_TYPES
 from apps.task.models import Task
 from apps.task.services.interface import TERMINAL_STATUSES
@@ -55,7 +61,7 @@ def reconcile_restore_node_task_projections(*, limit: int = 200) -> dict[str, in
     classified, classification_failed = _classify_terminal_legacy_insight_tasks(
         limit=batch_size
     )
-    _resume_stranded_insight_restore_items(limit=batch_size)
+    _resume_stranded_restore_items(limit=batch_size)
     return {
         "candidates": len(candidates),
         "replayed": replayed,
@@ -65,8 +71,8 @@ def reconcile_restore_node_task_projections(*, limit: int = 200) -> dict[str, in
     }
 
 
-def _resume_stranded_insight_restore_items(*, limit: int) -> None:
-    """Durably continue sequential Chat restores after callback/broker failure."""
+def _resume_stranded_restore_items(*, limit: int) -> None:
+    """Durably continue bounded restores after callback or worker failure."""
 
     from apps.restore.services.interface import _dispatch_restore_items
 
@@ -79,7 +85,6 @@ def _resume_stranded_insight_restore_items(*, limit: int) -> None:
     )
     record_ids = list(
         RestoreRecord.objects.filter(
-            purpose=RestoreRecord.Purpose.LENS_WORKSPACE,
             task_id__in=Subquery(active_task_ids),
             items__status__in=_ACTIVE_ITEM_STATUSES,
             items__node_task_id__isnull=True,
@@ -99,17 +104,22 @@ def _resume_stranded_insight_restore_items(*, limit: int) -> None:
                 if task is None:
                     continue
                 items = list(record.items.all())
-                if any(
-                    item.node_task_id is not None
+                active_items = [
+                    item
+                    for item in items
+                    if item.node_task_id is not None
                     and item.status
                     in (
                         RestoreRecordItem.Status.PENDING,
                         RestoreRecordItem.Status.RUNNING,
                     )
-                    for item in items
+                ]
+                if (
+                    record.purpose == RestoreRecord.Purpose.LENS_WORKSPACE
+                    and active_items
                 ):
                     continue
-                if any(
+                if record.purpose == RestoreRecord.Purpose.LENS_WORKSPACE and any(
                     item.status
                     in (
                         RestoreRecordItem.Status.FAILED,
@@ -119,6 +129,35 @@ def _resume_stranded_insight_restore_items(*, limit: int) -> None:
                     for item in items
                 ):
                     continue
+                execution_node = Node.objects.filter(
+                    pk=record.target_execution_node_id,
+                    organization_id=record.target_execution_organization_id,
+                    is_deleted=False,
+                ).first()
+                if execution_node is None or is_node_offline_stale(execution_node):
+                    error_code = (
+                        "RESTORE_EXECUTION_NODE_UNAVAILABLE"
+                        if execution_node is None
+                        else "AGENT_OFFLINE"
+                    )
+                    error_message = (
+                        "Restore execution node is no longer available."
+                        if execution_node is None
+                        else "Agent remained offline beyond the reconnect grace period."
+                    )
+                    RestoreRecordItem.objects.filter(
+                        restore_record=record,
+                        node_task_id__isnull=True,
+                        status__in=_ACTIVE_ITEM_STATUSES,
+                    ).update(
+                        status=RestoreRecordItem.Status.FAILED,
+                        error_code=error_code,
+                        error_message=error_message,
+                        terminal_projection_at=timezone.now(),
+                    )
+                    sync_restore_record_progress(record=record)
+                    _finalize_record_if_done(record=record, product_task=task)
+                    continue
                 _dispatch_restore_items(
                     organization_id=record.organization_id,
                     record=record,
@@ -126,7 +165,7 @@ def _resume_stranded_insight_restore_items(*, limit: int) -> None:
                 )
         except Exception:
             logger.exception(
-                "insight restore continuation reconciliation failed record_id=%s",
+                "restore continuation reconciliation failed record_id=%s",
                 record_id,
             )
 

--- a/src/backend/apps/restore/signals.py
+++ b/src/backend/apps/restore/signals.py
@@ -55,7 +55,7 @@ def _repository_server_failure_message(node_task: NodeTask) -> str:
     return message or "Restore repository server failed."
 
 
-def _continue_lens_workspace_restore(record_id: int) -> None:
+def _continue_restore_dispatch(record_id: int) -> None:
     """Best-effort fast path; periodic reconciliation is the durable fallback."""
 
     from apps.restore.services.interface import _dispatch_restore_items
@@ -78,9 +78,22 @@ def _continue_lens_workspace_restore(record_id: int) -> None:
             )
     except Exception:
         logger.exception(
-            "insight restore continuation dispatch failed record_id=%s",
+            "restore continuation dispatch failed record_id=%s",
             record_id,
         )
+
+
+def _node_task_failed_offline(node_task: NodeTask) -> bool:
+    if node_task.status not in {NodeTask.Status.FAILED, NodeTask.Status.TIMEOUT}:
+        return False
+    result = node_task.result if isinstance(node_task.result, dict) else {}
+    code = str(
+        result.get("error_code") or result.get("diagnostic_error_code") or ""
+    ).strip().upper()
+    if code in {"AGENT_OFFLINE", "AGENT_CONNECTION_UNSTABLE"}:
+        return True
+    message = str(node_task.last_error or "").strip().lower()
+    return "agent went offline" in message or "agent heartbeat expired" in message
 
 
 @receiver(post_save, sender=NodeTask)
@@ -162,18 +175,16 @@ def sync_restore_record_from_node_task(
             node_task=instance,
             product_task=product_task,
         )
-    if record.purpose == RestoreRecord.Purpose.LENS_WORKSPACE:
-        remaining = RestoreRecordItem.objects.filter(
-            restore_record=record,
-            node_task_id__isnull=True,
-            status=RestoreRecordItem.Status.PENDING,
-        )
-        if remaining.exists():
+    remaining = RestoreRecordItem.objects.filter(
+        restore_record=record,
+        node_task_id__isnull=True,
+        status=RestoreRecordItem.Status.PENDING,
+    )
+    if remaining.exists():
+        if record.purpose == RestoreRecord.Purpose.LENS_WORKSPACE:
             if instance.status == NodeTask.Status.SUCCESS:
                 transaction.on_commit(
-                    lambda record_id=record.id: _continue_lens_workspace_restore(
-                        record_id
-                    )
+                    lambda record_id=record.id: _continue_restore_dispatch(record_id)
                 )
             else:
                 remaining.update(
@@ -184,6 +195,17 @@ def sync_restore_record_from_node_task(
                     ),
                     terminal_projection_at=timezone.now(),
                 )
+        elif _node_task_failed_offline(instance):
+            remaining.update(
+                status=RestoreRecordItem.Status.FAILED,
+                error_code="AGENT_OFFLINE",
+                error_message="Agent remained offline beyond the reconnect grace period.",
+                terminal_projection_at=timezone.now(),
+            )
+        else:
+            transaction.on_commit(
+                lambda record_id=record.id: _continue_restore_dispatch(record_id)
+            )
     from apps.restore.services.restore_progress import sync_restore_record_progress
 
     sync_restore_record_progress(record=record)
@@ -450,6 +472,8 @@ def _restore_failure_details(
         )
     if "agent restarted before task completed" in lower:
         return "AGENT_RESTARTED", raw_message[:2000], remediation, diagnostic
+    if _node_task_failed_offline(node_task):
+        return "AGENT_OFFLINE", raw_message[:2000], remediation, diagnostic
     return (
         structured_code or "RESTORE_AGENT_FAILED",
         structured_message or raw_message[:2000],

--- a/src/backend/apps/restore/tests/test_reconciliation.py
+++ b/src/backend/apps/restore/tests/test_reconciliation.py
@@ -140,7 +140,7 @@ class RestoreProjectionReconciliationTests(SimpleTestCase):
             update_fields=["terminal_projection_at", "updated_at"]
         )
 
-    @patch("apps.restore.services.reconciliation._resume_stranded_insight_restore_items")
+    @patch("apps.restore.services.reconciliation._resume_stranded_restore_items")
     @patch("apps.restore.services.reconciliation.sync_restore_record_from_node_task")
     @patch(
         "apps.restore.services.reconciliation._classify_terminal_legacy_insight_tasks",
@@ -172,7 +172,7 @@ class RestoreProjectionReconciliationTests(SimpleTestCase):
         resume_insight.assert_called_once_with(limit=20)
         self.assertEqual(projector.call_args_list, [call(NodeTask, first)])
 
-    @patch("apps.restore.services.reconciliation._resume_stranded_insight_restore_items")
+    @patch("apps.restore.services.reconciliation._resume_stranded_restore_items")
     @patch("apps.restore.services.reconciliation.logger.exception")
     @patch(
         "apps.restore.services.reconciliation._classify_terminal_legacy_insight_tasks",
@@ -218,7 +218,7 @@ class RestoreProjectionReconciliationTests(SimpleTestCase):
         resume_insight.assert_called_once_with(limit=20)
         log_exception.assert_called_once()
 
-    @patch("apps.restore.services.reconciliation._resume_stranded_insight_restore_items")
+    @patch("apps.restore.services.reconciliation._resume_stranded_restore_items")
     @patch("apps.restore.services.reconciliation.logger.exception")
     @patch(
         "apps.restore.services.reconciliation._classify_terminal_legacy_insight_tasks",

--- a/src/backend/apps/restore/tests/test_restore_api.py
+++ b/src/backend/apps/restore/tests/test_restore_api.py
@@ -32,7 +32,10 @@ from apps.restore.models import (
     RestoreRecordItem,
 )
 from apps.restore.services import interface as restore_service
-from apps.restore.services.reconciliation import reconcile_restore_node_task_projections
+from apps.restore.services.reconciliation import (
+    _resume_stranded_restore_items,
+    reconcile_restore_node_task_projections,
+)
 from apps.restore.services.task_events import (
     RESTORE_EVENT_SCHEMA_KEY,
     RESTORE_EVENT_SCHEMA_VERSION,
@@ -175,6 +178,39 @@ class RestoreApiTests(TestCase):
                 }
             ],
         }
+
+    def _manual_restore_payload_with_directory_count(self, count: int):
+        snapshot_directories = [self.snapshot_dir]
+        for index in range(1, count):
+            config_directory = BackupConfigDirectory.objects.create(
+                organization_id=self.org.id,
+                backup_config=self.config,
+                path=f"/data-{index}",
+                path_type=BackupConfigDirectory.PathType.DIRECTORY,
+                sort_order=index,
+            )
+            snapshot_directories.append(
+                BackupSourceSnapshotDirectory.objects.create(
+                    organization_id=self.org.id,
+                    source_snapshot=self.snapshot,
+                    backup_config_id=self.config.id,
+                    backup_config_dir_id=config_directory.id,
+                    source_path=config_directory.path,
+                    path_type=BackupSourceSnapshotDirectory.PathType.DIRECTORY,
+                    repository_id=self.repository.id,
+                    kopia_snapshot_id=f"kopia-snapshot-{index + 1}",
+                    status=BackupSourceSnapshotDirectory.Status.AVAILABLE,
+                )
+            )
+        payload = self._manual_restore_payload()
+        payload["items"] = [
+            {
+                "source_snapshot_directory_id": directory.id,
+                "selected_paths": [],
+            }
+            for directory in snapshot_directories
+        ]
+        return payload, snapshot_directories
 
     def _workspace_binding(self, gateway_link: LensGatewayLink):
         gateway = gateway_link.gateway
@@ -2570,6 +2606,142 @@ class RestoreApiTests(TestCase):
                 message="Restore item completed",
             ).count(),
             1,
+        )
+
+    @patch(
+        "apps.restore.services.interface.restore_conf.DIRECTORY_CONCURRENCY",
+        4,
+    )
+    def test_user_restore_dispatches_items_through_bounded_window(self):
+        payload, _snapshot_directories = (
+            self._manual_restore_payload_with_directory_count(6)
+        )
+
+        create = self.client.post(
+            "/api/v1/restore/records/",
+            payload,
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        record = RestoreRecord.objects.get(id=create.data["restore_record_id"])
+        node_tasks = NodeTask.objects.filter(
+            correlation_type="restore.record",
+            correlation_id=str(record.task_uuid),
+        )
+        self.assertEqual(node_tasks.count(), 4)
+        self.assertEqual(
+            record.items.filter(
+                status=RestoreRecordItem.Status.PENDING,
+                node_task_id__isnull=True,
+            ).count(),
+            2,
+        )
+        start_event = TaskEvent.objects.get(
+            task_id=record.task_id,
+            step__step_name="restore",
+            message="Restore execution started",
+        )
+        self.assertEqual(start_event.metadata["item_count"], 6)
+
+        first_task = node_tasks.order_by("created_at", "id").first()
+        self.assertIsNotNone(first_task)
+        first_task.status = NodeTask.Status.FAILED
+        first_task.result = {"error_code": "RESTORE_AGENT_FAILED"}
+        first_task.last_error = "one directory could not be restored"
+        with self.captureOnCommitCallbacks(execute=True):
+            first_task.save(
+                update_fields=["status", "result", "last_error", "updated_at"]
+            )
+
+        self.assertEqual(node_tasks.count(), 5)
+        self.assertEqual(
+            record.items.filter(status=RestoreRecordItem.Status.FAILED).count(),
+            1,
+        )
+        self.assertEqual(
+            record.items.filter(
+                status=RestoreRecordItem.Status.PENDING,
+                node_task_id__isnull=True,
+            ).count(),
+            1,
+        )
+        self.assertEqual(
+            TaskEvent.objects.filter(
+                task_id=record.task_id,
+                step__step_name="restore",
+                message="Restore execution started",
+            ).count(),
+            1,
+        )
+
+        with patch(
+            "apps.restore.services.reconciliation.is_node_offline_stale",
+            return_value=True,
+        ):
+            _resume_stranded_restore_items(limit=10)
+
+        stranded_item = record.items.get(node_task_id__isnull=True)
+        self.assertEqual(stranded_item.status, RestoreRecordItem.Status.FAILED)
+        self.assertEqual(stranded_item.error_code, "AGENT_OFFLINE")
+
+    @patch(
+        "apps.restore.services.interface.restore_conf.DIRECTORY_CONCURRENCY",
+        4,
+    )
+    def test_bounded_dispatch_failure_preserves_already_running_items(self):
+        payload, snapshot_directories = (
+            self._manual_restore_payload_with_directory_count(6)
+        )
+        create = self.client.post(
+            "/api/v1/restore/records/",
+            payload,
+            format="json",
+            **self._headers(),
+        )
+
+        self.assertEqual(create.status_code, status.HTTP_201_CREATED, create.content)
+        record = RestoreRecord.objects.get(id=create.data["restore_record_id"])
+        node_tasks = NodeTask.objects.filter(
+            correlation_type="restore.record",
+            correlation_id=str(record.task_uuid),
+        ).order_by("created_at", "id")
+        self.assertEqual(node_tasks.count(), 4)
+        snapshot_directories[4].delete()
+
+        first_task = node_tasks.first()
+        self.assertIsNotNone(first_task)
+        first_task.status = NodeTask.Status.FAILED
+        first_task.last_error = "one directory could not be restored"
+        with self.captureOnCommitCallbacks(execute=True):
+            first_task.save(update_fields=["status", "last_error", "updated_at"])
+
+        record.refresh_from_db()
+        task = Task.objects.get(pk=record.task_id)
+        self.assertEqual(task.status, Task.Status.RUNNING)
+        self.assertEqual(
+            record.items.filter(
+                node_task_id__isnull=False,
+                status=RestoreRecordItem.Status.RUNNING,
+            ).count(),
+            3,
+        )
+        self.assertEqual(
+            record.items.filter(status=RestoreRecordItem.Status.FAILED).count(),
+            3,
+        )
+
+        for node_task in node_tasks.exclude(pk=first_task.pk):
+            node_task.status = NodeTask.Status.SUCCESS
+            node_task.result = {"restore_outcome": "restored"}
+            node_task.save(update_fields=["status", "result", "updated_at"])
+
+        task.refresh_from_db()
+        self.assertEqual(task.status, Task.Status.FAILED)
+        self.assertEqual(
+            record.items.filter(status=RestoreRecordItem.Status.RUNNING).count(),
+            0,
         )
 
     def test_create_manual_restore_rejects_repository_being_removed(self):

--- a/src/backend/apps/storage/services/internal/repository_health.py
+++ b/src/backend/apps/storage/services/internal/repository_health.py
@@ -75,6 +75,12 @@ from apps.storage.services.internal.repository_usage import (
 logger = logging.getLogger(__name__)
 
 REPOSITORY_HEALTH_PROBE_CORRELATION_TYPE = "storage.repository_health"
+_PRIMARY_DATA_TASK_CORRELATIONS = frozenset(
+    {
+        "protection.backup",
+        "restore.record",
+    }
+)
 
 
 def repository_health_lock_key(repository_id: int) -> str:
@@ -86,6 +92,19 @@ class _AgentProbeState(StrEnum):
     ONLINE = "online"
     CONFIRMED_FAILURE = "confirmed_failure"
     TRANSPORT_UNKNOWN = "transport_unknown"
+
+
+def _nodes_with_primary_data_tasks(*, node_ids: list[int]) -> set[int]:
+    """Return nodes where automatic probing should yield to data work."""
+    if not node_ids:
+        return set()
+    return set(
+        NodeTask.objects.filter(
+            node_id__in=node_ids,
+            correlation_type__in=_PRIMARY_DATA_TASK_CORRELATIONS,
+            status__in=(NodeTask.Status.PENDING, NodeTask.Status.RUNNING),
+        ).values_list("node_id", flat=True)
+    )
 
 
 def is_repository_ownership_failure(exc: Exception) -> bool:
@@ -293,6 +312,8 @@ def _dispatch_automatic_repository_observation_locked(
             repository_subdir = ""
             repository_payload = proxy_fs_repository_payload(repository)
             legacy_location = repository_has_legacy_location(repository)
+        if _nodes_with_primary_data_tasks(node_ids=[node.id]):
+            return []
         legacy_adoption = bool(
             claim is not None
             and claim.ownership_verified_at is None
@@ -338,7 +359,19 @@ def _dispatch_automatic_repository_observation_locked(
         )
         return []
 
-    online_nodes = [node for node in nodes if node.availability == Node.Availability.ONLINE]
+    busy_node_ids = _nodes_with_primary_data_tasks(
+        node_ids=[int(node.id) for node in nodes]
+    )
+    if busy_node_ids:
+        # A direct NAS observation is one aggregate sample across all of its
+        # execution nodes.  Defer the whole automatic sample so a busy node is
+        # not misclassified as offline or omitted from the expected shard set.
+        return []
+    online_nodes = [
+        node
+        for node in nodes
+        if node.availability == Node.Availability.ONLINE
+    ]
     expected_node_ids = [int(node.id) for node in online_nodes]
 
     from apps.storage.services.internal.repository_usage import (

--- a/src/backend/apps/storage/tests/test_repository_health_tasks.py
+++ b/src/backend/apps/storage/tests/test_repository_health_tasks.py
@@ -1221,6 +1221,30 @@ class AutomaticDirectNASObservationTests(TestCase):
     @mock.patch(
         "apps.storage.services.internal.repository_health.run_agent_task_async"
     )
+    def test_active_restore_defers_entire_automatic_observation(self, run_async):
+        node = self._node("busy-restore-agent")
+        self._node("idle-restore-agent")
+        NodeTask.objects.create(
+            organization=self.organization,
+            node=node,
+            kind="restore.run",
+            correlation_type="restore.record",
+            correlation_id="active-restore",
+            status=NodeTask.Status.RUNNING,
+            watchdog_deadline_at=timezone.now() + timedelta(minutes=5),
+        )
+
+        tasks = dispatch_automatic_repository_observation(
+            repository=self.repository,
+            include_usage=True,
+        )
+
+        self.assertEqual(tasks, [])
+        run_async.assert_not_called()
+
+    @mock.patch(
+        "apps.storage.services.internal.repository_health.run_agent_task_async"
+    )
     def test_removing_repository_does_not_dispatch_a_late_observation(self, run_async):
         self._node("removing-repository-agent")
         Repository.objects.filter(pk=self.repository.id).update(


### PR DESCRIPTION
## Summary

- retain active Agent tasks while nodes pass through the reconnect grace period
- add configurable bounded restore concurrency and renewable restore activity leases
- refill pending restore work safely while preserving cancellation and Lens workspace sequencing
- defer automatic repository observations while backup or restore data work is active

## Compatibility

- no Agent, protocol, frontend, schema, or migration changes
- compatible with deployed v0.2.12 Agents through the existing task.alive heartbeat

## Validation

- 269 affected backend tests passed
- Ruff checks passed
- Python compile checks passed
- git diff checks passed