### PR TITLE
Clear stale Step 3 selections

### DIFF
--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -2801,6 +2801,11 @@ watch(step1Selection, () => {
   nextTick(() => syncStep2TableSelection())
 })
 
+// Rebuild Element Plus' reserved row keys after filtering or paging removes a selection.
+watch(step3SourceSelection, () => {
+  nextTick(() => syncStep3TableSelection())
+})
+
 watch(backupSelectableRows, (list) => {
   const visibleIds = new Set(list.map((row) => row.id))
   const nextSelectedIds = selectedSourceIds.value.filter((id) => visibleIds.has(id))

--- a/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionStep3MoreActions.test.ts
@@ -20,6 +20,20 @@ function functionSource(name: string, nextName: string) {
 }
 
 describe('backup wizard step 3 More Actions refresh', () => {
+  it('clears hidden reserved rows when the Step 3 selection changes', () => {
+    const watcher = sourceBetween(
+      'watch(step3SourceSelection, () => {',
+      'watch(backupSelectableRows, (list) => {',
+    )
+    const table = sourceBetween(
+      'ref="step3TableRef"',
+      ':selectable="flowSourceRowSelectable"',
+    )
+
+    expect(table).toContain('reserve-selection')
+    expect(watcher).toContain('nextTick(() => syncStep3TableSelection())')
+  })
+
   it('keeps the global Step 2 pending summary separate from filtered table pagination', () => {
     expect(page).toContain('const step2GlobalPendingCount = computed(() => pipelineStep2Count.value)')
     expect(page).toContain('step2GlobalPendingCount.value === 0 && step3ReadyCount.value > 0')


### PR DESCRIPTION
## Summary
- Resync Backup Wizard Step 3 table selection after filtering or paging removes selected rows
- Prevent Element Plus reserve-selection state from leaking hidden sources into bulk actions
- Add regression coverage for the hidden selection scenario

## Testing
- `npm test -- src/pages/protection/DataProtectionStep3MoreActions.test.ts`
- `npm run lint` (0 errors; existing warnings remain)
- `npm run build`
- `npm test -- src/directives/tableOverflowCoverage.test.ts`

Closes #1077