### PR TITLE
Fix Windows uninstall callback TLS negotiation

### DIFF
--- a/src/agent/internal/platform/install/local_uninstall_windows.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows.go
@@ -163,6 +163,7 @@ function Stop-Or-ContinueAfterFailure {
 }
 
 function Report-UninstallCompletion {
+  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
   if ($callbackInsecureTls) {
     [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
   }

--- a/src/agent/internal/platform/install/local_uninstall_windows_test.go
+++ b/src/agent/internal/platform/install/local_uninstall_windows_test.go
@@ -58,6 +58,7 @@ func TestWriteWindowsUninstallScriptUsesUninstallLogAndInstallPs1(t *testing.T) 
 		`Stop-Or-ContinueAfterFailure`,
 		`Force Cleanup will continue with the remaining physical cleanup steps`,
 		`Report-UninstallCompletion`,
+		`[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12`,
 		`cleanup_failures = @($cleanupFailures)`,
 		`retained_resources = @($retainedResources)`,
 		`foreach ($attempt in 1..6)`,
@@ -110,6 +111,16 @@ func TestWriteWindowsUninstallScriptUsesUninstallLogAndInstallPs1(t *testing.T) 
 		`Confirm-UninstallArtifacts -InstallDir $install`,
 		`Remove-AgentDataDirectory -DataDir $data`,
 		`Report-UninstallCompletion`,
+	)
+	completionCallback := substringBetween(
+		t,
+		body,
+		"function Report-UninstallCompletion",
+		"function Start-DeferredRemove",
+	)
+	assertOrdered(t, completionCallback,
+		`[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12`,
+		`Invoke-RestMethod -Method Post`,
 	)
 	assertPowerShellParses(t, path)
 	assertPowerShellDataPathSafety(t, dir, body)


### PR DESCRIPTION
## Summary

- enable TLS 1.2 for the detached Windows uninstall completion callback
- preserve the existing signed callback, certificate validation, retry, and timeout behavior
- verify the TLS setting remains scoped to the completion callback and precedes the HTTP request

## Root cause

Windows PowerShell 5.1 on Windows Server 2016 can default to legacy TLS protocols, causing the uninstall completion callback to fail against controllers that require TLS 1.2 even though physical Agent removal succeeds.

## Validation

- Agent install package tests
- Go vet
- Windows AMD64 Agent cross-build
- PowerShell script ordering and syntax checks
- Windows Server 2016 TLS transport verification

Fixes #1078