### PR TITLE
Fix login method labels and Turnstile locale mapping

### DIFF
--- a/language-packs/packs/es/frontend/messages.json
+++ b/language-packs/packs/es/frontend/messages.json
@@ -6709,7 +6709,7 @@
     "passwordErrIncorrect": "Contraseña incorrecta",
     "methodLabel": "Método de inicio de sesión",
     "passwordMethod": "Contraseña",
-    "emailCodeMethod": "Código por correo",
+    "emailCodeMethod": "Código de verificación",
     "emailCodePlaceholder": "Código de verificación de 6 dígitos",
     "emailCodeSend": "Enviar código",
     "emailCodeSending": "Enviando...",

--- a/language-packs/packs/es/frontend/source-lock.json
+++ b/language-packs/packs/es/frontend/source-lock.json
@@ -6322,7 +6322,7 @@
   "login.passwordErrIncorrect": "8e0690f76d99b229d20d5e99807a3b148d94c5bf6eca5d3a6c9e19da6ffe0ab5",
   "login.methodLabel": "c1aba4021179304a704522ff23f548d1ee8ac82af0a84fc8b97819fc3cd9dbae",
   "login.passwordMethod": "9e10723b0401305948bb37923eca0c3d39cec1ae300540438c3c40ae005f5e31",
-  "login.emailCodeMethod": "6ec0bf5dd587cf5237f9817f6e103823bfc1f0822ae41eddbe3f409af2e0d611",
+  "login.emailCodeMethod": "a9430fb668fbedc9e45bc36a3475f3cb433f8b6d769661ba5b163e77cbb1903b",
   "login.emailCodePlaceholder": "ba51e0ab10de6d8e715411a36013a6cab22cf23c8940cd62f91d73e3dc398ca2",
   "login.emailCodeSend": "cd8082c520ac7fcdcd63b88f5b54f1453a978a5d9c2bd413ec3ed54349e223c7",
   "login.emailCodeSending": "41319b7ba3576df64ad30b6332517d9dddb41c4e117a279af81fd8bc569b43a3",

--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -6737,8 +6737,8 @@
       "admin": "管理员"
     },
     "methodLabel": "登录方式",
-    "passwordMethod": "密码",
-    "emailCodeMethod": "邮箱验证码登录",
+    "passwordMethod": "密码登录",
+    "emailCodeMethod": "邮箱验证码",
     "emailCodePlaceholder": "请输入 6 位验证码",
     "emailCodeSend": "获取验证码",
     "emailCodeSending": "发送中…",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -6307,7 +6307,7 @@
   "login.passwordErrIncorrect": "8e0690f76d99b229d20d5e99807a3b148d94c5bf6eca5d3a6c9e19da6ffe0ab5",
   "login.methodLabel": "c1aba4021179304a704522ff23f548d1ee8ac82af0a84fc8b97819fc3cd9dbae",
   "login.passwordMethod": "9e10723b0401305948bb37923eca0c3d39cec1ae300540438c3c40ae005f5e31",
-  "login.emailCodeMethod": "6ec0bf5dd587cf5237f9817f6e103823bfc1f0822ae41eddbe3f409af2e0d611",
+  "login.emailCodeMethod": "a9430fb668fbedc9e45bc36a3475f3cb433f8b6d769661ba5b163e77cbb1903b",
   "login.emailCodePlaceholder": "ba51e0ab10de6d8e715411a36013a6cab22cf23c8940cd62f91d73e3dc398ca2",
   "login.emailCodeSend": "cd8082c520ac7fcdcd63b88f5b54f1453a978a5d9c2bd413ec3ed54349e223c7",
   "login.emailCodeSending": "41319b7ba3576df64ad30b6332517d9dddb41c4e117a279af81fd8bc569b43a3",

--- a/src/frontend/src/components/TurnstileWidget.test.ts
+++ b/src/frontend/src/components/TurnstileWidget.test.ts
@@ -26,6 +26,9 @@ const i18n = createI18n({
     fr: {
       login: { captchaLoading: 'Chargement de la vérification humaine...' },
     },
+    'zh-hans': {
+      login: { captchaLoading: 'Localized human verification message' },
+    },
   },
 })
 
@@ -243,13 +246,13 @@ describe('TurnstileWidget lifecycle', () => {
     await flushPromises()
     await vi.advanceTimersByTimeAsync(100)
 
-    i18n.global.locale.value = 'fr'
+    i18n.global.locale.value = 'zh-hans'
     await flushPromises()
 
     expect(wrapper.emitted('invalidate')).toHaveLength(1)
     expect(wrapper.emitted('expire')).toBeUndefined()
     expect(remove).toHaveBeenCalledWith('widget-1')
-    expect(renderOptions.at(-1)?.language).toBe('fr')
+    expect(renderOptions.at(-1)?.language).toBe('zh-cn')
 
     renderOptions[0].callback('stale-language-token')
     expect(wrapper.emitted('success')).toBeUndefined()

--- a/src/frontend/src/lib/turnstileLanguage.test.ts
+++ b/src/frontend/src/lib/turnstileLanguage.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { turnstileLanguageFromAppLocale } from './turnstileLanguage'
+
+describe('turnstileLanguageFromAppLocale', () => {
+  it.each([
+    ['zh-hans', 'zh-cn'],
+    ['zh-cn', 'zh-cn'],
+    ['zh', 'zh-cn'],
+    ['ZH_HANS', 'zh-cn'],
+    ['es', 'es'],
+    ['en-US', 'en-us'],
+    ['', 'en'],
+    ['  ', 'en'],
+  ])('maps %s to %s', (appLocale, expected) => {
+    expect(turnstileLanguageFromAppLocale(appLocale)).toBe(expected)
+  })
+})

--- a/src/frontend/src/lib/turnstileLanguage.ts
+++ b/src/frontend/src/lib/turnstileLanguage.ts
@@ -1,4 +1,12 @@
 /** Map vue-i18n locale to a Cloudflare Turnstile language code. */
 export function turnstileLanguageFromAppLocale(appLocale: string): string {
-  return appLocale.trim().toLowerCase() || 'en'
+  const locale = appLocale.trim().toLowerCase().replaceAll('_', '-')
+
+  // The application uses zh-hans for Simplified Chinese, while Turnstile
+  // expects the regional code zh-cn for its Simplified Chinese UI.
+  if (locale === 'zh' || locale === 'zh-hans' || locale === 'zh-cn') {
+    return 'zh-cn'
+  }
+
+  return locale || 'en'
 }

--- a/src/frontend/src/locales/SpanishLanguagePack.test.ts
+++ b/src/frontend/src/locales/SpanishLanguagePack.test.ts
@@ -51,7 +51,7 @@ describe('Spanish language pack', () => {
 
   it('ships reviewed labels for authentication, protection, and Insight', () => {
     expect(spanish.login.welcomeTitle).toBe('Bienvenido a HyperFileLens')
-    expect(spanish.login.emailCodeMethod).toBe('Código por correo')
+    expect(spanish.login.emailCodeMethod).toBe('Código de verificación')
     expect(spanish.login.forgotPwd).toBe('¿Olvidó su contraseña?')
     expect(spanish.login.noAccount).toBe('¿No tiene una cuenta?')
     expect(spanish.account.menuSignOut).toBe('Cerrar sesión')

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -4445,7 +4445,7 @@ export const en = {
     passwordErrIncorrect: 'Incorrect password',
     methodLabel: 'Sign-in method',
     passwordMethod: 'Password',
-    emailCodeMethod: 'Email code',
+    emailCodeMethod: 'Verification Code',
     emailCodePlaceholder: '6-digit verification code',
     emailCodeSend: 'Send code',
     emailCodeSending: 'Sending...',


### PR DESCRIPTION
## Summary

- standardize login method labels across English, Simplified Chinese, and Spanish
- map the application Simplified Chinese locale to Cloudflare Turnstile zh-cn
- invalidate and rerender Turnstile when the locale changes
- add translation contract and locale mapping coverage

## Validation

- English source boundary check
- full frontend test suite: 1,629 tests passed
- ESLint and Vue TypeScript checks
- zh-hans and es language-pack builds