### PR TITLE
Remove installation images during uninstall

### DIFF
--- a/deploy/installer/install.sh
+++ b/deploy/installer/install.sh
@@ -32,7 +32,10 @@ SESSION_ACTION="operation"
 INTERACTIVE_SESSION=0
 declare -a SESSION_WARNINGS=()
 declare -a OWNED_INSTALLATION_CONTAINER_IDS=()
+declare -a RETAINED_INSTALLATION_IMAGES=()
 MANAGED_BRIDGE_NETWORK_REMOVED=0
+INSTALLATION_IMAGES_REMOVED=0
+INSTALLATION_IMAGES_RETAINED=0
 PUBLIC_HOST="${HFL_PUBLIC_HOST:-}"
 PUBLIC_URL="${HFL_PUBLIC_URL:-}"
 ADMIN_PUBLIC_URL="${HFL_ADMIN_PUBLIC_URL:-}"
@@ -3656,64 +3659,274 @@ cleanup_upgrade_tmp() {
 	fi
 }
 
-remove_manifest_images() {
+remove_installation_images() {
+	local include_hfl=${1:-1} include_sourcelens=${2:-1} output="" status label detail
+	INSTALLATION_IMAGES_REMOVED=0
+	INSTALLATION_IMAGES_RETAINED=0
+	RETAINED_INSTALLATION_IMAGES=()
 	[[ -f "${ROOT}/MANIFEST.json" ]] || return 0
-	step "Removing application Docker images..."
-	python3 - "${ROOT}" <<'PY'
+	step "Removing installation Docker images ..."
+	if ! output="$(python3 - "${ROOT}/MANIFEST.json" \
+		"${include_hfl}" "${include_sourcelens}" <<'PY'
 import json
 import subprocess
 import sys
-with open(f"{sys.argv[1]}/MANIFEST.json", encoding="utf-8") as fh:
+
+with open(sys.argv[1], encoding="utf-8") as fh:
     manifest = json.load(fh)
-seen = set()
+include_hfl = sys.argv[2] == "1"
+include_sourcelens = sys.argv[3] == "1"
 
 
-def installer_owned_ref(ref):
-    repository = ref.split("@", 1)[0].rsplit(":", 1)[0]
-    name = repository.rsplit("/", 1)[-1]
-    return name.startswith("hyperfilelens-")
+def selected(role):
+    normalized = str(role or "")
+    if normalized == "shared":
+        return include_hfl and include_sourcelens
+    is_sourcelens = normalized.startswith("sourcelens")
+    return include_sourcelens if is_sourcelens else include_hfl
 
 
-entries = list(manifest.get("images", []))
-entries.extend(
-    {"refs": [entry.get("local_ref", "")]}
-    for entry in (manifest.get("delivery") or {}).get("asset_images", [])
+def repository(ref):
+    value = str(ref or "").split("@", 1)[0]
+    slash = value.rfind("/")
+    colon = value.rfind(":")
+    return value[:colon] if colon > slash else value
+
+
+def inspect(ref):
+    completed = subprocess.run(
+        ["docker", "image", "inspect", ref],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or "").strip()
+        missing = detail.lower()
+        if "no such image" in missing or "no such object" in missing:
+            return None
+        raise SystemExit(
+            f"could not inspect Docker image {ref}: "
+            f"{detail or 'unknown Docker error'}"
+        )
+    try:
+        value = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"Docker returned invalid image metadata for {ref}: {error}")
+    if not isinstance(value, list) or len(value) != 1 or not isinstance(value[0], dict):
+        raise SystemExit(f"Docker returned incomplete image metadata for {ref}")
+    return value[0]
+
+
+def image_id(value):
+    raw = str(value or "")
+    return raw[7:] if raw.startswith("sha256:") else raw
+
+
+def has_digest(image, digest):
+    return any(
+        str(item).rsplit("@", 1)[-1] == digest
+        for item in image.get("RepoDigests") or []
+    )
+
+
+docker_ready = subprocess.run(
+    ["docker", "info"],
+    check=False,
+    stdout=subprocess.DEVNULL,
+    stderr=subprocess.DEVNULL,
 )
-for entry in entries:
-    if str(entry.get("role", "")).startswith("sourcelens"):
+if docker_ready.returncode != 0:
+    raise SystemExit("Docker is unavailable while resolving installation images")
+
+
+records = []
+delivery_refs = set()
+delivery = manifest.get("delivery") or {}
+for group in ("registry_images", "asset_images"):
+    for entry in delivery.get(group) or []:
+        local_ref = str(entry.get("local_ref") or "")
+        if not local_ref or not selected(entry.get("role")):
+            continue
+        records.append(
+            {
+                "label": local_ref,
+                "local_ref": local_ref,
+                "digest": str(entry.get("digest") or ""),
+                "sources": [
+                    str(source.get("ref") or "")
+                    for source in entry.get("sources") or []
+                    if source.get("ref")
+                ],
+            }
+        )
+        delivery_refs.add(local_ref)
+
+for entry in manifest.get("images") or []:
+    if not selected(entry.get("role")):
         continue
-    for ref in entry.get("refs", []):
-        tag = ref.split("@", 1)[0]
-        # Upstream and Docker Library tags are shared host caches rather than
-        # installer-owned artifacts. Removing them could disrupt unrelated
-        # containers on the same host, so only clean HFL-owned image names.
-        if not tag or not installer_owned_ref(tag):
+    for ref in entry.get("refs") or []:
+        value = str(ref or "")
+        if value and value not in delivery_refs:
+            records.append(
+                {"label": value, "local_ref": value, "digest": "", "sources": []}
+            )
+
+groups = {}
+for record in records:
+    immutable_refs = []
+    digest = record["digest"]
+    if digest.startswith("sha256:"):
+        immutable_refs = [
+            f"{repository(source)}@{digest}" for source in record["sources"]
+        ]
+    anchor_refs = [record["local_ref"], *immutable_refs]
+    anchors = {}
+    for ref in anchor_refs:
+        value = inspect(ref)
+        if value and (
+            ref != record["local_ref"]
+            or not digest.startswith("sha256:")
+            or has_digest(value, digest)
+        ):
+            anchors[ref] = image_id(value.get("Id"))
+
+    # A mutable source tag is eligible only when it still identifies the same
+    # immutable image as the installed local tag or declared digest.
+    for source in record["sources"]:
+        value = inspect(source)
+        if not value:
             continue
-        if tag in seen:
+        current_id = image_id(value.get("Id"))
+        digest_matches = has_digest(value, digest)
+        if digest_matches or (
+            not digest.startswith("sha256:") and current_id in anchors.values()
+        ):
+            anchors[source] = current_id
+
+    for ref, current_id in anchors.items():
+        if not current_id:
             continue
-        seen.add(tag)
-        print(f"[install.sh] removing image {tag}")
-        image_ids = subprocess.run(
-            ["docker", "image", "ls", "--quiet", "--no-trunc", tag],
-            stdout=subprocess.PIPE,
+        group = groups.setdefault(current_id, {"labels": set(), "refs": set()})
+        group["labels"].add(record["label"])
+        group["refs"].add(ref)
+
+containers = subprocess.run(
+    ["docker", "ps", "-aq", "--no-trunc"],
+    check=False,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.DEVNULL,
+)
+if containers.returncode != 0:
+    raise SystemExit("Docker containers could not be enumerated safely")
+users = {}
+for container_id in containers.stdout.split():
+    completed = subprocess.run(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            "{{.Image}}\t{{.Name}}",
+            container_id,
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        raise SystemExit(
+            f"Docker container {container_id[:12]} could not be inspected safely"
+        )
+    raw_id, _, raw_name = completed.stdout.strip().partition("\t")
+    current_id = image_id(raw_id)
+    name = raw_name.lstrip("/") or container_id[:12]
+    users.setdefault(current_id, []).append(f"{name} ({container_id[:12]})")
+
+for current_id, group in sorted(groups.items(), key=lambda item: sorted(item[1]["labels"])):
+    label = ", ".join(sorted(group["labels"]))
+    if users.get(current_id):
+        print(
+            f"RETAINED\t{label}\tused by container(s): "
+            + ", ".join(sorted(users[current_id]))
+        )
+        continue
+
+    for ref in sorted(group["refs"]):
+        if not inspect(ref):
+            continue
+        removed = subprocess.run(
+            ["docker", "image", "rm", ref],
+            check=False,
             text=True,
-            check=True,
-        ).stdout.split()
-        if not image_ids:
-            print(f"[install.sh] image not present: {tag}")
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        if removed.returncode != 0 and inspect(ref):
+            detail = (removed.stderr or "").strip().splitlines()
+            reason = detail[-1] if detail else "unknown Docker error"
+            raise SystemExit(f"could not remove Docker image reference {ref}: {reason}")
+
+    remaining = inspect(f"sha256:{current_id}") or inspect(current_id)
+    if remaining:
+        remaining_refs = sorted(
+            str(ref)
+            for ref in [
+                *(remaining.get("RepoTags") or []),
+                *(remaining.get("RepoDigests") or []),
+            ]
+            if ref
+        )
+        if remaining_refs:
+            print(
+                f"RETAINED\t{label}\tshared by other image reference(s): "
+                + ", ".join(remaining_refs)
+            )
             continue
-        removed = subprocess.run(["docker", "image", "rm", "-f", tag], check=False)
-        if removed.returncode != 0:
-            remaining = subprocess.run(
-                ["docker", "image", "ls", "--quiet", "--no-trunc", tag],
-                stdout=subprocess.PIPE,
-                text=True,
-                check=True,
-            ).stdout.split()
-            if remaining:
-                raise SystemExit(f"failed to remove image: {tag}")
-            print(f"[install.sh] image was already removed: {tag}")
+        removed = subprocess.run(
+            ["docker", "image", "rm", f"sha256:{current_id}"],
+            check=False,
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        if removed.returncode != 0 and (inspect(f"sha256:{current_id}") or inspect(current_id)):
+            detail = (removed.stderr or "").strip().splitlines()
+            reason = detail[-1] if detail else "unknown Docker error"
+            raise SystemExit(
+                f"could not remove untagged Docker image sha256:{current_id}: {reason}"
+            )
+    print(f"REMOVED\t{label}\tinstallation image references removed")
 PY
+	)"; then
+		warn "Installation Docker image cleanup could not be completed; remaining images were retained"
+		return 1
+	fi
+	while IFS=$'\t' read -r status label detail; do
+		[[ -n "${status}" ]] || continue
+		case "${status}" in
+		REMOVED)
+			INSTALLATION_IMAGES_REMOVED=$((INSTALLATION_IMAGES_REMOVED + 1))
+			debug "Removed installation Docker image ${label}"
+			;;
+		RETAINED)
+			INSTALLATION_IMAGES_RETAINED=$((INSTALLATION_IMAGES_RETAINED + 1))
+			RETAINED_INSTALLATION_IMAGES+=("${label}: ${detail}")
+			warn "Retained Docker image ${label}; ${detail}"
+			;;
+		esac
+	done <<<"${output}"
+	if [[ "${INSTALLATION_IMAGES_RETAINED}" -eq 0 ]]; then
+		if [[ "${INSTALLATION_IMAGES_REMOVED}" -eq 0 ]]; then
+			ok "No installation Docker images were present"
+		else
+			ok "All ${INSTALLATION_IMAGES_REMOVED} installation Docker images were removed"
+		fi
+	else
+		log "Docker image cleanup: ${INSTALLATION_IMAGES_REMOVED} removed; ${INSTALLATION_IMAGES_RETAINED} retained"
+	fi
 }
 
 uninstall_hfl_runtime() {
@@ -3732,7 +3945,6 @@ uninstall_hfl_runtime() {
 	fi
 	remove_owned_installation_containers "HyperFileLens" hyperfilelens
 	remove_empty_owned_compose_networks hyperfilelens
-	remove_manifest_images || return 1
 }
 
 version_lt() {
@@ -4300,60 +4512,8 @@ stop_bundled_sourcelens() {
 }
 
 remove_sourcelens_images() {
-	local manifest="${ROOT}/MANIFEST.json"
-	[[ -f "${manifest}" ]] || return 0
-	step "Removing SourceLens Docker images ..."
-	python3 - "${manifest}" <<'PY'
-import json
-import subprocess
-import sys
-
-with open(sys.argv[1], encoding="utf-8") as fh:
-    manifest = json.load(fh)
-seen = set()
-
-
-def installer_owned_ref(ref):
-    repository = ref.split("@", 1)[0].rsplit(":", 1)[0]
-    name = repository.rsplit("/", 1)[-1]
-    return name.startswith("hyperfilelens-")
-
-
-for entry in manifest.get("images", []):
-    role = entry.get("role", "")
-    if not role.startswith("sourcelens"):
-        continue
-    for ref in entry.get("refs", []):
-        tag = ref.split("@", 1)[0]
-        # New registry-backed releases use the upstream SourceLens and Docker
-        # Library names directly. Those shared tags are not owned by HFL.
-        if not installer_owned_ref(tag):
-            continue
-        if tag in seen:
-            continue
-        seen.add(tag)
-        print(f"[install.sh] removing SourceLens image {tag}")
-        image_ids = subprocess.run(
-            ["docker", "image", "ls", "--quiet", "--no-trunc", tag],
-            stdout=subprocess.PIPE,
-            text=True,
-            check=True,
-        ).stdout.split()
-        if not image_ids:
-            print(f"[install.sh] SourceLens image not present: {tag}")
-            continue
-        removed = subprocess.run(["docker", "image", "rm", "-f", tag], check=False)
-        if removed.returncode != 0:
-            remaining = subprocess.run(
-                ["docker", "image", "ls", "--quiet", "--no-trunc", tag],
-                stdout=subprocess.PIPE,
-                text=True,
-                check=True,
-            ).stdout.split()
-            if remaining:
-                raise SystemExit(f"failed to remove SourceLens image: {tag}")
-            print(f"[install.sh] SourceLens image was already removed: {tag}")
-PY
+	remove_installation_images 0 1 \
+		|| die "SourceLens Docker image cleanup could not be verified"
 }
 
 purge_sourcelens_data_dir() {
@@ -4386,7 +4546,6 @@ uninstall_bundled_sourcelens() {
 	fi
 	remove_owned_installation_containers "SourceLens" hyperfilelens-sourcelens sourcelens
 	remove_empty_owned_compose_networks hyperfilelens-sourcelens sourcelens
-	remove_sourcelens_images || return 1
 	if [[ "${purge_data}" -eq 1 ]]; then
 		purge_sourcelens_data_dir || return 1
 	fi
@@ -6991,7 +7150,7 @@ cmd_uninstall() {
 	fi
 	print_section "Removal plan"
 	print_value "Containers" "remove"
-	print_value "App images" "remove"
+	print_value "Docker images" "remove when not used by other containers"
 	if [[ "${full_runtime}" -eq 1 ]]; then
 		print_value "Shared network" "remove when installer-managed and unused"
 	else
@@ -7040,23 +7199,27 @@ cmd_uninstall() {
 		platform_gateway_removed=1
 	fi
 
+	if ! uninstall_hfl_runtime; then
+		die "HyperFileLens runtime uninstall did not complete; application data was preserved"
+	fi
+	runtime_removed=1
 	if [[ "${with_sourcelens}" -eq 1 ]]; then
-		if ! uninstall_bundled_sourcelens "${purge_sourcelens_data}"; then
+		if ! uninstall_bundled_sourcelens 0; then
 			die "SourceLens uninstall did not complete; HyperFileLens data was preserved"
 		fi
 		if [[ "${sourcelens_present}" -eq 1 ]]; then
 			sourcelens_removed=1
 		fi
-		[[ "${purge_sourcelens_data}" -eq 0 || "${sourcelens_data_present}" -eq 0 ]] \
-			|| sourcelens_data_removed=1
 	fi
-	if ! uninstall_hfl_runtime; then
-		die "HyperFileLens runtime uninstall did not complete; application data was preserved"
-	fi
-	runtime_removed=1
 	if [[ "${full_runtime}" -eq 1 ]]; then
 		remove_managed_bridge_network
 		bridge_network_removed="${MANAGED_BRIDGE_NETWORK_REMOVED}"
+	fi
+	remove_installation_images 1 "${with_sourcelens}" \
+		|| die "Docker image cleanup could not be verified; configuration and data were preserved"
+	if [[ "${purge_sourcelens_data}" -eq 1 && "${purge_data}" -eq 0 ]]; then
+		purge_sourcelens_data_dir
+		[[ "${sourcelens_data_present}" -eq 0 ]] || sourcelens_data_removed=1
 	fi
 
 	if [[ "${purge_media}" -eq 1 ]]; then
@@ -7105,9 +7268,11 @@ cmd_uninstall() {
 		|| "${application_files_removed}" -eq 1 || "${install_root_removed}" -eq 1 ]]; then
 		print_section "Removed"
 		[[ "${platform_gateway_removed}" -eq 0 ]] || print_value "Platform Data Gateway" "local Agent, AI engine, and data"
-		[[ "${runtime_removed}" -eq 0 ]] || print_value "Runtime" "HyperFileLens containers, application images, and Compose networks"
+		[[ "${runtime_removed}" -eq 0 ]] || print_value "Runtime" "HyperFileLens containers and Compose networks"
 		[[ "${bridge_network_removed}" -eq 0 ]] || print_value "Shared network" "${HFL_BRIDGE_NETWORK}"
-		[[ "${sourcelens_removed}" -eq 0 ]] || print_value "Insight" "application containers and images"
+		[[ "${sourcelens_removed}" -eq 0 ]] || print_value "Insight" "application containers"
+		[[ "${INSTALLATION_IMAGES_REMOVED}" -eq 0 ]] \
+			|| print_value "Docker images" "${INSTALLATION_IMAGES_REMOVED} installation image(s)"
 		if [[ "${install_root_removed}" -eq 1 ]]; then
 			print_value "Installation root" "${ROOT} (including configuration, data, backups, and logs)"
 		else
@@ -7154,6 +7319,9 @@ cmd_uninstall() {
 	if [[ "${session_log_removed}" -eq 0 ]]; then
 		print_value "Log file" "${LOG_FILE}"
 	fi
+	for retained_image in "${RETAINED_INSTALLATION_IMAGES[@]}"; do
+		print_value "Docker image" "${retained_image}"
+	done
 
 	print_section "Notes"
 	printf '  - Host Docker CE is not removed by HyperFileLens uninstall.\n'

--- a/tools/quality/test-release-purge-all.sh
+++ b/tools/quality/test-release-purge-all.sh
@@ -123,8 +123,9 @@ fi
 	sourcelens_runtime_present
 )
 
-# Uninstall removes historical HFL aliases but preserves upstream and Docker
-# Library image tags, which may be shared by unrelated workloads on the host.
+# Installation image cleanup removes every exact manifest reference after all
+# managed containers are gone. Images used by any running or stopped foreign
+# container, and layers with unrelated tags, are retained without force.
 (
 	set -euo pipefail
 	source "${REPO_ROOT}/deploy/installer/install.sh"
@@ -138,36 +139,303 @@ fi
     {"role": "sourcelens-backend", "refs": ["oneprolabs/sourcelens-backend:0.49.5"]},
     {"role": "sourcelens-nginx", "refs": ["nginx:stable-alpine"]},
     {"role": "sourcelens-frontend", "refs": ["hyperfilelens-sourcelens-frontend:legacy"]}
-  ]
+  ],
+  "delivery": {
+    "mode": "registry",
+    "registry_images": [
+      {
+        "role": "hyperfilelens",
+        "local_ref": "hyperfilelens-backend:1.0.0",
+        "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        "sources": [
+          {"region": "cn", "ref": "registry.example.cn/oneprolabs/hyperfilelens-backend:1.0.0"},
+          {"region": "global", "ref": "docker.io/oneprolabs/hyperfilelens-backend:1.0.0"}
+        ]
+      },
+      {
+        "role": "sourcelens-backend",
+        "local_ref": "oneprolabs/sourcelens-backend:0.49.5",
+        "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "sources": [
+          {"region": "cn", "ref": "registry.example.cn/oneprolabs/sourcelens-backend:0.49.5"},
+          {"region": "global", "ref": "docker.io/oneprolabs/sourcelens-backend:0.49.5"}
+        ]
+      },
+      {
+        "role": "shared",
+        "local_ref": "postgres:17",
+        "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "sources": [
+          {"region": "cn", "ref": "registry.example.cn/oneprolabs/postgres:17-pinned"},
+          {"region": "global", "ref": "docker.io/oneprolabs/postgres:17-pinned"}
+        ]
+      },
+      {
+        "role": "shared",
+        "local_ref": "redis:alpine",
+        "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "sources": [
+          {"region": "cn", "ref": "registry.example.cn/oneprolabs/redis:alpine-pinned"},
+          {"region": "global", "ref": "docker.io/oneprolabs/redis:alpine-pinned"}
+        ]
+      },
+      {
+        "role": "sourcelens-nginx",
+        "local_ref": "nginx:stable-alpine",
+        "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+        "sources": [
+          {"region": "cn", "ref": "registry.example.cn/oneprolabs/nginx:stable-alpine-pinned"},
+          {"region": "global", "ref": "docker.io/oneprolabs/nginx:stable-alpine-pinned"}
+        ]
+      }
+    ],
+    "asset_images": [
+      {
+        "role": "language-assets",
+        "local_ref": "hyperfilelens-language-assets:1.0.0",
+        "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+        "sources": [
+          {"region": "cn", "ref": "registry.example.cn/oneprolabs/hyperfilelens-language-assets:1.0.0"},
+          {"region": "global", "ref": "docker.io/oneprolabs/hyperfilelens-language-assets:1.0.0"}
+        ]
+      },
+      {
+        "role": "gateway-assets",
+        "local_ref": "hyperfilelens-gateway-assets:1.0.0",
+        "digest": "sha256:7777777777777777777777777777777777777777777777777777777777777777",
+        "sources": [
+          {"region": "cn", "ref": "registry.example.cn/oneprolabs/hyperfilelens-gateway-assets:1.0.0"},
+          {"region": "global", "ref": "docker.io/oneprolabs/hyperfilelens-gateway-assets:1.0.0"}
+        ]
+      }
+    ]
+  }
 }
 JSON
-	removed="${fixture}/removed-image-tags"
-	: >"${removed}"
+	state="${fixture}/image-ownership-state.json"
+	warnings="${fixture}/image-ownership-warnings"
+	cat >"${state}" <<'JSON'
+{
+  "images": {
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {"refs": ["hyperfilelens-backend:1.0.0", "registry.example.cn/oneprolabs/hyperfilelens-backend:1.0.0", "registry.example.cn/oneprolabs/hyperfilelens-backend@sha256:1111111111111111111111111111111111111111111111111111111111111111"]},
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {"refs": ["oneprolabs/sourcelens-backend:0.49.5", "docker.io/oneprolabs/sourcelens-backend:0.49.5", "docker.io/oneprolabs/sourcelens-backend@sha256:2222222222222222222222222222222222222222222222222222222222222222"]},
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc": {"refs": ["postgres:17", "registry.example.cn/oneprolabs/postgres:17-pinned", "registry.example.cn/oneprolabs/postgres@sha256:3333333333333333333333333333333333333333333333333333333333333333"]},
+    "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd": {"refs": ["redis:alpine", "docker.io/oneprolabs/redis:alpine-pinned", "docker.io/oneprolabs/redis@sha256:4444444444444444444444444444444444444444444444444444444444444444"]},
+    "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {"refs": ["nginx:stable-alpine", "registry.example.cn/oneprolabs/nginx:stable-alpine-pinned", "registry.example.cn/oneprolabs/nginx@sha256:5555555555555555555555555555555555555555555555555555555555555555"]},
+    "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff": {"refs": ["hyperfilelens-language-assets:1.0.0", "docker.io/oneprolabs/hyperfilelens-language-assets:1.0.0", "docker.io/oneprolabs/hyperfilelens-language-assets@sha256:6666666666666666666666666666666666666666666666666666666666666666"]},
+    "1212121212121212121212121212121212121212121212121212121212121212": {"refs": ["hyperfilelens-sourcelens-frontend:legacy"]},
+    "7777777777777777777777777777777777777777777777777777777777777777": {"refs": ["hyperfilelens-gateway-assets:1.0.0", "registry.example.cn/oneprolabs/hyperfilelens-gateway-assets:1.0.0", "registry.example.cn/oneprolabs/hyperfilelens-gateway-assets@sha256:7777777777777777777777777777777777777777777777777777777777777777", "example/customer-gateway-cache:latest"]},
+    "9999999999999999999999999999999999999999999999999999999999999999": {"refs": ["example/unmanaged:latest"]}
+  },
+  "containers": {
+    "running-container-id": {"image": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "name": "customer-redis"},
+    "stopped-container-id": {"image": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "name": "customer-nginx"}
+  }
+}
+JSON
+	: >"${warnings}"
 	mkdir -p "${fixture}/image-ownership-bin"
-	cat >"${fixture}/image-ownership-bin/docker" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-case "$*" in
-"image ls --quiet --no-trunc hyperfilelens-backend:1.0.0") printf '%s\n' backend-id ;;
-"image ls --quiet --no-trunc hyperfilelens-sourcelens-frontend:legacy") printf '%s\n' sourcelens-id ;;
-"image rm -f hyperfilelens-backend:1.0.0") printf '%s\n' hyperfilelens-backend:1.0.0 >>"${HFL_TEST_REMOVED_TAGS}" ;;
-"image rm -f hyperfilelens-sourcelens-frontend:legacy") printf '%s\n' hyperfilelens-sourcelens-frontend:legacy >>"${HFL_TEST_REMOVED_TAGS}" ;;
-*) printf 'unexpected Docker image cleanup: %s\n' "$*" >&2; exit 90 ;;
-esac
-SH
+	cat >"${fixture}/image-ownership-bin/docker" <<'PY'
+#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+path = pathlib.Path(os.environ["HFL_TEST_DOCKER_STATE"])
+state = json.loads(path.read_text(encoding="utf-8"))
+args = sys.argv[1:]
+
+
+def save():
+    path.write_text(json.dumps(state), encoding="utf-8")
+
+
+def find_image(ref):
+    raw = ref[7:] if ref.startswith("sha256:") else ref
+    if raw in state["images"]:
+        return raw, state["images"][raw]
+    for image_id, image in state["images"].items():
+        if ref in image["refs"]:
+            return image_id, image
+    return None, None
+
+
+if args == ["info"]:
+    if os.environ.get("HFL_TEST_DOCKER_INFO_FAILURE") == "1":
+        raise SystemExit(1)
+elif args == ["ps", "-aq", "--no-trunc"]:
+    print("\n".join(state["containers"]))
+elif len(args) == 4 and args[:2] == ["inspect", "--format"]:
+    container = state["containers"].get(args[3])
+    if not container:
+        raise SystemExit(1)
+    print(f"sha256:{container['image']}\t/{container['name']}")
+elif len(args) == 3 and args[:2] == ["image", "inspect"]:
+    if (
+        os.environ.get("HFL_TEST_DOCKER_INSPECT_FAILURE") == "1"
+        and args[2] == "redis:alpine"
+    ):
+        print("Error response from daemon: temporary daemon failure", file=sys.stderr)
+        raise SystemExit(1)
+    image_id, image = find_image(args[2])
+    if not image:
+        print(f"Error response from daemon: No such image: {args[2]}", file=sys.stderr)
+        raise SystemExit(1)
+    tags = [ref for ref in image["refs"] if "@" not in ref]
+    digests = [ref for ref in image["refs"] if "@" in ref]
+    print(json.dumps([{"Id": f"sha256:{image_id}", "RepoTags": tags, "RepoDigests": digests}]))
+elif len(args) == 3 and args[:2] == ["image", "rm"]:
+    ref = args[2]
+    if ref == "-f":
+        raise SystemExit("forced image removal is forbidden")
+    if os.environ.get("HFL_TEST_DOCKER_RM_FAILURE") == "1":
+        print("Error response from daemon: temporary image removal failure", file=sys.stderr)
+        raise SystemExit(1)
+    image_id, image = find_image(ref)
+    if not image:
+        raise SystemExit(1)
+    if ref.startswith("sha256:") or ref == image_id:
+        if image["refs"]:
+            raise SystemExit("image still has references")
+        del state["images"][image_id]
+    else:
+        image["refs"].remove(ref)
+        if not image["refs"]:
+            del state["images"][image_id]
+    save()
+else:
+    raise SystemExit(f"unexpected Docker image cleanup: {' '.join(args)}")
+PY
 	chmod 755 "${fixture}/image-ownership-bin/docker"
-	export HFL_TEST_REMOVED_TAGS="${removed}"
+	export HFL_TEST_DOCKER_STATE="${state}"
 	export PATH="${fixture}/image-ownership-bin:${PATH}"
 	step() { :; }
-	remove_manifest_images
+	ok() { :; }
+	log() { :; }
+	debug() { :; }
+	warn() {
+		SESSION_WARNINGS+=("$*")
+		printf '%s\n' "$*" >>"${warnings}"
+	}
+	remove_installation_images 1 1
+	[[ "${INSTALLATION_IMAGES_REMOVED}" -eq 5 ]]
+	[[ "${INSTALLATION_IMAGES_RETAINED}" -eq 3 ]]
+	grep -F 'redis:alpine; used by container(s): customer-redis (running-cont)' \
+		"${warnings}" >/dev/null
+	grep -F 'nginx:stable-alpine; used by container(s): customer-nginx (stopped-cont)' \
+		"${warnings}" >/dev/null
+	grep -F 'hyperfilelens-gateway-assets:1.0.0; shared by other image reference(s): example/customer-gateway-cache:latest' \
+		"${warnings}" >/dev/null
+	python3 - "${state}" <<'PY'
+import json
+import pathlib
+import sys
+
+state = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert set(state["images"]) == {
+    "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+    "7777777777777777777777777777777777777777777777777777777777777777",
+    "9999999999999999999999999999999999999999999999999999999999999999",
+}
+gateway = state["images"]["7777777777777777777777777777777777777777777777777777777777777777"]
+assert gateway["refs"] == ["example/customer-gateway-cache:latest"]
+assert len(state["images"]["dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"]["refs"]) == 3
+assert len(state["images"]["eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"]["refs"]) == 3
+assert state["images"]["9999999999999999999999999999999999999999999999999999999999999999"]["refs"] == ["example/unmanaged:latest"]
+PY
+	export HFL_TEST_DOCKER_INSPECT_FAILURE=1
+	if remove_installation_images 1 1 >/dev/null 2>&1; then
+		printf 'Docker image inspection failure was accepted\n' >&2
+		exit 1
+	fi
+	unset HFL_TEST_DOCKER_INSPECT_FAILURE
+	python3 - "${state}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_text(
+    json.dumps(
+        {
+            "images": {
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+                    "refs": [
+                        "hyperfilelens-backend:1.0.0",
+                        "registry.example.cn/oneprolabs/hyperfilelens-backend:1.0.0",
+                        "registry.example.cn/oneprolabs/hyperfilelens-backend@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                    ]
+                },
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+                    "refs": [
+                        "oneprolabs/sourcelens-backend:0.49.5",
+                        "docker.io/oneprolabs/sourcelens-backend:0.49.5",
+                        "docker.io/oneprolabs/sourcelens-backend@sha256:2222222222222222222222222222222222222222222222222222222222222222",
+                    ]
+                },
+                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc": {
+                    "refs": [
+                        "postgres:17",
+                        "registry.example.cn/oneprolabs/postgres:17-pinned",
+                        "registry.example.cn/oneprolabs/postgres@sha256:3333333333333333333333333333333333333333333333333333333333333333",
+                    ]
+                }
+            },
+            "containers": {},
+        }
+    ),
+    encoding="utf-8",
+)
+PY
 	remove_sourcelens_images
-	mapfile -t removed_tags <"${removed}"
-	[[ "${removed_tags[*]}" == \
-		'hyperfilelens-backend:1.0.0 hyperfilelens-sourcelens-frontend:legacy' ]]
+	python3 - "${state}" <<'PY'
+import json
+import pathlib
+import sys
+
+state = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert set(state["images"]) == {
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+}
+PY
+	remove_installation_images 1 0
+	python3 - "${state}" <<'PY'
+import json
+import pathlib
+import sys
+
+state = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert set(state["images"]) == {
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}
+PY
+	export HFL_TEST_DOCKER_RM_FAILURE=1
+	if remove_installation_images 1 1 >/dev/null 2>&1; then
+		printf 'Docker image removal failure was accepted\n' >&2
+		exit 1
+	fi
+	unset HFL_TEST_DOCKER_RM_FAILURE
+	remove_installation_images 1 1
+	python3 - "${state}" <<'PY'
+import json
+import pathlib
+import sys
+
+state = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert not state["images"]
+PY
+	export HFL_TEST_DOCKER_INFO_FAILURE=1
+	if remove_installation_images 1 1 >/dev/null 2>&1; then
+		printf 'unverified Docker image cleanup was accepted\n' >&2
+		exit 1
+	fi
 )
 
 # The real SourceLens fallback must remove verified orphan containers before
-# images and data. Image cleanup failure must preserve data for retry.
+# its data. Container cleanup failure must preserve data for retry.
 run_sourcelens_component_contract() (
 	set -euo pipefail
 	source "${REPO_ROOT}/deploy/installer/install.sh"
@@ -177,12 +445,11 @@ run_sourcelens_component_contract() (
 	: >"${events}"
 	sourcelens_installed() { return 1; }
 	sourcelens_runtime_present() { return 0; }
-	remove_owned_installation_containers() { printf '%s\n' containers >>"${events}"; }
-	remove_empty_owned_compose_networks() { printf 'networks:%s\n' "$*" >>"${events}"; }
-	remove_sourcelens_images() {
-		printf '%s\n' images >>"${events}"
-		[[ "${scenario}" != image_failure ]]
+	remove_owned_installation_containers() {
+		printf '%s\n' containers >>"${events}"
+		[[ "${scenario}" != container_failure ]] || die "simulated container cleanup failure"
 	}
+	remove_empty_owned_compose_networks() { printf 'networks:%s\n' "$*" >>"${events}"; }
 	purge_sourcelens_data_dir() { printf '%s\n' data >>"${events}"; }
 	step() { :; }
 	warn() { :; }
@@ -192,13 +459,13 @@ run_sourcelens_component_contract() (
 
 run_sourcelens_component_contract orphan_success
 mapfile -t component_events <"${fixture}/component-events-orphan_success"
-[[ "${component_events[*]}" == 'containers networks:hyperfilelens-sourcelens sourcelens images data' ]]
-if run_sourcelens_component_contract image_failure >/dev/null 2>&1; then
-	printf 'SourceLens image cleanup failure was accepted\n' >&2
+[[ "${component_events[*]}" == 'containers networks:hyperfilelens-sourcelens sourcelens data' ]]
+if run_sourcelens_component_contract container_failure >/dev/null 2>&1; then
+	printf 'SourceLens container cleanup failure was accepted\n' >&2
 	exit 1
 fi
-mapfile -t image_failure_events <"${fixture}/component-events-image_failure"
-[[ "${image_failure_events[*]}" == 'containers networks:hyperfilelens-sourcelens sourcelens images' ]]
+mapfile -t container_failure_events <"${fixture}/component-events-container_failure"
+[[ "${container_failure_events[*]}" == 'containers' ]]
 
 # The shared bridge is removed only when HyperFileLens created it and no
 # containers remain attached. Foreign or still-used networks are retained.
@@ -300,10 +567,11 @@ if grep -F 'No such file or directory' "${complete_output}" >/dev/null; then
 	exit 1
 fi
 
-# Plain uninstall and --purge-all must remove the installer-owned Gateway first,
-# then bundled SourceLens, and only then stop the HFL control plane. --keep-data
-# removes the same runtimes while retaining persistent state. Explicit legacy
-# selection flags keep their narrower behavior.
+# Plain uninstall and --purge-all remove the installer-owned Gateway first,
+# then HFL and bundled SourceLens containers. Networks and images are cleaned
+# only after both application stacks are down. --keep-data removes the same
+# runtimes while retaining persistent state. Explicit legacy selection flags
+# keep their narrower behavior.
 run_uninstall_contract() (
 	set -euo pipefail
 	source "${REPO_ROOT}/deploy/installer/install.sh"
@@ -331,12 +599,15 @@ run_uninstall_contract() (
 	uninstall_hfl_runtime() {
 		printf '%s\n' hfl >>"${events}"
 		[[ "${scenario}" != hfl_failure ]] || return 1
-		printf '%s\n' images >>"${events}"
 	}
 	remove_managed_bridge_network() {
 		printf '%s\n' bridge >>"${events}"
 		[[ "${scenario}" != bridge_failure ]] || die "simulated shared network cleanup failure"
 		MANAGED_BRIDGE_NETWORK_REMOVED=1
+	}
+	remove_installation_images() {
+		printf 'images:%s:%s\n' "$1" "$2" >>"${events}"
+		[[ "${scenario}" != image_failure ]]
 	}
 	remove_complete_installation_root() { printf '%s\n' root >>"${events}"; }
 	remove_installation_files_preserving_data() { printf '%s\n' application-files >>"${events}"; }
@@ -357,31 +628,38 @@ run_uninstall_contract() (
 
 run_uninstall_contract managed
 mapfile -t default_events <"${fixture}/events-managed"
-[[ "${default_events[*]}" == 'gateway sourcelens:1 hfl images bridge data config root' ]]
+[[ "${default_events[*]}" == 'gateway hfl sourcelens:0 bridge images:1:1 data config root' ]]
 
 run_uninstall_contract purge --purge-all
 mapfile -t purge_events <"${fixture}/events-purge"
-[[ "${purge_events[*]}" == 'gateway sourcelens:1 hfl images bridge data config root' ]]
+[[ "${purge_events[*]}" == 'gateway hfl sourcelens:0 bridge images:1:1 data config root' ]]
 
 run_uninstall_contract keep --keep-data
 mapfile -t keep_events <"${fixture}/events-keep"
-[[ "${keep_events[*]}" == 'gateway sourcelens:0 hfl images bridge application-files' ]]
+[[ "${keep_events[*]}" == 'gateway hfl sourcelens:0 bridge images:1:1 application-files' ]]
 
 run_uninstall_contract selective --with-sourcelens
 mapfile -t selective_events <"${fixture}/events-selective"
-[[ "${selective_events[*]}" == 'sourcelens:0 hfl images' ]]
+[[ "${selective_events[*]}" == 'hfl sourcelens:0 images:1:1' ]]
+
+run_uninstall_contract selective_sourcelens_data \
+	--with-sourcelens --purge-sourcelens-data
+mapfile -t selective_sourcelens_data_events \
+	<"${fixture}/events-selective_sourcelens_data"
+[[ "${selective_sourcelens_data_events[*]}" == \
+	'hfl sourcelens:0 images:1:1 data' ]]
 
 run_uninstall_contract selective_config --purge-config
 mapfile -t selective_config_events <"${fixture}/events-selective_config"
-[[ "${selective_config_events[*]}" == 'hfl images config' ]]
+[[ "${selective_config_events[*]}" == 'hfl images:1:0 config' ]]
 
 run_uninstall_contract unmanaged
 mapfile -t unmanaged_events <"${fixture}/events-unmanaged"
-[[ "${unmanaged_events[*]}" == 'sourcelens:1 hfl images bridge data config root' ]]
+[[ "${unmanaged_events[*]}" == 'hfl sourcelens:0 bridge images:1:1 data config root' ]]
 
 run_uninstall_contract orphan
 mapfile -t orphan_events <"${fixture}/events-orphan"
-[[ "${orphan_events[*]}" == 'gateway sourcelens:1 hfl images bridge data config root' ]]
+[[ "${orphan_events[*]}" == 'gateway hfl sourcelens:0 bridge images:1:1 data config root' ]]
 
 if run_uninstall_contract docker_down >/dev/null 2>&1; then
 	printf 'plain uninstall continued without Docker\n' >&2
@@ -426,20 +704,28 @@ if run_uninstall_contract sourcelens_failure >/dev/null 2>&1; then
 	exit 1
 fi
 mapfile -t sourcelens_failure_events <"${fixture}/events-sourcelens_failure"
-[[ "${sourcelens_failure_events[*]}" == 'gateway sourcelens:1' ]]
+[[ "${sourcelens_failure_events[*]}" == 'gateway hfl sourcelens:0' ]]
 
 if run_uninstall_contract hfl_failure >/dev/null 2>&1; then
 	printf 'complete uninstall continued after HyperFileLens cleanup failure\n' >&2
 	exit 1
 fi
 mapfile -t hfl_failure_events <"${fixture}/events-hfl_failure"
-[[ "${hfl_failure_events[*]}" == 'gateway sourcelens:1 hfl' ]]
+[[ "${hfl_failure_events[*]}" == 'gateway hfl' ]]
 
 if run_uninstall_contract bridge_failure >/dev/null 2>&1; then
 	printf 'complete uninstall continued after shared network cleanup failure\n' >&2
 	exit 1
 fi
 mapfile -t bridge_failure_events <"${fixture}/events-bridge_failure"
-[[ "${bridge_failure_events[*]}" == 'gateway sourcelens:1 hfl images bridge' ]]
+[[ "${bridge_failure_events[*]}" == 'gateway hfl sourcelens:0 bridge' ]]
+
+if run_uninstall_contract image_failure >/dev/null 2>&1; then
+	printf 'complete uninstall continued after unverified image cleanup\n' >&2
+	exit 1
+fi
+mapfile -t image_failure_events <"${fixture}/events-image_failure"
+[[ "${image_failure_events[*]}" == \
+	'gateway hfl sourcelens:0 bridge images:1:1' ]]
 
 printf 'Release purge-all ownership and lifecycle contracts passed.\n'


### PR DESCRIPTION
## Summary

- remove manifest-declared HyperFileLens, SourceLens, shared dependency, and asset image references during uninstall
- retain images used by running or stopped containers, and preserve layers shared by unrelated tags
- keep configuration and data available for retry when Docker cleanup cannot be verified
- preserve selective uninstall boundaries for shared runtime images

## Validation

- release purge-all ownership and lifecycle contracts
- lifecycle output contracts
- SaaS registry delivery contracts
- release contract checks
- online installation, Gateway, upgrade transaction, and blue/green recovery regressions

Fixes #1096