### PR TITLE
Skip login page for active sessions

### DIFF
--- a/src/frontend/src/composables/useAuth.ts
+++ b/src/frontend/src/composables/useAuth.ts
@@ -4,7 +4,6 @@ import { router } from '../router'
 import {
   clearDeployProfileCache,
   fetchDeployProfile,
-  resolvePostLoginPath,
   shouldForceDeployProfileRefresh,
 } from './useDeployProfile'
 import { getCorrelationHeaders } from '../lib/requestContext'
@@ -18,6 +17,7 @@ import {
   subscribeSessionNotice,
 } from '../lib/sessionNotice'
 import { clearLogoutBrowserStorage } from '../lib/logoutStorage'
+import { resolveAuthenticatedLoginTarget } from '../lib/loginNavigation'
 
 export interface User {
   id: number
@@ -425,6 +425,33 @@ export function setupAuthGuard() {
     const isPublicPath = publicPaths.some(path => to.path.startsWith(path))
     const isPlatformOpsPath = to.path.startsWith('/platform-ops')
 
+    if (to.path === '/login') {
+      const confirmation = isLoggedIn.value
+        ? { state: 'authenticated' as const, user: currentUser.value }
+        : await confirmCurrentSession()
+
+      if (confirmation.state === 'authenticated') {
+        const profile = await fetchDeployProfile(true)
+        if (!profile) {
+          next()
+          return
+        }
+
+        const target = resolveAuthenticatedLoginTarget(profile, to.query.redirect)
+        if (target.kind === 'external') {
+          window.location.replace(target.url)
+          return
+        }
+        if (target.kind === 'internal') {
+          next(target.path)
+          return
+        }
+      }
+
+      next()
+      return
+    }
+
     if (to.path === '/register') {
       const profile = await fetchDeployProfile()
       if (profile && !profile.email_signup_enabled) {
@@ -501,12 +528,6 @@ export function setupAuthGuard() {
         next('/login')
         return
       }
-    }
-
-    // If logged in and going to login page, redirect to home
-    if (isLoggedIn.value && to.path === '/login') {
-      next(await resolvePostLoginPath())
-      return
     }
 
     next()

--- a/src/frontend/src/composables/useAuthLoginGuard.test.ts
+++ b/src/frontend/src/composables/useAuthLoginGuard.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Guard = (
+  to: { path: string; query: Record<string, unknown>; meta: Record<string, unknown> },
+  from: { path: string },
+  next: ReturnType<typeof vi.fn>,
+) => Promise<void>
+
+const mocks = vi.hoisted(() => ({
+  beforeEach: vi.fn(),
+  fetchDeployProfile: vi.fn(),
+  guard: null as Guard | null,
+  refreshAuthToken: vi.fn(),
+}))
+
+vi.mock('../router', () => ({
+  router: {
+    currentRoute: { value: { path: '/login', fullPath: '/login' } },
+    beforeEach: mocks.beforeEach.mockImplementation((guard: Guard) => {
+      mocks.guard = guard
+    }),
+    replace: vi.fn(),
+  },
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('../lib/authRefresh', () => ({
+  refreshAuthToken: mocks.refreshAuthToken,
+}))
+
+vi.mock('../lib/requestContext', () => ({
+  getCorrelationHeaders: () => ({}),
+}))
+
+vi.mock('./useDeployProfile', () => ({
+  clearDeployProfileCache: vi.fn(),
+  fetchDeployProfile: mocks.fetchDeployProfile,
+  resolvePostLoginPath: vi.fn().mockResolvedValue('/'),
+  shouldForceDeployProfileRefresh: vi.fn().mockReturnValue(false),
+}))
+
+import { clearAuth, setupAuthGuard } from './useAuth'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const tenantProfile = {
+  site_role: 'tenant',
+  email_signup_enabled: false,
+  email_code_login_available: false,
+  platform_ops_enabled: true,
+  password_reset_available: true,
+  tenant_public_url: 'https://tenant.example.test',
+  admin_console_url: 'https://ops.example.test',
+  landing_path: '/',
+  admin_console_landing_path: '/platform-ops/overview',
+  admin_console_entry_visible: true,
+  platform_ops_access_allowed: false,
+}
+
+describe('login route authentication guard', () => {
+  beforeEach(() => {
+    clearAuth()
+    mocks.beforeEach.mockClear()
+    mocks.fetchDeployProfile.mockReset()
+    mocks.guard = null
+    setupAuthGuard()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    clearAuth()
+  })
+
+  it('holds the login route until session inspection redirects an authenticated user', async () => {
+    let resolveSession!: (response: Response) => void
+    const sessionResponse = new Promise<Response>((resolve) => {
+      resolveSession = resolve
+    })
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(sessionResponse))
+    mocks.fetchDeployProfile.mockResolvedValue(tenantProfile)
+    const next = vi.fn()
+
+    const navigation = mocks.guard?.(
+      { path: '/login', query: {}, meta: {} },
+      { path: '/' },
+      next,
+    )
+
+    await Promise.resolve()
+    expect(next).not.toHaveBeenCalled()
+
+    resolveSession(jsonResponse({
+      data: {
+        user: { id: 7, email: 'person@example.com', username: 'person' },
+        refresh_available: false,
+      },
+    }))
+    await navigation
+
+    expect(next).toHaveBeenCalledOnce()
+    expect(next).toHaveBeenCalledWith('/')
+  })
+
+  it('allows the login page after the backend confirms there is no session', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      data: { user: null, refresh_available: false },
+    })))
+    const next = vi.fn()
+
+    await mocks.guard?.(
+      { path: '/login', query: {}, meta: {} },
+      { path: '/' },
+      next,
+    )
+
+    expect(next).toHaveBeenCalledOnce()
+    expect(next).toHaveBeenCalledWith()
+    expect(mocks.fetchDeployProfile).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- inspect the cookie session in the global route guard before resolving `/login`
- redirect authenticated users directly from the global loading screen to their role-aware destination
- keep the login component unmounted while session inspection is pending
- preserve the existing login and recovery flows for confirmed signed-out or unavailable sessions

## Testing

- targeted frontend Vitest suite (64 passed)
- frontend production build
- frontend ESLint with `--quiet`
- `git diff --check`

Follow-up to #1059 and #1136.