### PR TITLE
Show newest source hosts first

### DIFF
--- a/src/backend/apps/node/api/views/node.py
+++ b/src/backend/apps/node/api/views/node.py
@@ -186,6 +186,8 @@ class NodeViewSet(OrgScopedMixin, SoftDeleteDestroyMixin, viewsets.ModelViewSet)
         status = (self.request.query_params.get("status") or "").strip()
         if status:
             queryset = queryset.filter(status=status)
+        if role == NodeRole.AGENT:
+            return queryset.order_by("-created_at", "-id")
         return queryset.order_by("name", "id")
 
     def _build_enrichments(self, nodes) -> dict[int, dict]:

--- a/src/backend/apps/node/tests/test_node_list_pagination.py
+++ b/src/backend/apps/node/tests/test_node_list_pagination.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -24,12 +27,16 @@ class NodeListPaginationTests(APITestCase):
         )
         self.org, _ = provision_registered_user_tenant(self.user)
         self.client.force_authenticate(user=self.user)
+        registered_at = timezone.now() - timedelta(days=1)
         for idx in range(35):
-            Node.objects.create(
+            node = Node.objects.create(
                 organization=self.org,
                 name=f"agent-{idx:02d}",
                 role=NodeRole.AGENT,
                 ip_address=f"10.0.0.{idx + 1}",
+            )
+            Node.objects.filter(pk=node.pk).update(
+                created_at=registered_at + timedelta(minutes=idx)
             )
 
     def test_list_without_page_size_returns_all(self):
@@ -41,6 +48,8 @@ class NodeListPaginationTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsInstance(response.data, list)
         self.assertEqual(len(response.data), 35)
+        self.assertEqual(response.data[0]["name"], "agent-34")
+        self.assertEqual(response.data[-1]["name"], "agent-00")
 
     def test_list_with_page_size_returns_paginated_payload(self):
         response = self.client.get(
@@ -51,6 +60,7 @@ class NodeListPaginationTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 35)
         self.assertEqual(len(response.data["results"]), 30)
+        self.assertEqual(response.data["results"][0]["name"], "agent-34")
         self.assertEqual(response.data["results"][0]["availability"], "offline")
         self.assertIsNotNone(
             response.data["results"][0]["availability_updated_at"]
@@ -63,6 +73,50 @@ class NodeListPaginationTests(APITestCase):
         )
         self.assertEqual(page_two.status_code, status.HTTP_200_OK)
         self.assertEqual(len(page_two.data["results"]), 5)
+        self.assertEqual(page_two.data["results"][-1]["name"], "agent-00")
+
+    def test_list_uses_descending_id_to_break_registration_time_ties(self):
+        tied_nodes = list(Node.objects.filter(organization=self.org).order_by("id")[:2])
+        tied_at = timezone.now() + timedelta(days=1)
+        Node.objects.filter(id__in=[node.id for node in tied_nodes]).update(
+            created_at=tied_at
+        )
+
+        response = self.client.get(
+            reverse("node-list"),
+            {"role": "agent", "page": 1, "page_size": 30},
+            HTTP_X_ORG_KEY=self.org.key,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            [row["id"] for row in response.data["results"][:2]],
+            sorted((node.id for node in tied_nodes), reverse=True),
+        )
+
+    def test_source_host_order_does_not_change_other_node_roles(self):
+        Node.objects.create(
+            organization=self.org,
+            name="proxy-z",
+            role=NodeRole.PROXY,
+        )
+        Node.objects.create(
+            organization=self.org,
+            name="proxy-a",
+            role=NodeRole.PROXY,
+        )
+
+        response = self.client.get(
+            reverse("node-list"),
+            {"role": "proxy", "page": 1, "page_size": 30},
+            HTTP_X_ORG_KEY=self.org.key,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            [row["name"] for row in response.data["results"]],
+            ["proxy-a", "proxy-z"],
+        )
 
     def test_list_search_filters_by_name(self):
         response = self.client.get(
@@ -90,3 +144,4 @@ class NodeListPaginationTests(APITestCase):
         )
         self.assertEqual(by_ip.status_code, status.HTTP_200_OK)
         self.assertEqual(by_ip.data["count"], 11)
+        self.assertEqual(by_ip.data["results"][0]["name"], "agent-18")


### PR DESCRIPTION
## Summary

- order Source Host node results by registration time descending
- use descending node ID as a deterministic pagination tie-breaker
- preserve the existing default order for Proxy, Gateway, and unfiltered node lists
- cover paginated, unpaginated, searched, and equal-timestamp results

## Testing

- `docker compose exec -e SECURE_SSL_REDIRECT=false -e HFL_EXTENSIONS= api python manage.py test apps.node.tests.test_node_list_pagination` (6 tests passed)
- `git diff --check origin/main...HEAD`
- Full `apps.node.tests` run: all executable tests passed; 3 unrelated modules could not import because the runtime container does not include the dev-only `pytest` dependency

Closes #1130
