### PR TITLE
Show failed Data Gateway installations accurately

### DIFF
--- a/src/backend/apps/lens_bridge/services/provisioning.py
+++ b/src/backend/apps/lens_bridge/services/provisioning.py
@@ -1411,14 +1411,19 @@ def apply_gateway_lensnode_snapshot(
     link: LensGatewayLink,
     data: dict[str, Any],
 ) -> LensGatewayLink:
-    """Persist a LensNode heartbeat payload without overriding active lifecycle work."""
-    preserve_lifecycle = link.sidecar_status in (
+    """Persist a LensNode snapshot without overriding authoritative lifecycle state."""
+    config = dict(link.config_json or {})
+    sl_status = str(data.get("status") or "").lower()
+    preserve_sidecar_status = link.sidecar_status in (
         LensGatewayLink.SidecarStatus.REMOVING,
         LensGatewayLink.SidecarStatus.UPGRADING,
+    ) or (
+        link.sidecar_status == LensGatewayLink.SidecarStatus.ERROR
+        and config.get("install_status") == "failed"
+        and sl_status != "online"
     )
     update_fields: list[str] = []
-    if not preserve_lifecycle:
-        sl_status = str(data.get("status") or "").lower()
+    if not preserve_sidecar_status:
         if sl_status == "online":
             next_status = LensGatewayLink.SidecarStatus.ONLINE
         elif sl_status == "offline":
@@ -1429,7 +1434,6 @@ def apply_gateway_lensnode_snapshot(
             link.sidecar_status = next_status
             update_fields.append("sidecar_status")
 
-    config = dict(link.config_json or {})
     snapshot = _extract_sl_lensnode_snapshot(data)
     if config.get("sl_lensnode_snapshot") != snapshot:
         config["sl_lensnode_snapshot"] = snapshot

--- a/src/backend/apps/lens_bridge/tests/test_provisioning.py
+++ b/src/backend/apps/lens_bridge/tests/test_provisioning.py
@@ -4,8 +4,12 @@ from unittest.mock import MagicMock, call, patch
 from django.test import SimpleTestCase
 from rest_framework.exceptions import ValidationError
 
+from apps.lens_bridge.models import LensGatewayLink
 from apps.lens_bridge.services import sl_client
-from apps.lens_bridge.services.provisioning import _lensnode_matches_workspace
+from apps.lens_bridge.services.provisioning import (
+    _lensnode_matches_workspace,
+    apply_gateway_lensnode_snapshot,
+)
 
 
 class SlClientErrorFormatTests(SimpleTestCase):
@@ -292,6 +296,26 @@ class SlLensnodeSnapshotTests(SimpleTestCase):
         self.assertEqual(snap["sl_status"], "online")
         self.assertEqual(len(snap["sl_tasks"]), 1)
         self.assertEqual(snap["sl_tasks"][0]["title"], "Knowledge Q&A")
+
+    def test_preserves_reported_install_failure_during_snapshot_refresh(self):
+        link = MagicMock(
+            sidecar_status=LensGatewayLink.SidecarStatus.ERROR,
+            config_json={"install_status": "failed"},
+        )
+
+        apply_gateway_lensnode_snapshot(link, {"status": "offline"})
+
+        self.assertEqual(link.sidecar_status, LensGatewayLink.SidecarStatus.ERROR)
+
+    def test_online_snapshot_recovers_a_previous_install_failure(self):
+        link = MagicMock(
+            sidecar_status=LensGatewayLink.SidecarStatus.ERROR,
+            config_json={"install_status": "failed"},
+        )
+
+        apply_gateway_lensnode_snapshot(link, {"status": "online"})
+
+        self.assertEqual(link.sidecar_status, LensGatewayLink.SidecarStatus.ONLINE)
 
 
 class EnsureKsWorkspaceTests(SimpleTestCase):

--- a/src/frontend/src/lib/gatewayDisplayStatus.test.ts
+++ b/src/frontend/src/lib/gatewayDisplayStatus.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ApiNode } from '../types/node'
+import {
+  resolveGatewayDisplayStatus,
+  type GatewayAiPhase,
+  type GatewayDisplayStatus,
+} from './gatewayDisplayStatus'
+
+const node = {} as ApiNode
+
+function resolveFor(
+  aiPhase: GatewayAiPhase,
+  agentDisplay: GatewayDisplayStatus = {
+    labelKey: 'nodeLifecycle.state.active',
+    tagType: 'success',
+  },
+) {
+  return resolveGatewayDisplayStatus(node, aiPhase, vi.fn(() => agentDisplay))
+}
+
+describe('resolveGatewayDisplayStatus', () => {
+  it.each([
+    ['online', 'insight.dataGateway.gatewayPhase.online', 'success', undefined],
+    ['not_provisioned', 'insight.dataGateway.gatewayPhase.setup_incomplete', 'info', undefined],
+    ['pending_install', 'insight.dataGateway.gatewayPhase.installing', 'info', true],
+    ['agent_offline', 'protection.sourceResources.nodeStatusOffline', 'danger', undefined],
+    ['offline', 'insight.dataGateway.gatewayPhase.degraded', 'danger', undefined],
+    ['error', 'insight.dataGateway.gatewayPhase.error', 'danger', undefined],
+  ] as const)(
+    'shows the %s AI Engine phase for an active Gateway Agent',
+    (aiPhase, labelKey, tagType, spinning) => {
+      expect(resolveFor(aiPhase)).toEqual({ labelKey, tagType, ...(spinning ? { spinning } : {}) })
+    },
+  )
+
+  it('keeps compatibility with the legacy online Agent status', () => {
+    expect(resolveFor('error', {
+      labelKey: 'protection.sourceResources.nodeStatusOnline',
+      tagType: 'success',
+    })).toEqual({
+      labelKey: 'insight.dataGateway.gatewayPhase.error',
+      tagType: 'danger',
+    })
+  })
+
+  it('preserves an active lifecycle operation instead of replacing it with the AI Engine phase', () => {
+    const lifecycleDisplay: GatewayDisplayStatus = {
+      labelKey: 'nodeLifecycle.state.upgrading',
+      tagType: 'info',
+      spinning: true,
+    }
+
+    expect(resolveFor('error', lifecycleDisplay)).toBe(lifecycleDisplay)
+  })
+
+  it('preserves the SourceLens status for a Gateway that is not managed by HFL', () => {
+    const externalNode = { managed_by_hfl: false } as ApiNode & { managed_by_hfl: boolean }
+    const sourceLensDisplay: GatewayDisplayStatus = {
+      labelKey: 'nodeLifecycle.state.active',
+      tagType: 'success',
+    }
+
+    expect(resolveGatewayDisplayStatus(
+      externalNode,
+      'not_provisioned',
+      vi.fn(() => sourceLensDisplay),
+    )).toBe(sourceLensDisplay)
+  })
+})

--- a/src/frontend/src/lib/gatewayDisplayStatus.ts
+++ b/src/frontend/src/lib/gatewayDisplayStatus.ts
@@ -1,6 +1,16 @@
 import type { ApiNode } from '../types/node'
 
-export type GatewayAiPhase = 'not_provisioned' | 'pending_install' | 'online' | 'offline' | 'error'
+export type GatewayAiPhase =
+  | 'not_provisioned'
+  | 'pending_install'
+  | 'online'
+  | 'agent_offline'
+  | 'offline'
+  | 'error'
+
+type GatewayStatusNode = ApiNode & {
+  managed_by_hfl?: boolean
+}
 
 export type GatewayDisplayStatus = {
   labelKey: string
@@ -9,15 +19,18 @@ export type GatewayDisplayStatus = {
   spinning?: boolean
 }
 
-const AGENT_ONLINE_KEY = 'protection.sourceResources.nodeStatusOnline'
+const AGENT_READY_KEYS = new Set([
+  'nodeLifecycle.state.active',
+  'protection.sourceResources.nodeStatusOnline',
+])
 
 export function resolveGatewayDisplayStatus(
-  node: ApiNode,
+  node: GatewayStatusNode,
   aiPhase: GatewayAiPhase,
   resolveDisplayStatus: (node: ApiNode) => GatewayDisplayStatus,
 ): GatewayDisplayStatus {
   const agentDisplay = resolveDisplayStatus(node)
-  if (agentDisplay.labelKey !== AGENT_ONLINE_KEY) {
+  if (node.managed_by_hfl === false || !AGENT_READY_KEYS.has(agentDisplay.labelKey)) {
     return agentDisplay
   }
 
@@ -32,6 +45,8 @@ export function resolveGatewayDisplayStatus(
         tagType: 'info',
         spinning: true,
       }
+    case 'agent_offline':
+      return { labelKey: 'protection.sourceResources.nodeStatusOffline', tagType: 'danger' }
     case 'offline':
       return { labelKey: 'insight.dataGateway.gatewayPhase.degraded', tagType: 'danger' }
     case 'error':

--- a/src/frontend/src/pages/insight/InsightDataGateways.vue
+++ b/src/frontend/src/pages/insight/InsightDataGateways.vue
@@ -39,6 +39,7 @@ import {
   updateNode,
 } from '../../lib/nodeApi'
 import { canRemoteAgentUpgrade } from '../../lib/agentVersion'
+import type { GatewayAiPhase } from '../../lib/gatewayDisplayStatus'
 import {
   formatNodeBytes,
   formatNodeDate,
@@ -221,10 +222,11 @@ function ipLine(row: ApiNode) {
   return row.ip_address?.trim() || '—'
 }
 
-function aiPhase(row: InsightGatewayRow): 'not_provisioned' | 'pending_install' | 'online' | 'offline' | 'error' {
+function aiPhase(row: InsightGatewayRow): GatewayAiPhase {
   if (!bridgeReady.value) return 'not_provisioned'
   if (row.managed_by_hfl === false) return 'not_provisioned'
-  if (!row.hfl_agent_online) return 'offline'
+  if (!row.hfl_agent_online) return 'agent_offline'
+  if (row.sidecar_status === 'error') return 'error'
   if (!row.ai_enabled) {
     if (row.status === 'online') return 'error'
     return 'not_provisioned'


### PR DESCRIPTION
## Summary

- preserve reported Data Gateway installation failures while the LensNode remains offline
- show Agent, AI engine, and lifecycle states with the correct precedence
- keep external SourceLens gateways unchanged and recover stale failures when the sidecar becomes online
- add focused backend and frontend regression coverage

## Validation

- Backend Ruff checks
- Backend provisioning tests (25 passed)
- Frontend TypeScript and ESLint checks
- Frontend gateway and lifecycle tests (18 passed)
- git diff --check

Fixes #1050