### PR TITLE
Improve Windows security software block diagnostics

### DIFF
--- a/deploy/bootstrap/agent-bootstrap-windows.ps1
+++ b/deploy/bootstrap/agent-bootstrap-windows.ps1
@@ -25,6 +25,25 @@ function Write-HflBootstrapLog {
   Write-Host "  [$status] $Message"
 }
 
+function Test-HflSecuritySoftwareBlock {
+  param([Parameter(Mandatory = $true)]$ErrorRecord)
+  $exception = $ErrorRecord.Exception
+  for ($depth = 0; $depth -lt 8 -and $null -ne $exception; $depth++) {
+    if (
+      $exception -is [System.ComponentModel.Win32Exception] -and
+      $exception.NativeErrorCode -eq 225
+    ) {
+      return $true
+    }
+    # Normalize signed Int32 HRESULT values before comparing 0x800700E1.
+    if (([int64]$exception.HResult -band 4294967295) -eq 2147942625) {
+      return $true
+    }
+    $exception = $exception.InnerException
+  }
+  return $false
+}
+
 function Format-HflBytes {
   param([Parameter(Mandatory = $true)][long]$Bytes)
   $units = @('B', 'KiB', 'MiB', 'GiB', 'TiB')
@@ -178,6 +197,10 @@ function Get-HflEnrollmentBinary {
     Write-HflBootstrapLog " OK  " "HyperFileLens enrollment helper downloaded ($(Format-HflBytes $downloaded))."
   }
   catch {
+    if (Test-HflSecuritySoftwareBlock -ErrorRecord $_) {
+      Remove-Item -Force -LiteralPath $partial -ErrorAction SilentlyContinue
+      throw
+    }
     if ($curlAvailable) {
       Remove-Item -Force -LiteralPath $partial -ErrorAction SilentlyContinue
       & curl.exe @curlArgs
@@ -225,6 +248,13 @@ try {
   Get-HflEnrollmentBinary -Url $enrollUrl -OutFile $bin
   & $bin install @args
   $exitCode = $LASTEXITCODE
+}
+catch {
+  if (-not (Test-HflSecuritySoftwareBlock -ErrorRecord $_)) {
+    throw
+  }
+  Write-HflBootstrapLog "FAIL " "Windows security software blocked the HyperFileLens enrollment helper."
+  Write-HflBootstrapLog "INFO " "Review the detection in your security software. Once the helper is allowed, run the installation command again."
 }
 finally {
   if (Test-Path -LiteralPath $bin) {

--- a/src/backend/apps/node/tests/test_bootstrap.py
+++ b/src/backend/apps/node/tests/test_bootstrap.py
@@ -165,6 +165,32 @@ class BootstrapViewTests(TestCase):
         self.assertIn("$bin install", body)
         self.assertIn("bootstrap-token-abc", body)
 
+    def test_windows_bootstrap_reports_security_software_block(self):
+        response = self._get("windows")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode("utf-8")
+        self.assertIn("function Test-HflSecuritySoftwareBlock", body)
+        self.assertIn("$exception.NativeErrorCode -eq 225", body)
+        self.assertIn(
+            "([int64]$exception.HResult -band 4294967295) -eq 2147942625",
+            body,
+        )
+        self.assertEqual(
+            body.count("Test-HflSecuritySoftwareBlock -ErrorRecord $_"),
+            2,
+        )
+        self.assertIn(
+            "Windows security software blocked the HyperFileLens enrollment helper.",
+            body,
+        )
+        self.assertIn(
+            "Review the detection in your security software. Once the helper is "
+            "allowed, run the installation command again.",
+            body,
+        )
+        self.assertNotIn("Get-MpThreatDetection", body)
+
     def test_user_continuous_token_rejects_non_linux_bootstrap(self):
         self.token_row.installation_mode = NodeInstallationMode.USER_CONTINUOUS
         self.token_row.save(update_fields=["installation_mode"])


### PR DESCRIPTION
## Summary

- classify Windows security software blocks from Win32 error 225 and HRESULT 0x800700E1
- show a concise recovery message and preserve the existing exit code
- keep ordinary download failures and curl fallback behavior unchanged
- remove partial downloads when a security product blocks the helper

## Validation

- 15 focused Django bootstrap tests
- Windows Server 2016 / PowerShell 5.1 classification checks
- Ruff, Python compilation, release contract checks, and diff validation

Related to #1079.