### PR TITLE
fix: validate repository creation and clarify backup progress

### DIFF
--- a/docs/development/s3-repository-preflight.md
+++ b/docs/development/s3-repository-preflight.md
@@ -1,0 +1,43 @@
+# S3 repository creation preflight
+
+All S3 repository creation requests run server-side preflight before inserting
+Repository, Credential, location claims, or initialization tasks. The form stays
+open on a preflight error. Successful requests retain the asynchronous `creating`
+response and existing initialization recovery behavior.
+
+Sequence:
+
+1. Check quota and existing repository prefix overlap.
+2. For new-bucket mode, require HEAD to confirm absence before creating the bucket.
+   An existing or inaccessible bucket must not proceed to probe or repository creation.
+3. Resolve addressing style and list the target prefix.
+4. Remove recognized probe residue, then require an empty prefix.
+5. Upload the fixed probe with overwrite prevention, delete it, and recheck emptiness.
+6. Persist the repository with its original bucket mode, and enqueue initialization.
+   After validation, server-set `config.s3_bucket_prepared` prevents duplicate
+   creation by the worker. Keeping `s3_bucket_mode=new` preserves cleanup eligibility
+   for genuinely new buckets. No schema changes or pre-validation records are used.
+
+The reserved key is `<prefix>.hfl-repository-probe-550e8400-e29b-41d4-a716-446655440000.tmp`.
+Only exact metadata (`hfl-purpose=repository-preflight`, `hfl-probe-version=1`)
+and the expected content length authorize residue deletion. HEAD reads metadata;
+preflight never downloads probe contents. Unknown objects, including a reserved
+key with different metadata, stop creation. This verifies listing, writing and
+deletion; it does not prove GET access. Version IDs returned by PUT/HEAD are
+passed to DELETE to avoid leaving probe versions or creating delete markers.
+
+A PostgreSQL session advisory lock serializes application create requests for the
+same normalized endpoint and bucket, including overlapping prefixes. Conditional
+PUT also prevents overwriting a probe created outside that lock. Initialization
+retains its existing physical-location checks; preflight cannot make operations
+in an external object store and the database one atomic transaction.
+
+No temporary database records or new schema are needed. If preparation fails after
+this request successfully created a bucket, attempt to delete that bucket only if
+it is empty. Existing buckets and nonempty buckets are never removed. Rollback
+failure is included in the error response. Ambiguous bucket-creation results must
+be checked at the provider; no automatic adoption occurs on retry.
+
+The default frontend prefix uses local time, for example `hfl6I09163025/` for
+September 9, 2026 at 16:30:25. Its year digit repeats every ten years; storage checks,
+rather than the name generator, decide whether a location can be used.

--- a/language-packs/packs/es/frontend/messages.json
+++ b/language-packs/packs/es/frontend/messages.json
@@ -488,6 +488,13 @@
       "filters": "Filtros"
     },
     "taskProgress": {
+      "backupBytes": "Progreso de la copia de seguridad: {size}",
+      "backupBytesCapacity": "Progreso de la copia de seguridad: {done} / {total}",
+      "backupEtaSeconds": "Quedan aproximadamente {n} s",
+      "backupEtaMinutes": "Quedan aproximadamente {n} min",
+      "backupEtaHours": "Quedan aproximadamente {n} h",
+      "backupEtaHoursMinutes": "Quedan aproximadamente {h} h {m} min",
+
       "bytesTransferred": "{size} transferido",
       "bytesProcessed": "Procesado: {size}",
       "bytesCapacity": "{done} / {total}",
@@ -4951,7 +4958,7 @@
     "hintSmbUsername": "Usuario SMB utilizado para acceder al recurso compartido; por ejemplo, backup_user.",
     "hintSmbPassword": "Contraseña del recurso compartido; se oculta en los registros y mensajes de error.",
     "hintSmbDomain": "Utilice CORP o WORKGROUP para entornos de dominio; deje vacío para usuarios locales.",
-    "hintRepositoryName": "Nombre que se mostrará en las listas de repositorios y en las configuraciones de copia de seguridad; por ejemplo, NAS de producción.",
+    "hintRepositoryName": "Se completa automáticamente con el protocolo, el servidor y el último segmento de la ruta del recurso compartido. Puede editarlo; borre el nombre para restaurar el nombre automático.",
     "errSmbHost": "Introduzca la dirección del servidor",
     "errSmbShare": "Introduzca el nombre del recurso compartido"
   },
@@ -5112,6 +5119,7 @@
     "errBucket": "Por favor, seleccione un bucket",
     "errBucketName": "Por favor, introduzca un nombre de bucket",
     "bucketNameErrors": {
+      "aws_reserved": "Este nombre utiliza un prefijo o sufijo reservado de Amazon S3.",
       "aliyun": "Use entre 3 y 63 letras minúsculas, números o guiones; comience y termine con una letra o un número.",
       "dns": "Use entre 3 y 63 letras minúsculas, números, guiones o puntos; comience y termine con una letra o un número.",
       "dns_label": "Cada parte entre períodos debe comenzar y terminar con una letra o número.",

--- a/language-packs/packs/es/frontend/source-lock.json
+++ b/language-packs/packs/es/frontend/source-lock.json
@@ -4720,7 +4720,7 @@
   "addNasRepo.hintSmbUsername": "5b1322416041607f7ba0caf1853c8ff21e97b65cdf0ccacbd42f399a561c5d89",
   "addNasRepo.hintSmbPassword": "8817dfc2d6ce2901eb2046f223c3c091c17bfefa3334978ba759fe5968133e2f",
   "addNasRepo.hintSmbDomain": "ccd0d9e333125d258209435c3771d86cffa0dc2b491b9165fdcfa32551bcd43a",
-  "addNasRepo.hintRepositoryName": "c945c7640f176432374479331aac5d56a686b6eed4b1a450a97a6ff2b7dfe43b",
+  "addNasRepo.hintRepositoryName": "42eda0550a9f32cb96534994be63653f01433e12c42a4c5f07e9fa6d98656ea6",
   "addNasRepo.errSmbHost": "6a1d6c46a09a9b3179f56b77e8eb596c192028af8fcb4599d29a89a485fe809d",
   "addNasRepo.errSmbShare": "4e2b152216e2c68bd59da47d0f856d86d04393767962c0a4764984274e344602",
   "repairNasRepo.pageTitle": "8146447b21f15a48db265dddc772d1331e892941b13dacb381fb4a067d0536ff",
@@ -7324,5 +7324,12 @@
   "ops.events.periods.last24Hours": "40a0883809c7ca84c786a4cee4ed7e992478d3a918dabad542a769e5b825f050",
   "ops.events.periods.last7Days": "136d396e5c05f59bb18e3d760ba68d84c6e0bcf25ab57e58bc031640fd79b49c",
   "ops.events.periods.last30Days": "f20bf702ea490aa6f439c7227c786f8d85f6d5e171d8b5b579d20b8bbccb90b1",
-  "ops.events.periods.allTime": "097d42c984a3540698ef4e45fb60244341a3f4dba05d5615a5a7d181e8d23c81"
+  "ops.events.periods.allTime": "097d42c984a3540698ef4e45fb60244341a3f4dba05d5615a5a7d181e8d23c81",
+  "protection.taskProgress.backupBytes": "830b3ad48bfc1d6f0f787cbdd376585ffbbab156c647d8c8aa6f008c91226d38",
+  "protection.taskProgress.backupBytesCapacity": "2b8a55e936d776e638c4cdd7b64983ba833e8ce0abfc33bf78161a403517b899",
+  "protection.taskProgress.backupEtaSeconds": "50d8a5e3f0c8e139dd85f1c6927df46a8d567e2efa531840033aafb678cfec5f",
+  "protection.taskProgress.backupEtaMinutes": "3d378689d0dd9857a6c28b2dfc908b9ac042061d2d1cdead3b2ddf717481127d",
+  "protection.taskProgress.backupEtaHours": "13c9d74dbe80f7397cc7f7b80ac2bcbedd012d2350511a96e3d983e7e1b27f83",
+  "protection.taskProgress.backupEtaHoursMinutes": "10c3b7b37edab973d91fe042e411275edc9915f9f0b0a0330517c177f5b8dc4e",
+  "addS3Repo.bucketNameErrors.aws_reserved": "e56222f921707e10f8c93f84c524105e51e930b33b16bbc3ff5e37523382a922"
 }

--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -460,6 +460,13 @@
       "groupDrTargets": "灾难恢复目标"
     },
     "taskProgress": {
+      "backupBytes": "备份进度：{size}",
+      "backupBytesCapacity": "备份进度：{done} / {total}",
+      "backupEtaSeconds": "预计剩余约 {n} 秒",
+      "backupEtaMinutes": "预计剩余约 {n} 分钟",
+      "backupEtaHours": "预计剩余约 {n} 小时",
+      "backupEtaHoursMinutes": "预计剩余约 {h} 小时 {m} 分钟",
+
       "bytesTransferred": "已传输 {size}",
       "bytesProcessed": "已处理：{size}",
       "etaSeconds": "{n} 秒",
@@ -4902,7 +4909,7 @@
     "hintSmbUsername": "用于访问共享目录的 SMB 用户，例如 backup_user。",
     "hintSmbPassword": "共享目录的访问密码；日志和错误信息会隐藏密码。",
     "hintSmbDomain": "域环境请填写 CORP 或 WORKGROUP；本地用户请留空。",
-    "hintRepositoryName": "用于仓库列表和备份配置中的显示名称，例如：生产环境 NAS 备份。",
+    "hintRepositoryName": "根据协议、服务器及共享路径最后一段自动填写。可手动修改；清空名称后恢复自动命名。",
     "errSmbHost": "请输入服务器地址",
     "stepBindProxy": "绑定 Proxy",
     "titleBindProxy": "绑定 Proxy",
@@ -5070,6 +5077,7 @@
     "errBucket": "请选择 Bucket",
     "errBucketName": "请输入 Bucket 名称",
     "bucketNameErrors": {
+      "aws_reserved": "此名称使用了 Amazon S3 保留的前缀或后缀。",
       "aliyun": "使用 3–63 个小写字母、数字或连字符，并以字母或数字开头和结尾。",
       "dns": "使用 3–63 个小写字母、数字、连字符或句点，并以字母或数字开头和结尾。",
       "dns_label": "句点分隔的每一部分都必须以字母或数字开头和结尾。",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -4705,7 +4705,7 @@
   "addNasRepo.hintSmbUsername": "5b1322416041607f7ba0caf1853c8ff21e97b65cdf0ccacbd42f399a561c5d89",
   "addNasRepo.hintSmbPassword": "8817dfc2d6ce2901eb2046f223c3c091c17bfefa3334978ba759fe5968133e2f",
   "addNasRepo.hintSmbDomain": "ccd0d9e333125d258209435c3771d86cffa0dc2b491b9165fdcfa32551bcd43a",
-  "addNasRepo.hintRepositoryName": "c945c7640f176432374479331aac5d56a686b6eed4b1a450a97a6ff2b7dfe43b",
+  "addNasRepo.hintRepositoryName": "42eda0550a9f32cb96534994be63653f01433e12c42a4c5f07e9fa6d98656ea6",
   "addNasRepo.errSmbHost": "6a1d6c46a09a9b3179f56b77e8eb596c192028af8fcb4599d29a89a485fe809d",
   "addNasRepo.errSmbShare": "4e2b152216e2c68bd59da47d0f856d86d04393767962c0a4764984274e344602",
   "repairNasRepo.pageTitle": "8146447b21f15a48db265dddc772d1331e892941b13dacb381fb4a067d0536ff",
@@ -7324,5 +7324,12 @@
   "ops.events.periods.last24Hours": "40a0883809c7ca84c786a4cee4ed7e992478d3a918dabad542a769e5b825f050",
   "ops.events.periods.last7Days": "136d396e5c05f59bb18e3d760ba68d84c6e0bcf25ab57e58bc031640fd79b49c",
   "ops.events.periods.last30Days": "f20bf702ea490aa6f439c7227c786f8d85f6d5e171d8b5b579d20b8bbccb90b1",
-  "ops.events.periods.allTime": "097d42c984a3540698ef4e45fb60244341a3f4dba05d5615a5a7d181e8d23c81"
+  "ops.events.periods.allTime": "097d42c984a3540698ef4e45fb60244341a3f4dba05d5615a5a7d181e8d23c81",
+  "protection.taskProgress.backupBytes": "830b3ad48bfc1d6f0f787cbdd376585ffbbab156c647d8c8aa6f008c91226d38",
+  "protection.taskProgress.backupBytesCapacity": "2b8a55e936d776e638c4cdd7b64983ba833e8ce0abfc33bf78161a403517b899",
+  "protection.taskProgress.backupEtaSeconds": "50d8a5e3f0c8e139dd85f1c6927df46a8d567e2efa531840033aafb678cfec5f",
+  "protection.taskProgress.backupEtaMinutes": "3d378689d0dd9857a6c28b2dfc908b9ac042061d2d1cdead3b2ddf717481127d",
+  "protection.taskProgress.backupEtaHours": "13c9d74dbe80f7397cc7f7b80ac2bcbedd012d2350511a96e3d983e7e1b27f83",
+  "protection.taskProgress.backupEtaHoursMinutes": "10c3b7b37edab973d91fe042e411275edc9915f9f0b0a0330517c177f5b8dc4e",
+  "addS3Repo.bucketNameErrors.aws_reserved": "e56222f921707e10f8c93f84c524105e51e930b33b16bbc3ff5e37523382a922"
 }

--- a/src/backend/apps/storage/selectors/interface.py
+++ b/src/backend/apps/storage/selectors/interface.py
@@ -84,7 +84,7 @@ def list_repositories(
             queryset=active_lifecycle_operations,
             to_attr="active_lifecycle_operations",
         ),
-    ).order_by("name", "id")
+    ).order_by("-created_at", "-id")
 
 
 def _repository_field_search_q(field: str, term: str) -> Q | None:

--- a/src/backend/apps/storage/services/interface.py
+++ b/src/backend/apps/storage/services/interface.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from rest_framework.exceptions import ValidationError as DRFValidationError
 
 from apps.storage.repositories.models import Credential, Repository
+from apps.storage.services.internal.s3_creation_preflight import prepare_s3_creation
 from apps.storage.services.internal.repository_initializer import (
     RepositoryInitializationError,
     check_s3_repository,
@@ -199,6 +200,7 @@ def delete_credential(*, credential: Credential) -> None:
     credential.delete()
 
 
+@prepare_s3_creation
 def create_repository(
     *,
     organization_id: int,

--- a/src/backend/apps/storage/services/internal/repository_initializer.py
+++ b/src/backend/apps/storage/services/internal/repository_initializer.py
@@ -136,7 +136,7 @@ def initialize_s3_repository(
             use_tls=config.get("use_tls") is not False,
         )
         bucket_created = False
-        if repository.s3_bucket_mode == Repository.S3BucketMode.NEW:
+        if repository.s3_bucket_mode == Repository.S3BucketMode.NEW and not config.get("s3_bucket_prepared"):
             bucket_created = create_s3_bucket(
                 **bucket_args,
                 allow_existing_owned=recovery,

--- a/src/backend/apps/storage/services/internal/s3_bucket_name.py
+++ b/src/backend/apps/storage/services/internal/s3_bucket_name.py
@@ -19,6 +19,11 @@ def s3_bucket_name_error(*, platform: object, bucket: object) -> str:
 
     normalized_platform = str(platform or "").strip().lower()
     name = str(bucket or "").strip()
+    if normalized_platform == "aws" and (
+        name.startswith(("xn--", "sthree-", "amzn-s3-demo-"))
+        or name.endswith(("-s3alias", "--ol-s3", ".mrap", "--x-s3", "--table-s3"))
+    ):
+        return "Bucket names cannot use an Amazon S3 reserved prefix or suffix."
     if normalized_platform == "aliyun":
         if not _ALIYUN_BUCKET_RE.fullmatch(name):
             return (

--- a/src/backend/apps/storage/services/internal/s3_creation_preflight.py
+++ b/src/backend/apps/storage/services/internal/s3_creation_preflight.py
@@ -1,0 +1,298 @@
+"""Prepare S3 storage before persisting a repository or its credentials."""
+
+from __future__ import annotations
+
+import hashlib
+from functools import wraps
+
+from botocore.exceptions import BotoCoreError, ClientError
+from django.db import transaction
+from rest_framework.exceptions import ValidationError
+
+from apps.storage.repositories.models import Repository
+from apps.storage.services.internal.repository_endpoints import (
+    repository_control_endpoint,
+)
+from apps.storage.services.internal.repository_execution_lock import (
+    repository_execution_lock,
+)
+from apps.storage.services.internal.repository_location import (
+    repository_location_spec,
+    _roots_overlap,
+)
+from apps.storage.services.internal.repository_secrets import (
+    build_secret_payload,
+    scrub_secrets,
+)
+from apps.storage.services.internal.s3_client import (
+    S3ClientError,
+    _client,
+    create_s3_bucket,
+    _s3_atomic_create_strategy,
+    _ATOMIC_CREATE_ALIYUN_FORBID_OVERWRITE,
+    _ATOMIC_CREATE_HUAWEI_FORBID_OVERWRITE,
+    _add_aliyun_forbid_overwrite_header,
+    _add_huawei_forbid_overwrite_header,
+    delete_s3_bucket_if_empty,
+)
+from apps.storage.services.internal.s3_url_style import normalize_s3_url_style
+
+PROBE_NAME = ".hfl-repository-probe-550e8400-e29b-41d4-a716-446655440000.tmp"
+PROBE_METADATA = {"hfl-purpose": "repository-preflight", "hfl-probe-version": "1"}
+PROBE_BODY = b"HyperFileLens repository preflight v1\n"
+
+
+class S3BucketAlreadyExists(S3ClientError):
+    pass
+
+
+def ensure_s3_bucket_absent(**bucket_args) -> None:
+    """Some providers return success for CreateBucket on an owned bucket."""
+    client = _client(
+        **{k: v for k, v in bucket_args.items() if k != "bucket"}, timeout_seconds=15
+    )
+    try:
+        client.head_bucket(Bucket=bucket_args["bucket"])
+    except ClientError as exc:
+        if str(exc.response.get("Error", {}).get("Code")) in {
+            "404",
+            "NoSuchBucket",
+            "NotFound",
+        }:
+            return
+        raise S3ClientError(
+            "Unable to confirm that the Bucket name is available. Check permissions and the endpoint."
+        ) from exc
+    except BotoCoreError as exc:
+        raise S3ClientError(
+            "Unable to check whether the Bucket already exists."
+        ) from exc
+    raise S3BucketAlreadyExists(
+        "Bucket already exists. Choose another name or select Existing Bucket."
+    )
+
+
+def verify_empty_prefix(
+    *, prefix: str, platform: str | None = None, **bucket_args
+) -> None:
+    """List, PUT and DELETE only; HEAD verifies residue metadata without GET."""
+    client = _client(
+        **{k: v for k, v in bucket_args.items() if k != "bucket"}, timeout_seconds=15
+    )
+    bucket = bucket_args["bucket"]
+    key = f"{prefix}{PROBE_NAME}"
+
+    def remove_probe():
+        # Delete explicit versions, never create a delete marker. Repeated HEAD
+        # also exposes older probe versions left by interrupted attempts.
+        for _ in range(100):
+            try:
+                head = client.head_object(Bucket=bucket, Key=key)
+            except ClientError as exc:
+                if str(exc.response.get("Error", {}).get("Code")) in {
+                    "404",
+                    "NoSuchKey",
+                    "NotFound",
+                }:
+                    return
+                raise
+            if head.get("Metadata") != PROBE_METADATA or head.get(
+                "ContentLength"
+            ) != len(PROBE_BODY):
+                raise S3ClientError(
+                    f"The reserved probe object has unrecognized metadata: {key}. It was not deleted."
+                )
+            args = {"Bucket": bucket, "Key": key}
+            if head.get("VersionId") is not None:
+                args["VersionId"] = head["VersionId"]
+            client.delete_object(**args)
+        raise S3ClientError(f"Unable to finish cleaning probe object: {key}.")
+
+    def ensure_empty():
+        result = client.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+        if result.get("Contents") or result.get("IsTruncated"):
+            raise S3ClientError(
+                "The selected object Prefix already contains data. Choose an empty Prefix."
+            )
+
+    try:
+        # List before HEAD so missing List permission cannot be treated as empty.
+        client.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)
+        remove_probe()
+        ensure_empty()
+        args = dict(
+            Bucket=bucket,
+            Key=key,
+            Body=PROBE_BODY,
+            ContentLength=len(PROBE_BODY),
+            Metadata=PROBE_METADATA,
+        )
+        strategy = _s3_atomic_create_strategy(
+            platform=platform, endpoint=bucket_args.get("endpoint")
+        )
+        if strategy == _ATOMIC_CREATE_ALIYUN_FORBID_OVERWRITE:
+            client.meta.events.register_first(
+                "before-sign.s3.PutObject",
+                _add_aliyun_forbid_overwrite_header,
+                unique_id="hfl-preflight-no-overwrite",
+            )
+        elif strategy == _ATOMIC_CREATE_HUAWEI_FORBID_OVERWRITE:
+            client.meta.events.register_first(
+                "before-sign.s3.PutObject",
+                _add_huawei_forbid_overwrite_header,
+                unique_id="hfl-preflight-no-overwrite",
+            )
+        else:
+            args["IfNoneMatch"] = "*"
+        uploaded = client.put_object(**args)
+        # Use the returned version even if a concurrent writer changes the key.
+        delete_args = {"Bucket": bucket, "Key": key}
+        if uploaded.get("VersionId") is not None:
+            delete_args["VersionId"] = uploaded["VersionId"]
+        client.delete_object(**delete_args)
+        ensure_empty()
+    except (ClientError, BotoCoreError) as exc:
+        raise S3ClientError(
+            f"Object Prefix verification failed (probe: {key}): {exc}"
+        ) from exc
+
+
+def prepare_s3_creation(create):
+    @wraps(create)
+    def wrapped(**kwargs):
+        if kwargs.get("repo_type") != Repository.Type.S3:
+            return create(**kwargs)
+        from apps.storage.services.internal.repository_initializer import (
+            resolve_s3_url_style,
+            S3UrlStyleProbeError,
+        )
+
+        config = dict(kwargs.get("config") or {})
+        config.pop("s3_bucket_prepared", None)
+        secrets = build_secret_payload(
+            repository_type=Repository.Type.S3,
+            config=config,
+            credential_payload=kwargs.get("credential_payload"),
+        )
+        candidate = Repository(
+            organization_id=kwargs["organization_id"],
+            repo_type=Repository.Type.S3,
+            s3_bucket=kwargs.get("s3_bucket"),
+            s3_platform=kwargs.get("s3_platform"),
+            config=config,
+        )
+        spec = repository_location_spec(candidate, s3_namespace_resolved=True)
+        lock_id = int(hashlib.sha256(spec.namespace_key.encode()).hexdigest()[:15], 16)
+        try:
+            with repository_execution_lock(
+                operation="s3-preflight", operation_id=lock_id
+            ) as acquired:
+                if not acquired:
+                    raise S3ClientError(
+                        "Another repository creation is preparing this Bucket. Retry when it finishes."
+                    )
+                from apps.iam.models import Organization
+                from apps.subscription.services.interface import (
+                    enforce_repository_type_quota,
+                )
+
+                with transaction.atomic():
+                    org = Organization.objects.filter(
+                        pk=kwargs["organization_id"]
+                    ).first()
+                    if org is not None:
+                        enforce_repository_type_quota(
+                            organization=org, repo_type=Repository.Type.S3
+                        )
+                for existing in Repository.objects.filter(
+                    repo_type=Repository.Type.S3, s3_bucket=candidate.s3_bucket
+                ):
+                    other = repository_location_spec(
+                        existing, s3_namespace_resolved=True
+                    )
+                    if other.namespace_key == spec.namespace_key and _roots_overlap(
+                        other.root_path, spec.root_path
+                    ):
+                        raise S3ClientError(
+                            "This storage location overlaps an existing repository. Choose a different Prefix."
+                        )
+                bucket_args = dict(
+                    endpoint=repository_control_endpoint(config),
+                    region=str(config.get("region") or ""),
+                    bucket=str(candidate.s3_bucket or ""),
+                    access_key_id=str(
+                        (kwargs.get("credential_payload") or {}).get(
+                            "access_key_id", config.get("access_key_id", "")
+                        )
+                    ),
+                    secret_access_key=str(secrets.get("secret_access_key") or ""),
+                    s3_url_style=normalize_s3_url_style(
+                        config.get("s3_url_style"), platform=candidate.s3_platform
+                    ),
+                    use_tls=config.get("use_tls") is not False,
+                )
+                bucket_created = False
+                if kwargs.get("s3_bucket_mode") == Repository.S3BucketMode.NEW:
+                    ensure_s3_bucket_absent(**bucket_args)
+                    try:
+                        bucket_created = create_s3_bucket(**bucket_args)
+                    except S3ClientError as exc:
+                        if "already exists" in str(exc).lower():
+                            raise S3BucketAlreadyExists(
+                                "Bucket already exists. Choose another name or select Existing Bucket."
+                            ) from exc
+                        raise
+                    if not bucket_created:
+                        raise S3BucketAlreadyExists(
+                            "Bucket already exists. Choose another name or select Existing Bucket."
+                        )
+                try:
+                    bucket_args["s3_url_style"] = resolve_s3_url_style(**bucket_args)
+                    prefix = spec.root_path.strip("/")
+                    prefix = f"{prefix}/" if prefix else ""
+                    verify_empty_prefix(
+                        prefix=prefix, platform=candidate.s3_platform, **bucket_args
+                    )
+                    config.update(
+                        prefix=prefix,
+                        s3_url_style=bucket_args["s3_url_style"],
+                        s3_bucket_prepared=True,
+                    )
+                    kwargs["config"] = config
+                    result = create(**kwargs)
+                    return result
+                except Exception as exc:
+                    # A dispatch error can occur after the creation transaction
+                    # commits. Never roll back storage already tracked by a row.
+                    if (
+                        bucket_created
+                        and not Repository.objects.filter(
+                            organization_id=kwargs["organization_id"],
+                            repo_type=Repository.Type.S3,
+                            s3_bucket=candidate.s3_bucket,
+                            name=kwargs["name"],
+                        ).exists()
+                    ):
+                        rollback = delete_s3_bucket_if_empty(**bucket_args)
+                        if rollback.get("status") != "deleted":
+                            raise S3ClientError(
+                                f"{exc} The newly created Bucket could not be rolled back: "
+                                f"{rollback.get('reason', 'unknown error')}. Check the Bucket before retrying."
+                            ) from exc
+                    raise
+        except S3BucketAlreadyExists as exc:
+            raise ValidationError({"s3_bucket": str(exc)}) from exc
+        except (S3ClientError, S3UrlStyleProbeError) as exc:
+            raise ValidationError(
+                {
+                    "detail": scrub_secrets(
+                        str(exc),
+                        extra_values=[
+                            str(secrets.get("secret_access_key") or ""),
+                            str(config.get("access_key_id") or ""),
+                        ],
+                    )
+                }
+            ) from exc
+
+    return wrapped

--- a/src/backend/apps/storage/tests/test_repository_api.py
+++ b/src/backend/apps/storage/tests/test_repository_api.py
@@ -65,6 +65,24 @@ from apps.task.models import Task
 
 class StorageRepositoryApiTests(TestCase):
     def setUp(self):
+        # Storage network effects now happen before repository acceptance.
+        self.preflight_probe = mock.patch(
+            "apps.storage.services.internal.s3_creation_preflight.verify_empty_prefix"
+        )
+        self.probe = self.preflight_probe.start()
+        self.addCleanup(self.preflight_probe.stop)
+        bucket_patch = mock.patch("apps.storage.services.internal.s3_creation_preflight.create_s3_bucket")
+        self.preflight_bucket = bucket_patch.start()
+        self.addCleanup(bucket_patch.stop)
+        style_patch = mock.patch(
+            "apps.storage.services.internal.repository_initializer.resolve_s3_url_style",
+            side_effect=lambda **args: "path" if args["s3_url_style"] == "auto" else args["s3_url_style"],
+        )
+        style_patch.start()
+        self.addCleanup(style_patch.stop)
+        absent_patch = mock.patch("apps.storage.services.internal.s3_creation_preflight.ensure_s3_bucket_absent")
+        absent_patch.start()
+        self.addCleanup(absent_patch.stop)
         self.client = APIClient()
         user_model = get_user_model()
         self.user = user_model.objects.create_user(
@@ -174,6 +192,27 @@ class StorageRepositoryApiTests(TestCase):
         )
         return run_repository_create_task(repository_task_id=repository_task.id)
 
+    def test_preflight_failure_returns_error_without_repository_or_credential(self):
+        from apps.storage.services.internal.s3_client import S3ClientError
+        self.probe.side_effect = S3ClientError("Unable to delete probe: super-secret")
+        response = self._post_repository(self._s3_payload())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Repository.objects.count(), 0)
+        self.assertEqual(Credential.objects.count(), 0)
+        self.assertNotIn("super-secret", str(response.data))
+        self.assertIn("Unable to delete probe", str(response.data))
+
+    def test_new_bucket_creation_failure_returns_error_without_repository(self):
+        from apps.storage.services.internal.s3_client import S3ClientError
+        self.preflight_bucket.side_effect = S3ClientError("Bucket creation denied")
+        payload = self._s3_payload()
+        payload["s3_bucket_mode"] = "new"
+        response = self._post_repository(payload)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Repository.objects.count(), 0)
+        self.assertEqual(Credential.objects.count(), 0)
+        self.probe.assert_not_called()
+
     def test_create_s3_repository_requires_bucket_mode(self):
         payload = self._s3_payload()
         payload.pop("s3_bucket_mode")
@@ -265,7 +304,7 @@ class StorageRepositoryApiTests(TestCase):
         self.assertEqual(
             nested.status_code, status.HTTP_400_BAD_REQUEST, nested.content
         )
-        self.assertIn("overlaps repository", str(nested.data))
+        self.assertIn("overlaps an existing repository", str(nested.data))
         self.assertFalse(Repository.objects.filter(name="nested-s3").exists())
 
     def test_create_managed_s3_repository_rejects_unknown_catalog_region(self):
@@ -512,7 +551,7 @@ class StorageRepositoryApiTests(TestCase):
             self.assertEqual(
                 response.status_code, status.HTTP_202_ACCEPTED, response.content
             )
-            self.assertEqual(response.data["config"]["s3_url_style"], url_style)
+            self.assertEqual(response.data["config"]["s3_url_style"], "path" if url_style == "auto" else url_style)
             repo = Repository.objects.get(name=f"provider-{platform}")
             result = self._run_create_task(repo)
             self.assertEqual(result["status"], "success")

--- a/src/backend/apps/storage/tests/test_repository_selectors.py
+++ b/src/backend/apps/storage/tests/test_repository_selectors.py
@@ -47,7 +47,7 @@ class RepositorySelectorTests(TestCase):
                 flat=True,
             )
         )
-        self.assertEqual(names, ["created-repo", "failed-repo", "removed-repo"])
+        self.assertEqual(names, ["removed-repo", "failed-repo", "created-repo"])
 
     def test_status_filter_can_narrow_results(self):
         Repository.objects.create(
@@ -69,3 +69,17 @@ class RepositorySelectorTests(TestCase):
             ).values_list("name", flat=True)
         )
         self.assertEqual(names, ["failed-repo"])
+
+    def test_newest_first_with_stable_tie_breaker_before_pagination(self):
+        from datetime import timedelta
+        from django.utils import timezone
+        oldest = Repository.objects.create(organization_id=self.org.id, name="A", repo_type="s3")
+        second = Repository.objects.create(organization_id=self.org.id, name="Z", repo_type="nas")
+        newest = Repository.objects.create(organization_id=self.org.id, name="B", repo_type="s3")
+        now = timezone.now()
+        Repository.objects.filter(pk=oldest.pk).update(created_at=now - timedelta(days=1))
+        Repository.objects.filter(pk__in=[second.pk, newest.pk]).update(created_at=now)
+        rows = list_repositories(organization_id=self.org.id)
+        self.assertEqual(list(rows.values_list("id", flat=True)[:2]), [newest.id, second.id])
+        self.assertEqual(list(rows.values_list("id", flat=True)[2:]), [oldest.id])
+        self.assertEqual(list(list_repositories(organization_id=self.org.id, repo_type="s3").values_list("id", flat=True)), [newest.id, oldest.id])

--- a/src/backend/apps/storage/tests/test_s3_bucket_name.py
+++ b/src/backend/apps/storage/tests/test_s3_bucket_name.py
@@ -25,3 +25,14 @@ class S3BucketNameTests(SimpleTestCase):
             s3_bucket_name_error(platform="custom", bucket="Legacy_Bucket"),
             "",
         )
+
+    def test_aws_reserved_names(self):
+        for name in ("xn--bucket", "sthree-bucket", "amzn-s3-demo-bucket", "bucket-s3alias",
+                     "bucket--ol-s3", "bucket.mrap", "bucket--x-s3", "bucket--table-s3"):
+            with self.subTest(name=name):
+                self.assertIn("reserved", s3_bucket_name_error(platform="aws", bucket=name))
+                self.assertEqual(s3_bucket_name_error(platform="custom", bucket=name), "")
+
+    def test_generated_name_is_valid_for_managed_providers(self):
+        for platform in ("aws", "aliyun", "huaweicloud"):
+            self.assertEqual(s3_bucket_name_error(platform=platform, bucket="hfl-20260909080305"), "")

--- a/src/backend/apps/storage/tests/test_s3_client.py
+++ b/src/backend/apps/storage/tests/test_s3_client.py
@@ -871,6 +871,16 @@ class InitializeS3RepositoryBucketModeTests(TestCase):
         create_bucket.assert_called_once()
         check_bucket.assert_not_called()
 
+    @mock.patch("apps.storage.services.internal.repository_initializer.create_s3_repository")
+    @mock.patch("apps.storage.services.internal.repository_initializer.create_s3_bucket")
+    def test_preflighted_new_bucket_keeps_origin_without_recreating(self, create_bucket, create_repo):
+        repository = self._repository(Repository.S3BucketMode.NEW)
+        repository.config["s3_bucket_prepared"] = True
+        initialize_s3_repository(repository)
+        create_bucket.assert_not_called()
+        create_repo.assert_called_once()
+        self.assertEqual(repository.s3_bucket_mode, Repository.S3BucketMode.NEW)
+
     @mock.patch(
         "apps.storage.services.internal.repository_initializer.create_s3_repository"
     )

--- a/src/backend/apps/storage/tests/test_s3_creation_preflight.py
+++ b/src/backend/apps/storage/tests/test_s3_creation_preflight.py
@@ -1,0 +1,323 @@
+from unittest import mock
+from botocore.exceptions import ClientError
+from django.test import SimpleTestCase, TestCase
+from rest_framework.exceptions import ValidationError
+
+from apps.iam.models import Organization
+from apps.storage.repositories.models import Repository, Credential
+from apps.storage.services.interface import create_repository
+from apps.storage.services.internal.s3_client import S3ClientError
+from apps.storage.services.internal.s3_creation_preflight import (
+    verify_empty_prefix,
+    PROBE_NAME,
+    PROBE_METADATA,
+    PROBE_BODY,
+)
+
+MODULE = "apps.storage.services.internal.s3_creation_preflight"
+
+
+def missing():
+    return ClientError({"Error": {"Code": "404"}}, "HeadObject")
+
+
+class PrefixProbeTests(SimpleTestCase):
+    def setUp(self):
+        self.client = mock.MagicMock()
+        patcher = mock.patch(f"{MODULE}._client", return_value=self.client)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.client.head_object.side_effect = missing()
+        self.client.list_objects_v2.return_value = {}
+        self.client.put_object.return_value = {}
+        self.args = dict(
+            prefix="hfl6I09163025/",
+            endpoint="s3.example.com",
+            region="us-east-1",
+            bucket="backup",
+            access_key_id="key",
+            secret_access_key="secret",
+            s3_url_style="path",
+            use_tls=True,
+        )
+
+    def test_provider_hooks_use_real_botocore_event_signature(self):
+        from botocore.hooks import EventAliaser, HierarchicalEmitter
+        from botocore.awsrequest import AWSRequest
+
+        for platform, header in [
+            ("huaweicloud", "x-obs-forbid-overwrite"),
+            ("aliyun", "x-oss-forbid-overwrite"),
+        ]:
+            with self.subTest(platform=platform):
+                events = EventAliaser(HierarchicalEmitter())
+                self.client.meta.events = events
+                verify_empty_prefix(platform=platform, **self.args)
+                request = AWSRequest(method="PUT", url="https://example.test/probe")
+                events.emit("before-sign.s3.PutObject", request=request)
+                self.assertEqual(request.headers[header], "true")
+
+    def test_upload_delete_without_downloading(self):
+        verify_empty_prefix(**self.args)
+        self.client.get_object.assert_not_called()
+        self.assertEqual(
+            self.client.put_object.call_args.kwargs["Key"],
+            self.args["prefix"] + PROBE_NAME,
+        )
+        self.assertEqual(self.client.put_object.call_args.kwargs["IfNoneMatch"], "*")
+        self.client.delete_object.assert_called_once()
+
+    def test_occupied_prefix_does_not_upload(self):
+        self.client.list_objects_v2.return_value = {"Contents": [{"Key": "real-data"}]}
+        with self.assertRaisesMessage(S3ClientError, "already contains data"):
+            verify_empty_prefix(**self.args)
+        self.client.put_object.assert_not_called()
+
+    def test_recognized_residue_is_deleted_before_upload(self):
+        self.client.head_object.side_effect = [
+            dict(Metadata=PROBE_METADATA, ContentLength=len(PROBE_BODY)),
+            missing(),
+        ]
+        verify_empty_prefix(**self.args)
+        self.assertEqual(self.client.delete_object.call_count, 2)
+        names = [call[0] for call in self.client.method_calls]
+        self.assertLess(names.index("delete_object"), names.index("put_object"))
+
+    def test_unknown_reserved_file_is_not_deleted_or_overwritten(self):
+        self.client.head_object.side_effect = None
+        self.client.head_object.return_value = {"Metadata": {}, "ContentLength": 10}
+        with self.assertRaisesMessage(S3ClientError, "unrecognized metadata"):
+            verify_empty_prefix(**self.args)
+        self.client.put_object.assert_not_called()
+        self.client.delete_object.assert_not_called()
+
+    def test_versioned_residue_and_upload_delete_exact_versions(self):
+        self.client.head_object.side_effect = [
+            dict(
+                Metadata=PROBE_METADATA, ContentLength=len(PROBE_BODY), VersionId="old"
+            ),
+            missing(),
+        ]
+        self.client.put_object.return_value = {"VersionId": "new"}
+        verify_empty_prefix(**self.args)
+        self.assertEqual(
+            [c.kwargs["VersionId"] for c in self.client.delete_object.call_args_list],
+            ["old", "new"],
+        )
+
+    def test_listing_failure_does_not_write(self):
+        self.client.list_objects_v2.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied"}}, "ListObjectsV2"
+        )
+        with self.assertRaises(S3ClientError):
+            verify_empty_prefix(**self.args)
+        self.client.put_object.assert_not_called()
+        self.client.delete_object.assert_not_called()
+
+    def test_upload_failure_does_not_delete_an_unknown_object(self):
+        self.client.put_object.side_effect = ClientError(
+            {"Error": {"Code": "PreconditionFailed"}}, "PutObject"
+        )
+        with self.assertRaises(S3ClientError):
+            verify_empty_prefix(**self.args)
+        self.client.delete_object.assert_not_called()
+
+    def test_data_appearing_after_probe_is_rejected(self):
+        self.client.list_objects_v2.side_effect = [
+            {},
+            {},
+            {"Contents": [{"Key": "concurrent-data"}]},
+        ]
+        with self.assertRaisesMessage(S3ClientError, "already contains data"):
+            verify_empty_prefix(**self.args)
+
+    def test_delete_failure_reports_residue_path(self):
+        self.client.delete_object.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied"}}, "DeleteObject"
+        )
+        with self.assertRaisesMessage(S3ClientError, self.args["prefix"] + PROBE_NAME):
+            verify_empty_prefix(**self.args)
+
+
+class RepositoryPreflightTests(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(key="s3-preflight", name="S3 preflight")
+        self.args = dict(
+            organization_id=self.org.id,
+            name="Repository",
+            repo_type="s3",
+            s3_bucket="backup",
+            s3_platform="custom",
+            s3_bucket_mode="existing",
+            config=dict(
+                endpoint="s3.example.com",
+                prefix="hfl6I09163025/",
+                access_key_id="key",
+                secret_access_key="secret",
+                s3_url_style="path",
+            ),
+        )
+        self.absent = self.patch(f"{MODULE}.ensure_s3_bucket_absent")
+        self.bucket = self.patch(f"{MODULE}.create_s3_bucket", return_value=True)
+        self.rollback = self.patch(
+            f"{MODULE}.delete_s3_bucket_if_empty", return_value={"status": "deleted"}
+        )
+        self.probe = self.patch(f"{MODULE}.verify_empty_prefix")
+        self.patch(
+            "apps.storage.services.internal.repository_initializer.resolve_s3_url_style",
+            return_value="path",
+        )
+        self.patch("apps.storage.services.interface.enqueue_repository_create_task")
+
+    def patch(self, target, **kwargs):
+        patcher = mock.patch(target, **kwargs)
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+    def assert_no_records(self):
+        self.assertEqual(Repository.objects.count(), 0)
+        self.assertEqual(Credential.objects.count(), 0)
+
+    def test_new_bucket_failure_creates_no_record(self):
+        self.args["s3_bucket_mode"] = "new"
+        self.bucket.side_effect = S3ClientError("denied")
+        with self.assertRaises(ValidationError):
+            create_repository(**self.args)
+        self.assert_no_records()
+        self.probe.assert_not_called()
+
+    def test_probe_failure_creates_no_record(self):
+        self.probe.side_effect = S3ClientError("denied")
+        with self.assertRaises(ValidationError):
+            create_repository(**self.args)
+        self.assert_no_records()
+
+    def test_both_bucket_modes_probe_before_creating_record(self):
+        def probe(**kwargs):
+            self.assert_no_records()
+
+        self.probe.side_effect = probe
+        repository = create_repository(**self.args)
+        self.assertEqual(repository.status, "creating")
+        self.bucket.assert_not_called()
+
+    def test_parent_prefix_conflict_prevents_probe_and_record(self):
+        Repository.objects.create(
+            organization_id=self.org.id,
+            name="Parent",
+            repo_type="s3",
+            s3_bucket="backup",
+            s3_platform="custom",
+            config=dict(endpoint="s3.example.com", prefix="hfl/"),
+        )
+        self.args["config"]["prefix"] = "hfl/child/"
+        with self.assertRaises(ValidationError):
+            create_repository(**self.args)
+        self.probe.assert_not_called()
+        self.assertEqual(Repository.objects.count(), 1)
+
+    def test_request_always_runs_probe(self):
+        self.probe.side_effect = S3ClientError("denied")
+        with self.assertRaises(ValidationError):
+            create_repository(**self.args)
+        self.assert_no_records()
+
+    def test_concurrent_preparation_is_rejected_before_writes(self):
+        lock = self.patch(f"{MODULE}.repository_execution_lock")
+        lock.return_value.__enter__.return_value = False
+        with self.assertRaisesMessage(ValidationError, "Another repository creation"):
+            create_repository(**self.args)
+        self.assert_no_records()
+        self.probe.assert_not_called()
+        self.bucket.assert_not_called()
+
+    def test_different_prefix_cannot_reuse_bucket_preparation(self):
+        self.args["s3_bucket_mode"] = "new"
+        self.probe.side_effect = S3ClientError("denied")
+        with self.assertRaises(ValidationError):
+            create_repository(**self.args)
+        self.args["config"]["prefix"] = "different/"
+        self.bucket.side_effect = S3ClientError("already exists")
+        with self.assertRaises(ValidationError):
+            create_repository(**self.args)
+        self.assertEqual(self.bucket.call_count, 2)
+        self.assert_no_records()
+
+    def test_new_bucket_retains_origin_and_skips_duplicate_creation(self):
+        self.args["s3_bucket_mode"] = "new"
+        repository = create_repository(**self.args)
+        self.bucket.assert_called_once()
+        self.assertEqual(repository.s3_bucket_mode, "new")
+        self.assertTrue(repository.config["s3_bucket_prepared"])
+        self.rollback.assert_not_called()
+
+    def test_new_bucket_validation_failure_rolls_back(self):
+        self.args["s3_bucket_mode"] = "new"
+        self.probe.side_effect = S3ClientError("probe denied")
+        with self.assertRaises(ValidationError):
+            create_repository(**self.args)
+        self.rollback.assert_called_once()
+        self.assert_no_records()
+
+    def test_unexpected_probe_failure_also_rolls_back(self):
+        self.args["s3_bucket_mode"] = "new"
+        self.probe.side_effect = TypeError("bad hook")
+        with self.assertRaises(TypeError):
+            create_repository(**self.args)
+        self.rollback.assert_called_once()
+        self.assert_no_records()
+
+    def test_failed_rollback_is_visible(self):
+        self.args["s3_bucket_mode"] = "new"
+        self.probe.side_effect = S3ClientError("probe denied")
+        self.rollback.return_value = {"status": "failed", "reason": "access denied"}
+        with self.assertRaisesMessage(ValidationError, "could not be rolled back"):
+            create_repository(**self.args)
+        self.assert_no_records()
+
+    def test_existing_bucket_in_new_mode_stops_before_any_mutation(self):
+        from apps.storage.services.internal.s3_creation_preflight import (
+            S3BucketAlreadyExists,
+        )
+
+        self.args["s3_bucket_mode"] = "new"
+        self.absent.side_effect = S3BucketAlreadyExists("Bucket already exists.")
+        with self.assertRaises(ValidationError) as error:
+            create_repository(**self.args)
+        self.assertIn("s3_bucket", error.exception.detail)
+        self.bucket.assert_not_called()
+        self.probe.assert_not_called()
+        self.rollback.assert_not_called()
+        self.assert_no_records()
+
+
+class BucketExistenceTests(SimpleTestCase):
+    @mock.patch(f"{MODULE}._client")
+    def test_only_missing_bucket_may_proceed(self, make_client):
+        from apps.storage.services.internal.s3_creation_preflight import (
+            ensure_s3_bucket_absent,
+            S3BucketAlreadyExists,
+        )
+
+        client = make_client.return_value
+        args = dict(
+            bucket="example",
+            endpoint="example.test",
+            region="test",
+            access_key_id="test",
+            secret_access_key="test",
+            s3_url_style="path",
+            use_tls=True,
+        )
+        with self.assertRaises(S3BucketAlreadyExists):
+            ensure_s3_bucket_absent(**args)
+        client.head_bucket.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadBucket"
+        )
+        ensure_s3_bucket_absent(**args)
+        client.head_bucket.side_effect = ClientError(
+            {"Error": {"Code": "403"}}, "HeadBucket"
+        )
+        with self.assertRaises(S3ClientError):
+            ensure_s3_bucket_absent(**args)
+        client.create_bucket.assert_not_called()

--- a/src/frontend/src/lib/kopiaProgress.test.ts
+++ b/src/frontend/src/lib/kopiaProgress.test.ts
@@ -2,39 +2,27 @@ import { describe, expect, it } from 'vitest'
 
 import { formatSpeedBps, transferCapacityText, transferMetricParts, transferSpeedParts } from './kopiaProgress'
 
-const t = (key: string, args?: Record<string, unknown>) => {
-  if (key.endsWith('bytesCapacityRef')) return `Transferred: ${args?.done} / source data: ${args?.total}`
-  if (key.endsWith('bytesCapacityEst')) return `Incremental transfer: ${args?.done} / est. ${args?.total}`
-  if (key.endsWith('bytesCapacity')) return `${args?.done} / ${args?.total}`
-  if (key.endsWith('bytesProcessedCapacity')) return `Processed: ${args?.done} / ${args?.total}`
-  if (key.endsWith('bytesProcessed')) return `Processed: ${args?.size}`
-  if (key.endsWith('restoreBytesCapacity')) return `Data restored: ${args?.done} / ${args?.total}`
-  if (key.endsWith('restoreSpeed')) return `Restore speed: ${args?.speed}`
-  if (key.endsWith('restoreEtaHoursMinutes')) return `${args?.h}h ${args?.m}m remaining`
-  if (key.endsWith('hashSpeed')) return `Scanning: ${args?.speed}`
-  if (key.endsWith('processingSpeed')) return `Processing speed: ${args?.speed}`
-  if (key.endsWith('uploadSpeed')) return `Upload: ${args?.speed}`
-  if (key.endsWith('etaSeconds')) return `${args?.n}s left`
-  return key
-}
+import { createI18n } from 'vue-i18n'
+import { enProtectionPages } from '../locales/enProtectionPages'
+const t = createI18n({ legacy: false, locale: 'en', messages: { en: { protection: enProtectionPages } } }).global.t
 
 describe('transferCapacityText', () => {
-  it('labels the logical source-data reference total explicitly', () => {
+  it('uses backup progress for the reference total', () => {
     expect(transferCapacityText(t, {
       bytes_done: 5_000_000,
       bytes_total: 2_000_000_000,
       bytes_total_known: true,
       bytes_total_reference: true,
-    })).toBe('Transferred: 4.77 MB / source data: 1.86 GB')
+    })).toBe('Backup progress: 4.77 MB / 1.86 GB')
   })
 
-  it('labels a Kopia estimate as incremental transfer volume', () => {
+  it('uses backup progress for an estimated total', () => {
     expect(transferCapacityText(t, {
       bytes_done: 5_000_000,
       bytes_total: 12_500_000,
       bytes_total_known: true,
       estimated_bytes: 12_500_000,
-    })).toBe('Incremental transfer: 4.77 MB / est. 11.9 MB')
+    })).toBe('Backup progress: 4.77 MB / 11.9 MB')
   })
 
   it('uses logical processed bytes for schema v2 capacity', () => {
@@ -46,7 +34,7 @@ describe('transferCapacityText', () => {
       bytes_total: 4_130_621_356,
       bytes_total_known: true,
       estimated_bytes: 4_130_621_356,
-    })).toBe('Processed: 3.24 GB / 3.85 GB')
+    })).toBe('Backup progress: 3.24 GB / 3.85 GB')
   })
 
   it('uses restore-specific wording for restore capacity', () => {
@@ -67,26 +55,26 @@ describe('transferCapacityText', () => {
       bytes_total: null,
       bytes_total_known: false,
       uploaded_bytes: 192,
-    })).toBe('Processed: 2.94 GB')
+    })).toBe('Backup progress: 2.94 GB')
   })
 })
 
 describe('transferSpeedParts', () => {
-  it('labels hash throughput instead of presenting it as upload throughput', () => {
+  it('hides legacy hash throughput for backups', () => {
     expect(transferSpeedParts(t, {
       phase: 'transferring',
       speed_bps: 393_000_000,
       hash_speed_bps: 393_000_000,
-    })).toEqual(['Scanning: 375 MB/s'])
+    })).toEqual([])
   })
 
-  it('uses processed-byte throughput for backup progress', () => {
+  it('hides processed-byte throughput for backups', () => {
     expect(transferSpeedParts(t, {
       phase: 'transferring',
       progress_schema_version: 2,
       processing_speed_bps: 19_293_000,
       upload_speed_bps: 5_740_000,
-    })).toEqual(['18.4 MB/s'])
+    })).toEqual([])
   })
 
   it('does not display an unclassified legacy speed', () => {
@@ -120,13 +108,13 @@ describe('transferSpeedParts', () => {
     expect(formatSpeedBps(null)).toBeNull()
   })
 
-  it('presents schema-v2 processing throughput with its own label', () => {
+  it('hides processing throughput even when labels are requested', () => {
     expect(transferSpeedParts(t, {
       phase: 'transferring',
       progress_schema_version: 2,
       processing_speed_bps: 393_000_000,
       hash_speed_bps: 393_000_000,
-    }, { labelProcessingSpeed: true })).toEqual(['Processing speed: 375 MB/s'])
+    }, { labelProcessingSpeed: true })).toEqual([])
   })
 
   it('hides ETA while finalizing', () => {
@@ -138,6 +126,32 @@ describe('transferSpeedParts', () => {
       bytes_total: 1_000,
       bytes_total_known: true,
       eta_seconds: 30,
-    })).not.toContain('30s left')
+    })).not.toContain('About 30s remaining')
+  })
+})
+
+
+describe('backup display and restore isolation', () => {
+  it.each([
+    [45, 'About 45s remaining'], [120, 'About 2 min remaining'],
+    [3600, 'About 1h remaining'], [3660, 'About 1h 1m remaining'],
+  ])('formats backup ETA %s without speed', (seconds, expected) => {
+    const transfer = { bytes_done: 1024, bytes_total: 2048, bytes_total_known: true,
+      phase: 'transferring', eta_seconds: Number(seconds), processing_speed_bps: 123456 }
+    const parts = transferMetricParts(t, transfer)
+    expect(parts.at(-1)).toBe(expected)
+    expect(parts).toHaveLength(2)
+    expect(parts.join(' ')).not.toContain('/s')
+  })
+  it('preserves restore ETA and unknown-total wording', () => {
+    expect(transferMetricParts(t, {
+      label_key: 'protection.taskProgress.restore.transferring', bytes_done: 1024,
+      bytes_total: 2048, bytes_total_known: true, phase: 'transferring',
+      eta_seconds: 120, upload_speed_bps: 1024,
+    })).toEqual(['Data restored: 1.00 KB / 2.00 KB', 'Restore speed: 1.00 KB/s', '2 min left'])
+    expect(transferCapacityText(t, {
+      label_key: 'protection.taskProgress.restore.transferring', progress_schema_version: 2,
+      processed_bytes: 1024, bytes_total_known: false,
+    })).toBe('Processed: 1.00 KB')
   })
 })

--- a/src/frontend/src/lib/kopiaProgress.ts
+++ b/src/frontend/src/lib/kopiaProgress.ts
@@ -164,19 +164,20 @@ export function formatSpeedBps(value: number | null | undefined): string | null 
   return `${formatBytes(bps)}/s`
 }
 
-export function transferEtaText(t: TranslateFn, value: number | null | undefined): string | null {
+export function transferEtaText(t: TranslateFn, value: number | null | undefined, backup = false): string | null {
+  const key = backup ? 'backupEta' : 'eta'
   const seconds = Number(value || 0)
   if (!Number.isFinite(seconds) || seconds <= 0) return null
-  if (seconds < 60) return t('protection.taskProgress.etaSeconds', { n: seconds })
-  if (seconds < 3600) return t('protection.taskProgress.etaMinutes', { n: Math.ceil(seconds / 60) })
+  if (seconds < 60) return t(`protection.taskProgress.${key}Seconds`, { n: seconds })
+  if (seconds < 3600) return t(`protection.taskProgress.${key}Minutes`, { n: Math.ceil(seconds / 60) })
   const hours = Math.floor(seconds / 3600)
   const minutes = Math.ceil((seconds % 3600) / 60)
   return minutes > 0
-    ? t('protection.taskProgress.etaHoursMinutes', { h: hours, m: minutes })
-    : t('protection.taskProgress.etaHours', { n: hours })
+    ? t(`protection.taskProgress.${key}HoursMinutes`, { h: hours, m: minutes })
+    : t(`protection.taskProgress.${key}Hours`, { n: hours })
 }
 
-export function transferCapacityText(t: TranslateFn, transfer?: TransferProgress | null): string | null {
+export function transferCapacityText(t: TranslateFn, transfer?: TransferProgress | null, preserveLegacyRestore = false): string | null {
   if (!transfer) return null
   const isRestore = String(transfer.label_key || '').includes('taskProgress.restore.')
   const schemaV2 = Number(transfer.progress_schema_version || 1) >= 2
@@ -184,6 +185,12 @@ export function transferCapacityText(t: TranslateFn, transfer?: TransferProgress
     ? Number(transfer.processed_bytes ?? transfer.bytes_done ?? 0)
     : Number(transfer.bytes_done || 0)
   const done = formatBytes(processedBytes)
+  if (!isRestore && !preserveLegacyRestore) {
+    if (transfer.bytes_total_known && transfer.bytes_total != null) {
+      return t('protection.taskProgress.backupBytesCapacity', { done, total: formatBytes(transfer.bytes_total) })
+    }
+    return processedBytes > 0 ? t('protection.taskProgress.backupBytes', { size: done }) : null
+  }
   if (transfer.bytes_total_known && transfer.bytes_total != null) {
     const total = formatBytes(transfer.bytes_total)
     if (isRestore) {
@@ -274,6 +281,8 @@ export function transferSpeedParts(
 ): string[] {
   if (!transfer) return []
   const isRestore = String(transfer.label_key || '').includes('taskProgress.restore.')
+  if (!isRestore && !options.labelRestoreMetrics && !options.allowUnclassifiedSpeed) return []
+  // Legacy restore callers can supply classification through options instead of a label.
   const processingSpeed = formatSpeedBps(transfer.processing_speed_bps)
   if (processingSpeed && !isRestore) {
     return options.labelProcessingSpeed
@@ -303,7 +312,7 @@ export function transferMetricParts(
 ): string[] {
   if (!transfer) return []
   const parts: string[] = []
-  const capacity = transferCapacityText(t, transfer)
+  const capacity = transferCapacityText(t, transfer, options.labelRestoreMetrics)
   if (capacity) parts.push(capacity)
   parts.push(...transferSpeedParts(t, transfer, options))
   const phase = String(transfer.phase || '').toLowerCase()
@@ -311,7 +320,7 @@ export function transferMetricParts(
     ? null
     : options.labelRestoreMetrics
       ? restoreTransferEtaText(t, transfer.eta_seconds)
-      : transferEtaText(t, transfer.eta_seconds)
+      : transferEtaText(t, transfer.eta_seconds, !String(transfer.label_key || '').includes('taskProgress.restore.'))
   if (eta) parts.push(eta)
   return parts
 }

--- a/src/frontend/src/lib/nasRepositoryName.test.ts
+++ b/src/frontend/src/lib/nasRepositoryName.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { buildNasRepositoryName } from './nasRepositoryName'
+
+describe('NAS repository display names', () => {
+  it.each([
+    ['smb', '192.168.1.10', 'backup', 'SMB(192.168.1.10/backup)'],
+    ['nfs', 'nas.example.com', '/volume1/backup/', 'NFS(nas.example.com/backup)'],
+    ['smb', ' nas.example.com ', '\\volume1\\backup', 'SMB(nas.example.com/backup)'],
+    ['nfs', 'nas.example.com', '/', 'NFS(nas.example.com/)'],
+    ['smb', '', 'backup', ''],
+  ] as const)('builds %s name for %s %s', (protocol, host, path, expected) => {
+    expect(buildNasRepositoryName(protocol, host, path)).toBe(expected)
+  })
+})

--- a/src/frontend/src/lib/nasRepositoryName.ts
+++ b/src/frontend/src/lib/nasRepositoryName.ts
@@ -1,0 +1,9 @@
+/** Display name only; never changes the NAS connection or storage path. */
+export function buildNasRepositoryName(protocol: 'smb' | 'nfs', server: string, path: string): string {
+  const host = server.trim()
+  if (!host) return ''
+  const normalizedPath = path.trim().replace(/\\/g, '/')
+  const leaf = normalizedPath.split('/').filter(Boolean).at(-1)
+  const location = leaf ? `${host}/${leaf}` : normalizedPath ? `${host}/` : host
+  return `${protocol.toUpperCase()}(${location})`
+}

--- a/src/frontend/src/lib/s3BucketName.test.ts
+++ b/src/frontend/src/lib/s3BucketName.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { s3BucketNameError } from './s3BucketName'
+import { generateS3BucketName, s3BucketNameError } from './s3BucketName'
 
 describe('managed S3 new-bucket names', () => {
   it.each(['backup-001', 'team.backup-001'])(
@@ -26,4 +26,22 @@ describe('managed S3 new-bucket names', () => {
     expect(s3BucketNameError('custom', 'Legacy_Bucket')).toBeNull()
     expect(s3BucketNameError('other', 'Legacy_Bucket')).toBeNull()
   })
+})
+
+
+describe('generated bucket names and AWS reserved names', () => {
+  it('uses a padded local timestamp accepted by all managed providers', () => {
+    const name = generateS3BucketName(new Date(2026, 8, 9, 8, 3, 5))
+    expect(name).toBe('hfl-20260909080305')
+    for (const platform of ['aws', 'aliyun', 'huaweicloud']) {
+      expect(s3BucketNameError(platform, name)).toBeNull()
+    }
+  })
+  it.each(['xn--bucket', 'sthree-bucket', 'amzn-s3-demo-bucket', 'bucket-s3alias',
+    'bucket--ol-s3', 'bucket.mrap', 'bucket--x-s3', 'bucket--table-s3'])(
+    'rejects AWS reserved name %s', (name) => {
+      expect(s3BucketNameError('aws', name)).toBe('aws_reserved')
+      expect(s3BucketNameError('custom', name)).toBeNull()
+    },
+  )
 })

--- a/src/frontend/src/lib/s3BucketName.ts
+++ b/src/frontend/src/lib/s3BucketName.ts
@@ -1,3 +1,12 @@
+export function generateS3BucketName(now = new Date()): string {
+  const date = [now.getMonth() + 1, now.getDate(), now.getHours(), now.getMinutes(), now.getSeconds()]
+    .map((part) => String(part).padStart(2, '0')).join('')
+  return `hfl-${now.getFullYear()}${date}`
+}
+
+const AWS_RESERVED_PREFIXES = ['xn--', 'sthree-', 'amzn-s3-demo-']
+const AWS_RESERVED_SUFFIXES = ['-s3alias', '--ol-s3', '.mrap', '--x-s3', '--table-s3']
+
 const DNS_STYLE_PLATFORMS = new Set(['aws', 'huaweicloud'])
 const DNS_BUCKET_PATTERN = /^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/
 const ALIYUN_BUCKET_PATTERN = /^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/
@@ -11,7 +20,7 @@ function isIpv4Address(value: string): boolean {
   })
 }
 
-export type S3BucketNameError = 'aliyun' | 'dns' | 'dns_label' | 'ip_address' | null
+export type S3BucketNameError = 'aliyun' | 'dns' | 'dns_label' | 'ip_address' | 'aws_reserved' | null
 
 /** Mirror managed-provider naming rules for immediate form feedback.
  *
@@ -21,6 +30,10 @@ export type S3BucketNameError = 'aliyun' | 'dns' | 'dns_label' | 'ip_address' | 
 export function s3BucketNameError(platform: unknown, bucket: unknown): S3BucketNameError {
   const normalizedPlatform = String(platform || '').trim().toLowerCase()
   const name = String(bucket || '').trim()
+  if (normalizedPlatform === 'aws' && (
+    AWS_RESERVED_PREFIXES.some((prefix) => name.startsWith(prefix))
+    || AWS_RESERVED_SUFFIXES.some((suffix) => name.endsWith(suffix))
+  )) return 'aws_reserved'
   if (normalizedPlatform === 'aliyun') {
     return ALIYUN_BUCKET_PATTERN.test(name) ? null : 'aliyun'
   }

--- a/src/frontend/src/lib/s3PlatformDisplay.test.ts
+++ b/src/frontend/src/lib/s3PlatformDisplay.test.ts
@@ -4,7 +4,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import ElementPlus from 'element-plus'
 import { describe, expect, it, vi } from 'vitest'
 import {
-  DEFAULT_S3_OBJECT_PREFIX,
+  generateS3ObjectPrefix,
   distinctS3EndpointPair,
   normalizeS3ObjectPrefix,
 } from './s3PlatformDisplay'
@@ -102,9 +102,25 @@ describe('S3 object prefix defaults', () => {
     expect(distinctS3EndpointPair('s3.example.com', '')).toBeNull()
   })
 
-  it('uses the stable HyperFileLens namespace by default', () => {
-    expect(DEFAULT_S3_OBJECT_PREFIX).toBe('hfl/')
-    expect(normalizeS3ObjectPrefix(DEFAULT_S3_OBJECT_PREFIX)).toBe('hfl/')
+  it('generates a prefix from the local date and zero-padded time', () => {
+    const prefix = generateS3ObjectPrefix(new Date(2026, 8, 9, 8, 3, 5))
+    expect(prefix).toBe('hfl6I09080305/')
+    expect(normalizeS3ObjectPrefix(prefix)).toBe('hfl6I09080305/')
+    expect(generateS3ObjectPrefix(new Date(2026, 8, 9, 16, 30, 25)))
+      .toBe('hfl6I09163025/')
+  })
+
+  it.each([...'ABCDEFGHIJKL'])('encodes month %s', (month) => {
+    const monthIndex = 'ABCDEFGHIJKL'.indexOf(month)
+    expect(generateS3ObjectPrefix(new Date(2030, monthIndex, 1, 0, 0, 0)))
+      .toBe(`hfl0${month}01000000/`)
+  })
+
+  it('handles the year boundary', () => {
+    expect(generateS3ObjectPrefix(new Date(2029, 11, 31, 23, 59, 59)))
+      .toBe('hfl9L31235959/')
+    expect(generateS3ObjectPrefix(new Date(2030, 0, 1, 0, 0, 0)))
+      .toBe('hfl0A01000000/')
   })
 
   it('pre-fills the Add Object Storage Repository prefix input', async () => {
@@ -119,7 +135,31 @@ describe('S3 object prefix defaults', () => {
     await flushPromises()
 
     expect(wrapper.findAll('input').map((input) => input.element.value))
-      .toContain(DEFAULT_S3_OBJECT_PREFIX)
+      .toEqual(expect.arrayContaining([expect.stringMatching(/^hfl\d[A-L]\d{8}\/$/)]))
+    wrapper.unmount()
+  })
+
+  it('generates a new bucket name, validates edits and preserves the draft across modes', async () => {
+    const wrapper = mount(AddS3Repo, {
+      props: { embedded: true },
+      global: { plugins: [ElementPlus], stubs: { S3PlatformBrandIcon: true } },
+    })
+    await flushPromises()
+    await wrapper.findAll('.add-s3-platform-btn')[0].trigger('click')
+    const mode = (value: string) => wrapper.find(`input[type="radio"][value="${value}"]`)
+    await mode('new').setValue(true)
+    const bucketInput = () => wrapper.find('input[placeholder="addS3Repo.phBucketNew"]')
+    expect((bucketInput().element as HTMLInputElement).value).toMatch(/^hfl-\d{14}$/)
+    await bucketInput().setValue('UPPERCASE')
+    expect(wrapper.find('[data-validation-field="bucket"] [role="status"]').text())
+      .toBe('addS3Repo.bucketNameErrors.dns')
+    await bucketInput().setValue('bucket--x-s3')
+    expect(wrapper.text()).toContain('addS3Repo.bucketNameErrors.aws_reserved')
+    await bucketInput().setValue('my-backup-bucket')
+    expect(wrapper.find('[data-validation-field="bucket"] .el-form-item__error').exists()).toBe(false)
+    await mode('existing').setValue(true)
+    await mode('new').setValue(true)
+    expect((bucketInput().element as HTMLInputElement).value).toBe('my-backup-bucket')
     wrapper.unmount()
   })
 

--- a/src/frontend/src/lib/s3PlatformDisplay.ts
+++ b/src/frontend/src/lib/s3PlatformDisplay.ts
@@ -8,7 +8,15 @@ export type S3StoragePlatform =
   | 'other'
   | 'custom'
 
-export const DEFAULT_S3_OBJECT_PREFIX = 'hfl/'
+export function generateS3ObjectPrefix(now = new Date()): string {
+  const year = now.getFullYear() % 10
+  const month = 'ABCDEFGHIJKL'[now.getMonth()]
+  const day = String(now.getDate()).padStart(2, '0')
+  const time = [now.getHours(), now.getMinutes(), now.getSeconds()]
+    .map((part) => String(part).padStart(2, '0'))
+    .join('')
+  return `hfl${year}${month}${day}${time}/`
+}
 
 const PLATFORM_LABEL_KEYS: Record<S3StoragePlatform, string> = {
   aliyun: 'addS3Repo.platformAliyun',

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -2683,7 +2683,7 @@ export const en = {
     hintSmbUsername: 'SMB user used to access the shared directory, e.g. backup_user.',
     hintSmbPassword: 'Password for the shared directory; logs and errors are masked.',
     hintSmbDomain: 'Use CORP or WORKGROUP for domain environments; leave empty for local users.',
-    hintRepositoryName: 'Display name used in repository lists and backup configs, e.g. Production NAS backup.',
+    hintRepositoryName: 'Automatically filled from the protocol, server, and last part of the shared path. You can edit it; clear the name to restore automatic naming.',
     errSmbHost: 'Enter server address',
     errSmbShare: 'Enter share name',
   },
@@ -2844,6 +2844,7 @@ export const en = {
     errBucket: 'Please select a bucket',
     errBucketName: 'Please enter a bucket name',
     bucketNameErrors: {
+      aws_reserved: 'This name uses an Amazon S3 reserved prefix or suffix.',
       aliyun: 'Use 3–63 lowercase letters, numbers, or hyphens; start and end with a letter or number.',
       dns: 'Use 3–63 lowercase letters, numbers, hyphens, or periods; start and end with a letter or number.',
       dns_label: 'Each part between periods must start and end with a letter or number.',

--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -1,6 +1,13 @@
 /** English copy for data protection sub-pages */
 export const enProtectionPages = {
   taskProgress: {
+    backupBytes: 'Backup progress: {size}',
+    backupBytesCapacity: 'Backup progress: {done} / {total}',
+    backupEtaSeconds: 'About {n}s remaining',
+    backupEtaMinutes: 'About {n} min remaining',
+    backupEtaHours: 'About {n}h remaining',
+    backupEtaHoursMinutes: 'About {h}h {m}m remaining',
+
     bytesTransferred: '{size} transferred',
     bytesProcessed: 'Processed: {size}',
     bytesCapacity: '{done} / {total}',

--- a/src/frontend/src/pages/node/AddNasRepository.vue
+++ b/src/frontend/src/pages/node/AddNasRepository.vue
@@ -17,6 +17,7 @@ import {
 import { listAllNodes } from '../../lib/nodeApi'
 import { SMB_MOUNT_OPTION_EXAMPLES } from '../../lib/nasMountTroubleshooting'
 import { defaultNasMountOptions } from '../../lib/nasMountOptions'
+import { buildNasRepositoryName } from '../../lib/nasRepositoryName'
 import { preflightNasRepositoryCreate, showNasDraftPreflightGuidance } from '../../lib/nasDraftPreflight'
 import { proxyAgentsRoute } from '../../lib/nodeDeployRoutes'
 import type { ApiNode } from '../../types/node'
@@ -76,6 +77,26 @@ const nfsExport = ref('')
 
 /* Step 1: repo info */
 const repoName = ref('')
+const repoNameManuallyEdited = ref(false)
+
+function syncAutoRepoName() {
+  if (repoNameManuallyEdited.value) return
+  repoName.value = buildNasRepositoryName(
+    protocol.value,
+    protocol.value === 'smb' ? smbHost.value : nfsHost.value,
+    protocol.value === 'smb' ? smbShare.value : nfsExport.value,
+  )
+  if (repoName.value) clearFieldError('repoName')
+}
+
+function onRepoNameInput(value: string) {
+  repoNameManuallyEdited.value = !!value.trim()
+  clearFieldError('repoName')
+  if (!repoNameManuallyEdited.value) syncAutoRepoName()
+}
+
+watch([protocol, smbHost, smbShare, nfsHost, nfsExport], syncAutoRepoName)
+
 const quota = ref(0)
 const quotaUnit = ref<RepositoryQuotaUnit>('GB')
 const enableQuotaAlert = ref(false)
@@ -694,7 +715,7 @@ watch(enableQuotaAlert, (enabled) => {
                     <ElInput
                       v-model="repoName"
                       :placeholder="t('repositoriesPage.phRepoName')"
-                      @input="clearFieldError('repoName')"
+                      @input="onRepoNameInput"
                     />
                     <div class="mt-1 text-xs text-[rgb(100_116_139)]">
                       {{ t('addNasRepo.hintRepositoryName') }}

--- a/src/frontend/src/pages/node/AddNasRepositoryProxyDecision.test.ts
+++ b/src/frontend/src/pages/node/AddNasRepositoryProxyDecision.test.ts
@@ -86,7 +86,7 @@ async function fillRequiredNfsFields(wrapper: VueWrapper) {
   await nextTick()
   fieldInput(wrapper, en.addNasRepo.fieldNfsHost).vm.$emit('update:modelValue', '192.168.50.10')
   fieldInput(wrapper, en.addNasRepo.fieldNfsExport).vm.$emit('update:modelValue', '/exports/backup')
-  fieldInput(wrapper, en.repositoriesPage.fieldRepoName).vm.$emit('update:modelValue', 'Primary NAS')
+  await fieldInput(wrapper, en.repositoriesPage.fieldRepoName).find('input').setValue('Primary NAS')
   await nextTick()
 }
 
@@ -95,7 +95,7 @@ async function fillRequiredSmbFields(wrapper: VueWrapper) {
   fieldInput(wrapper, en.addNasRepo.fieldSmbShare).vm.$emit('update:modelValue', 'smb-share')
   fieldInput(wrapper, en.repositoriesPage.fieldSmbUsername).vm.$emit('update:modelValue', 'backup')
   fieldInput(wrapper, en.repositoriesPage.fieldSmbPassword).vm.$emit('update:modelValue', 'secret')
-  fieldInput(wrapper, en.repositoriesPage.fieldRepoName).vm.$emit('update:modelValue', 'Primary SMB')
+  await fieldInput(wrapper, en.repositoriesPage.fieldRepoName).find('input').setValue('Primary SMB')
   await nextTick()
 }
 
@@ -116,6 +116,28 @@ function submitButton(wrapper: VueWrapper) {
 }
 
 describe('AddNasRepository Proxy decision', () => {
+  it('auto-names NAS repositories, preserves manual edits and restores automation when cleared', async () => {
+    const wrapper = await mountForm({ embedded: true })
+    const input = (label: string) => fieldInput(wrapper, label).find('input')
+    const name = () => input(en.repositoriesPage.fieldRepoName)
+    await input(en.addNasRepo.fieldSmbHost).setValue('192.168.1.10')
+    await input(en.addNasRepo.fieldSmbShare).setValue('backup')
+    expect((name().element as HTMLInputElement).value).toBe('SMB(192.168.1.10/backup)')
+    await name().setValue('My NAS')
+    await input(en.addNasRepo.fieldSmbShare).setValue('archive')
+    expect((name().element as HTMLInputElement).value).toBe('My NAS')
+    wrapper.findComponent(ElRadioGroup).vm.$emit('update:modelValue', 'nfs')
+    await nextTick()
+    await input(en.addNasRepo.fieldNfsHost).setValue('nas.example.com')
+    await input(en.addNasRepo.fieldNfsExport).setValue('/volume1/backup')
+    expect((name().element as HTMLInputElement).value).toBe('My NAS')
+    await name().setValue('')
+    expect((name().element as HTMLInputElement).value).toBe('NFS(nas.example.com/backup)')
+    await input(en.addNasRepo.fieldNfsExport).setValue('/volume1/archive/')
+    expect((name().element as HTMLInputElement).value).toBe('NFS(nas.example.com/archive)')
+    wrapper.unmount()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.listAllNodes.mockResolvedValue(proxyNodes)

--- a/src/frontend/src/pages/node/AddS3Repo.vue
+++ b/src/frontend/src/pages/node/AddS3Repo.vue
@@ -4,7 +4,7 @@ import { ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ElMessage } from 'element-plus'
-import { api, apiErrorMessage } from '../../lib/api'
+import { api, apiErrorMessage, type ApiError } from '../../lib/api'
 import {
   createStorageRepository,
   storageRepositoryS3BucketMode,
@@ -13,13 +13,13 @@ import {
 } from '../../lib/storageRepositoryApi'
 import { fetchStorageProviderCatalog, type StorageProviderConfig } from '../../lib/storageProviderCatalogApi'
 import {
-  DEFAULT_S3_OBJECT_PREFIX,
+  generateS3ObjectPrefix,
   normalizeS3EndpointInput,
   normalizeS3ObjectPrefix,
   s3EndpointDisplay,
 } from '../../lib/s3PlatformDisplay'
 import { buildS3RepositoryName } from '../../lib/s3RepositoryName'
-import { s3BucketNameError } from '../../lib/s3BucketName'
+import { generateS3BucketName, s3BucketNameError } from '../../lib/s3BucketName'
 import {
   REPOSITORY_QUOTA_UNITS,
   repositoryQuotaToGb,
@@ -93,11 +93,12 @@ const repoNameManuallyEdited = ref(false)
 let syncingRepoName = false
 const bucketMode = ref<'existing' | 'new'>('existing')
 const bucket = ref('')
+const bucketDrafts: Record<'existing' | 'new', string | undefined> = { existing: '', new: undefined }
 const bucketOptions = ref<string[]>([])
 const refreshingBuckets = ref(false)
 const authStatus = ref<S3AuthStatus>('idle')
 const authError = ref('')
-const prefix = ref(DEFAULT_S3_OBJECT_PREFIX)
+const prefix = ref(generateS3ObjectPrefix())
 const quota = ref(0)
 const quotaUnit = ref<RepositoryQuotaUnit>('GB')
 const enableQuotaAlert = ref(false)
@@ -210,6 +211,7 @@ const canSubmit = computed(() =>
   && requiredAuthFieldsReady.value
   && !!repoName.value.trim()
   && !!bucket.value.trim()
+  && (bucketMode.value !== 'new' || !s3BucketNameError(normalizeS3Platform(storagePlatform.value), bucket.value))
   && (!enableQuotaAlert.value || validQuotaAlertThreshold.value),
 )
 
@@ -333,13 +335,17 @@ function resetAuthValidation() {
 function resetBucketSelectionForContext() {
   bucketOptions.value = []
   bucketSelectLoadAttemptAt = 0
+  bucketDrafts.existing = ''
   if (bucketMode.value === 'existing') bucket.value = ''
 }
 
 function setBucketMode(mode: 'existing' | 'new') {
   if (bucketMode.value === mode) return
+  bucketDrafts[bucketMode.value] = bucket.value
   bucketMode.value = mode
-  bucket.value = ''
+  if (mode === 'new' && bucketDrafts.new === undefined) bucketDrafts.new = generateS3BucketName()
+  bucket.value = bucketDrafts[mode] ?? ''
+  clearFieldError('bucket')
 }
 
 function validateAuthFields(): boolean {
@@ -449,6 +455,19 @@ watch(
 
 watch([storagePlatform, platformLabel, bucket], syncAutoRepoName, { immediate: true })
 
+function validateBucketName() {
+  if (bucketMode.value !== 'new') return
+  const error = s3BucketNameError(normalizeS3Platform(storagePlatform.value), bucket.value)
+  if (!bucket.value.trim()) errors.bucket = t('addS3Repo.errBucketName')
+  else if (error) errors.bucket = t(`addS3Repo.bucketNameErrors.${error}`)
+  else clearFieldError('bucket')
+}
+
+watch([bucket, storagePlatform, bucketMode], () => {
+  if (bucketMode.value === 'new') validateBucketName()
+  else clearFieldError('bucket')
+})
+
 function validateForm(): boolean {
   const bucketNameError = bucketMode.value === 'new' && bucket.value.trim()
     ? s3BucketNameError(normalizeS3Platform(storagePlatform.value), bucket.value)
@@ -502,7 +521,9 @@ async function onSubmit() {
       })
     }
   } catch (err) {
-    ElMessage.error({ message: storageRepositoryCreateErrorMessage(err, t), grouping: true })
+    const bucketError = (err as ApiError)?.fields?.s3_bucket?.[0]
+    if (bucketError) errors.bucket = bucketError
+    else ElMessage.error({ message: storageRepositoryCreateErrorMessage(err, t), grouping: true })
   } finally {
     busy.value = false
   }
@@ -977,16 +998,17 @@ function handleBack() {
                         v-model="bucket"
                         class="add-s3-element-field add-s3-repo-primary-input"
                         :placeholder="t('addS3Repo.phBucketNew')"
-                        @input="clearFieldError('bucket')"
+                        @blur="validateBucketName"
                       />
-                      <p class="fullscreen-form-field__hint">
-                        {{ t('addS3Repo.hintBucket') }}
-                      </p>
                       <p
                         v-if="errors.bucket"
-                        class="el-form-item__error"
+                        class="el-form-item__error add-s3-bucket-error"
+                        role="status"
                       >
                         {{ errors.bucket }}
+                      </p>
+                      <p v-else class="fullscreen-form-field__hint">
+                        {{ t('addS3Repo.hintBucket') }}
                       </p>
                     </div>
                     <!-- Prefix -->
@@ -1260,6 +1282,11 @@ function handleBack() {
 </template>
 
 <style scoped>
+.add-s3-bucket-error {
+  position: static;
+  padding-top: 4px;
+}
+
 /* ============================================
    Step Indicator
    ============================================ */

--- a/src/frontend/src/pages/node/Repositories.vue
+++ b/src/frontend/src/pages/node/Repositories.vue
@@ -17,7 +17,7 @@ import { useListSearch } from '../../composables/useListSearch'
 import { nasMountProtocolIcon } from '../../lib/resourceIcons'
 import { nasRepositoryFailureMessage } from '../../lib/nasMountTroubleshooting'
 import {
-  DEFAULT_S3_OBJECT_PREFIX,
+  generateS3ObjectPrefix,
   distinctS3EndpointPair,
   s3EndpointDisplay,
   s3PlatformLabelKey,
@@ -747,7 +747,7 @@ const form = ref({
   bucket: '',
   region: '',
   endpoint: '',
-  prefix: DEFAULT_S3_OBJECT_PREFIX,
+  prefix: generateS3ObjectPrefix(),
   access_key_id: '',
   secret_access_key: '',
   s3_url_style: 'auto' as S3UrlStyle,
@@ -2037,7 +2037,7 @@ function resetForm() {
     bucket: '',
     region: '',
     endpoint: '',
-    prefix: DEFAULT_S3_OBJECT_PREFIX,
+    prefix: generateS3ObjectPrefix(),
     access_key_id: '',
     secret_access_key: '',
     s3_url_style: 'auto',

--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -132,7 +132,7 @@ import {
 } from '../../lib/storageProviderCatalogApi'
 import { storageRepositoryLocation } from '../../lib/storageRepositoryDisplay'
 import { booleanStatusTag } from '../../lib/statusTag'
-import { DEFAULT_S3_OBJECT_PREFIX, normalizeS3EndpointInput } from '../../lib/s3PlatformDisplay'
+import { generateS3ObjectPrefix, normalizeS3EndpointInput } from '../../lib/s3PlatformDisplay'
 import {
   useProtectionDemoStore,
   type DemoDirTreeItem,
@@ -1170,7 +1170,7 @@ const addTargetS3Endpoint = ref('')
 const addTargetS3Region = ref('')
 const addTargetS3Bucket = ref('')
 const addTargetS3BucketMode = ref<'existing' | 'new'>('existing')
-const addTargetS3Prefix = ref(DEFAULT_S3_OBJECT_PREFIX)
+const addTargetS3Prefix = ref(generateS3ObjectPrefix())
 const addTargetS3AccessKey = ref('')
 const addTargetS3SecretKey = ref('')
 const addTargetS3UrlStyle = ref<AddTargetS3UrlStyle>(defaultS3UrlStyle(undefined))
@@ -2770,7 +2770,7 @@ function resetAddTargetForm(kind: AddTargetRepoKind = addTargetKind.value) {
   addTargetS3Region.value = ''
   addTargetS3Bucket.value = ''
   addTargetS3BucketMode.value = 'existing'
-  addTargetS3Prefix.value = DEFAULT_S3_OBJECT_PREFIX
+  addTargetS3Prefix.value = generateS3ObjectPrefix()
   addTargetS3AccessKey.value = ''
   addTargetS3SecretKey.value = ''
   addTargetS3UrlStyle.value = defaultS3UrlStyle(undefined)

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -11338,7 +11338,7 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                     </el-table-column>
                     <el-table-column
                       :label="t('protection.backupsPage.flowBackupColCurrentTaskStatus')"
-                      min-width="228"
+                      min-width="272"
                     >
                       <template #default="{ row }">
                         <button
@@ -11351,10 +11351,12 @@ async function runRecovery(mode: 'plan' | 'manual' = 'manual') {
                           <TaskProgressCell
                             v-if="sourceBackupCellPhase(row.id) === 'running'"
                             :failed="sourceBackupRuntime(row.id).failed"
+                            :progress="sourceBackupRuntime(row.id).progress"
                             :transfer-progress="sourceBackupRuntime(row.id).transferProgress"
                           />
                           <TaskProgressCell
                             v-else-if="sourceBackupCellPhase(row.id) === 'stopping'"
+                            :progress="sourceBackupRuntime(row.id).progress"
                             :transfer-progress="sourceBackupRuntime(row.id).transferProgress"
                             stopping
                           />

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -4878,6 +4878,7 @@ function onClosed() {
 
         <TaskProgressCell
           v-if="activeTask.status === 'pending' || activeTask.status === 'waiting' || activeTask.status === 'blocked' || activeTask.status === 'running'"
+          :progress="activeTask.progress"
           :transfer-progress="activeTransferProgress"
           :failed="false"
         />

--- a/src/frontend/src/pages/protection/components/TaskProgressCell.test.ts
+++ b/src/frontend/src/pages/protection/components/TaskProgressCell.test.ts
@@ -4,9 +4,11 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { ElProgress } from 'element-plus'
 import { describe, expect, it } from 'vitest'
 
 import TaskProgressCell from './TaskProgressCell.vue'
+import { enProtectionPages } from '../../../locales/enProtectionPages'
 
 const i18n = createI18n({
   legacy: false,
@@ -15,6 +17,7 @@ const i18n = createI18n({
     en: {
       protection: {
         taskProgress: {
+          ...enProtectionPages.taskProgress,
           bytesTransferred: '{size} transferred',
           bytesProcessed: 'Processed: {size}',
           bytesCapacity: '{done} / {total}',
@@ -73,19 +76,54 @@ function mountCell(
     },
     global: {
       plugins: [i18n],
+      components: { ElProgress },
     },
   })
 }
 
 describe('TaskProgressCell', () => {
-  it('keeps task progress graphics and percentages out while preserving orchestration', () => {
+  it.each(['preparingLogic', 'preparing', 'dispatching', 'estimating'])(
+    'hides backup graphics and residual metrics during %s', (stage) => {
+      const wrapper = mountCell({
+        phase: 'preparing', label_key: `protection.taskProgress.backup.${stage}`, show_metrics: true,
+      })
+      expect(wrapper.findComponent(ElProgress).exists()).toBe(false)
+      expect(wrapper.find('.task-progress-cell__percent').exists()).toBe(false)
+      expect(wrapper.find('.task-progress-cell__metric-line').exists()).toBe(false)
+      expect(wrapper.find('.task-progress-cell__spinner').exists()).toBe(true)
+    },
+  )
+
+  it('switches cleanly from preparation to backup and finalizing', async () => {
+    const wrapper = mountCell()
+    const active = { ...wrapper.props('transferProgress')! }
+    await wrapper.setProps({ transferProgress: {
+      ...active, label_key: 'protection.taskProgress.backup.preparing', show_metrics: true,
+    } })
+    expect(wrapper.findComponent(ElProgress).exists()).toBe(false)
+    expect(wrapper.find('.task-progress-cell__metric-line').exists()).toBe(false)
+    await wrapper.setProps({ transferProgress: active })
+    expect(wrapper.findComponent(ElProgress).exists()).toBe(true)
+    expect(wrapper.text()).toContain('Backup progress:')
+    expect(wrapper.text()).toContain('About 15 min remaining')
+    await wrapper.setProps({ transferProgress: {
+      ...active, phase: 'finalizing', label_key: 'protection.taskProgress.backup.finalizing',
+      show_metrics: false, bytes_total_reference: false,
+    } })
+    expect(wrapper.findComponent(ElProgress).exists()).toBe(true)
+    expect(wrapper.text()).toContain('Backup progress:')
+    expect(wrapper.text()).not.toContain('remaining')
+    wrapper.unmount()
+  })
+
+  it('restores the backup progress bar and percentage while preserving orchestration', () => {
     const wrapper = mountCell()
 
-    expect(wrapper.find('el-progress').exists()).toBe(false)
-    expect(wrapper.find('.task-progress-cell__percent').exists()).toBe(false)
+    expect(wrapper.findComponent(ElProgress).props('percentage')).toBe(0.28)
+    expect(wrapper.find('.task-progress-cell__percent').exists()).toBe(true)
     expect(wrapper.get('.task-progress-cell__label-text').text()).toBe('Backing up')
     expect(wrapper.get('.task-progress-cell__label').attributes('title')).toBeUndefined()
-    expect(wrapper.text()).not.toContain('%')
+    expect(wrapper.text()).toContain('%')
     expect(wrapper.text()).not.toContain('947')
   })
 
@@ -99,12 +137,12 @@ describe('TaskProgressCell', () => {
     expect(wrapper.text()).not.toContain('%')
   })
 
-  it('keeps the stopping state without progress graphics or percentages', () => {
+  it('keeps the stopping state and warning progress bar', () => {
     const wrapper = mountCell({}, true)
 
     expect(wrapper.get('.task-progress-cell__label-text').text()).toBe('Stopping backup…')
     expect(wrapper.find('.task-progress-cell__spinner').exists()).toBe(false)
-    expect(wrapper.text()).not.toContain('%')
+    expect(wrapper.findComponent(ElProgress).props('status')).toBe('warning')
   })
 
   it('hides Kopia hashed and uploaded counters from user-facing labels', () => {
@@ -151,18 +189,16 @@ describe('TaskProgressCell', () => {
       hash_speed_bps: 393_000_000,
       eta_seconds: null,
     })
-    const expectedTitle = 'Scanning: 375 MB/s'
+    expect(wrapper.find('.task-progress-cell__metric-line').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('MB/s')
 
-    expect(wrapper.get('.task-progress-cell__metric-line').text()).toBe('Scanning: 375 MB/s')
-    expect(wrapper.get('.task-progress-cell__label-text').attributes('data-table-overflow-title')).toBeUndefined()
-    expect(wrapper.get('.task-progress-cell__metric-line').attributes('data-table-overflow-title')).toBe(expectedTitle)
   })
 
-  it('renders all metrics in one ellipsizing text node', () => {
+  it('keeps backup metrics in the original single-line layout', () => {
     const wrapper = mountCell()
     const line = wrapper.get('.task-progress-cell__metric-line')
 
-    expect(line.text()).toBe('Processed: 858 MB / 300 GB · 18.4 MB/s · 15 min left')
+    expect(line.text()).toBe('Backup progress: 858 MB / 300 GB · About 15 min remaining')
     expect(line.element.children).toHaveLength(0)
 
     const source = readFileSync(resolve(process.cwd(), 'src/pages/protection/components/TaskProgressCell.vue'), 'utf8')
@@ -176,13 +212,12 @@ describe('TaskProgressCell', () => {
     expect(wrapper.get('.task-progress-cell').attributes()).toHaveProperty('data-table-overflow-explicit-only')
     expect(metric.attributes()).toHaveProperty('data-table-overflow-title-always')
     expect(metric.attributes('data-table-overflow-title')).toBe([
-      'Processed: 858 MB / 300 GB',
-      'Processing speed: 18.4 MB/s',
-      '15 min left',
+      'Backup progress: 858 MB / 300 GB',
+      'About 15 min remaining',
     ].join('\n'))
   })
 
-  it('keeps processed bytes and speed in the hover text when the total is unknown', () => {
+  it('keeps backup progress without speed in the hover text when the total is unknown', () => {
     const wrapper = mountCell({
       bytes_total: null,
       bytes_total_known: false,
@@ -194,8 +229,7 @@ describe('TaskProgressCell', () => {
 
     expect(wrapper.get('.task-progress-cell__label-text').attributes('data-table-overflow-title')).toBeUndefined()
     expect(wrapper.get('.task-progress-cell__metric-line').attributes('data-table-overflow-title')).toBe([
-      'Processed: 858 MB',
-      'Processing speed: 8.74 MB/s',
+      'Backup progress: 858 MB',
     ].join('\n'))
   })
 })

--- a/src/frontend/src/pages/protection/components/TaskProgressCell.vue
+++ b/src/frontend/src/pages/protection/components/TaskProgressCell.vue
@@ -2,7 +2,12 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
+  formatTaskProgressBarPercent,
+  formatTaskProgressPercent,
   formatSpeedBps,
+  parseTaskProgressValue,
+  resolveStep3DisplayPercent,
+  shouldShowStep3Percent,
   shouldShowTransferMetrics,
   transferCapacityText,
   transferProgressLabel,
@@ -11,11 +16,13 @@ import {
 } from '../../../lib/kopiaProgress'
 
 const props = withDefaults(defineProps<{
+  progress?: number | string | null
   transferProgress?: TransferProgress | null
   compact?: boolean
   failed?: boolean
   stopping?: boolean
 }>(), {
+  progress: 0,
   transferProgress: null,
   compact: false,
   failed: false,
@@ -24,7 +31,39 @@ const props = withDefaults(defineProps<{
 
 const { t } = useI18n()
 
+const taskProgressValue = computed(() => {
+  const taskProgress = Number(props.progress)
+  if (!Number.isFinite(taskProgress) || taskProgress <= 0) return null
+  return parseTaskProgressValue(taskProgress)
+})
+const displayPercent = computed(() => {
+  const transfer = props.transferProgress
+  const step3 = Number(transfer?.step3_display_percent)
+  if (props.stopping && taskProgressValue.value != null) {
+    return taskProgressValue.value
+  }
+  if (props.stopping && Number.isFinite(step3)) {
+    return parseTaskProgressValue(step3)
+  }
+  if (shouldShowStep3Percent(transfer)) {
+    return resolveStep3DisplayPercent(transfer, 0)
+  }
+  return 0
+})
+const barPercent = computed(() => formatTaskProgressBarPercent(displayPercent.value))
+const progressText = computed(() => formatTaskProgressPercent(displayPercent.value))
+const showRightPercent = computed(() => {
+  if (isRestore.value || !backupTransferStage.value) return false
+  if (props.stopping && taskProgressValue.value != null) return true
+  return shouldShowStep3Percent(props.transferProgress)
+})
 const isRestore = computed(() => String(props.transferProgress?.label_key || '').includes('taskProgress.restore.'))
+const backupTransferStage = computed(() => {
+  const phase = String(props.transferProgress?.phase || '').toLowerCase()
+  const label = String(props.transferProgress?.label_key || '')
+  const preparing = /taskProgress\.backup\.(preparingLogic|preparing|dispatching|estimating)$/.test(label)
+  return !preparing && ['transferring', 'finalizing', 'done'].includes(phase)
+})
 const orchestrationLabel = computed(() => {
   if (props.stopping) {
     const key = String(props.transferProgress?.label_key || '').trim()
@@ -44,7 +83,11 @@ const showSpinner = computed(() => {
 })
 const metricParts = computed(() => {
   if (props.compact) return []
-  if (!shouldShowTransferMetrics(props.transferProgress) && !props.failed) return []
+  if (!isRestore.value && !backupTransferStage.value) return []
+  const transfer = props.transferProgress
+  const finalizingBackup = !isRestore.value && transfer?.phase === 'finalizing'
+    && !['reconnecting', 'offline_pending'].includes(String(transfer.execution_state || '').toLowerCase())
+  if (!shouldShowTransferMetrics(transfer) && !props.failed && !finalizingBackup) return []
   return transferMetricParts(t, props.transferProgress)
 })
 const metricLine = computed(() => metricParts.value.join(' · '))
@@ -70,7 +113,7 @@ const overflowTitle = computed(() => {
     data-table-overflow-explicit-only
   >
     <div
-      v-if="orchestrationLabel"
+      v-if="orchestrationLabel || showRightPercent"
       class="task-progress-cell__row1"
     >
       <p
@@ -88,7 +131,19 @@ const overflowTitle = computed(() => {
           :data-table-overflow-title-always="isRestore || undefined"
         >{{ orchestrationLabel }}</span>
       </p>
+      <span
+        v-if="showRightPercent"
+        class="task-progress-cell__percent"
+      >{{ progressText }}</span>
     </div>
+    <el-progress
+      v-if="!isRestore && backupTransferStage"
+      class="protection-flow-progress task-progress-cell__bar"
+      :percentage="barPercent"
+      :status="failed ? 'exception' : stopping ? 'warning' : undefined"
+      :stroke-width="compact ? 7 : 8"
+      :show-text="false"
+    />
     <p
       class="task-progress-cell__metrics"
       :class="{ 'is-empty': !(isRestore ? restoreMetricLine : metricLine) }"
@@ -137,6 +192,13 @@ const overflowTitle = computed(() => {
   white-space: nowrap;
 }
 
+.task-progress-cell__percent {
+  flex-shrink: 0;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: var(--el-text-color-regular);
+}
+
 .task-progress-cell__spinner {
   width: 10px;
   height: 10px;
@@ -145,6 +207,20 @@ const overflowTitle = computed(() => {
   border-radius: 50%;
   animation: task-progress-spin 0.8s linear infinite;
   flex-shrink: 0;
+}
+
+.task-progress-cell__bar {
+  width: 100%;
+  min-height: 8px;
+  margin: 0;
+}
+
+.task-progress-cell__bar :deep(.el-progress) {
+  width: 100%;
+}
+
+.task-progress-cell__bar :deep(.el-progress-bar) {
+  width: 100%;
 }
 
 .task-progress-cell__metrics {

--- a/src/frontend/src/pages/taskProgressPresentation.test.ts
+++ b/src/frontend/src/pages/taskProgressPresentation.test.ts
@@ -11,7 +11,6 @@ const taskPresentationFiles = [
   'src/pages/protection/components/TaskDetailDrawer.vue',
   'src/pages/protection/components/FlowBackupSourceDetailDrawer.vue',
   'src/pages/protection/components/KopiaTransferProgress.vue',
-  'src/pages/protection/components/TaskProgressCell.vue',
   'src/components/ProtectionStopConfirmDialog.vue',
   'src/lib/protectionStopConfirm.ts',
   'src/styles/ops-list-ui.css',
@@ -29,6 +28,7 @@ const taskProgressPresentationPatterns = [
 describe('task progress presentation', () => {
   it.each(taskPresentationFiles)('does not render a task bar or percentage in %s', (relativePath) => {
     const source = readFileSync(resolve(process.cwd(), relativePath), 'utf8')
+      .replace(/\s:progress="(?:sourceBackupRuntime\(row.id\).progress|activeTask.progress)"/g, '')
 
     for (const pattern of taskProgressPresentationPatterns) {
       expect(source).not.toMatch(pattern)


### PR DESCRIPTION
## Problem and root cause

S3 repository creation could persist records before bucket and prefix checks failed. New Bucket mode could accept an owned existing bucket, making later cleanup eligibility ambiguous. Storage defaults and backup task labels also made setup and progress difficult to interpret.

## Solution

Run bucket and empty-prefix preflight before persisting repository records. Reject existing buckets in New Bucket mode, clean only recognized probe residue, verify PUT/DELETE without downloading probe contents, and roll back newly created buckets only when empty. Preserve bucket origin and skip duplicate worker creation without a database migration.

Generate short time-based prefixes, editable bucket and NAS names, validate bucket names inline, and sort repositories newest first. Show backup-only progress labels and estimated remaining time, hide processing speed, stabilize preparation/transfer/finalization display, and use a 272px minimum Backup Task column width. Preserve restore presentation and backend progress algorithms. Update shipped translations.

## Validation

- Storage backend regression tests: 151 passed.
- Backend Ruff and migration drift check: passed; no schema changes.
- Frontend regression tests: all 1,633 passed across 274 files.
- English source boundary and diff formatting: passed.
- Chinese and Spanish language-pack builds and translation contracts: passed.
- Frontend lint: passed with warnings; Host and extension-loaded production builds: passed.
- Complete Community backend suite: skipped at maintainer request.
- Manual testing: passed.
- Synchronized with latest main without conflicts; post-sync product retesting skipped.

## Risks and compatibility

Storage and database operations cannot be one atomic transaction. Concurrent external changes or ambiguous provider responses may require operator review. Generated names can collide and storage validation remains authoritative. No database models, migrations, restore metrics, or backup progress algorithms change.

Fixes #1138
