### PR TITLE
fix(protection): unify backup policy timezone

### DIFF
--- a/language-packs/packs/es/frontend/messages.json
+++ b/language-packs/packs/es/frontend/messages.json
@@ -2151,6 +2151,7 @@
       "hintSimpleInterval": "Configure un intervalo o calendario fácil de usar.",
       "labelInterval": "Repetir todos",
       "scheduleTimezone": "Zona horaria",
+      "policyTimezoneHint": "Esta zona horaria se aplica a la programación de copias de seguridad y a la retención. Los cambios afectan a las evaluaciones futuras, incluidas las instantáneas existentes; las tareas completadas y las marcas de tiempo no cambian.",
       "scheduleTimezonePlaceholder": "Seleccione una zona horaria IANA",
       "scheduleStartsAt": "Hora de inicio",
       "scheduleStartsAtPlaceholder": "Seleccione la primera fecha y hora elegibles",

--- a/language-packs/packs/es/frontend/source-lock.json
+++ b/language-packs/packs/es/frontend/source-lock.json
@@ -7331,5 +7331,6 @@
   "protection.taskProgress.backupEtaMinutes": "3d378689d0dd9857a6c28b2dfc908b9ac042061d2d1cdead3b2ddf717481127d",
   "protection.taskProgress.backupEtaHours": "13c9d74dbe80f7397cc7f7b80ac2bcbedd012d2350511a96e3d983e7e1b27f83",
   "protection.taskProgress.backupEtaHoursMinutes": "10c3b7b37edab973d91fe042e411275edc9915f9f0b0a0330517c177f5b8dc4e",
-  "addS3Repo.bucketNameErrors.aws_reserved": "e56222f921707e10f8c93f84c524105e51e930b33b16bbc3ff5e37523382a922"
+  "addS3Repo.bucketNameErrors.aws_reserved": "e56222f921707e10f8c93f84c524105e51e930b33b16bbc3ff5e37523382a922",
+  "protection.policiesPage.policyTimezoneHint": "a9d325d5700bc099d8052341e0a51fdc1b33a8a2b563199b7ac3505472ad803f"
 }

--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -2297,6 +2297,7 @@
       "freqSimple": "快速计划",
       "hintSimpleInterval": "配置用户友好的间隔或日历计划。",
       "scheduleTimezone": "时区",
+      "policyTimezoneHint": "此时区用于备份调度和保留规则。修改后会影响后续评估，包括现存快照；已完成的任务和时间戳保持不变。",
       "scheduleTimezonePlaceholder": "选择 IANA 时区",
       "scheduleStartsAt": "开始时间",
       "scheduleStartsAtPlaceholder": "选择第一个符合条件的日期和时间",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -7331,5 +7331,6 @@
   "protection.taskProgress.backupEtaMinutes": "3d378689d0dd9857a6c28b2dfc908b9ac042061d2d1cdead3b2ddf717481127d",
   "protection.taskProgress.backupEtaHours": "13c9d74dbe80f7397cc7f7b80ac2bcbedd012d2350511a96e3d983e7e1b27f83",
   "protection.taskProgress.backupEtaHoursMinutes": "10c3b7b37edab973d91fe042e411275edc9915f9f0b0a0330517c177f5b8dc4e",
-  "addS3Repo.bucketNameErrors.aws_reserved": "e56222f921707e10f8c93f84c524105e51e930b33b16bbc3ff5e37523382a922"
+  "addS3Repo.bucketNameErrors.aws_reserved": "e56222f921707e10f8c93f84c524105e51e930b33b16bbc3ff5e37523382a922",
+  "protection.policiesPage.policyTimezoneHint": "a9d325d5700bc099d8052341e0a51fdc1b33a8a2b563199b7ac3505472ad803f"
 }

--- a/src/backend/apps/protection/services/interface.py
+++ b/src/backend/apps/protection/services/interface.py
@@ -133,7 +133,10 @@ def normalize_schedule(value: Any) -> dict[str, Any]:
     raw_mode = str(value.get("mode") or "").strip().lower()
     if not raw_mode:
         cron_expr = validate_cron_expr(str(value.get("cron_expr") or ""))
-        return {"enabled": enabled, "cron_expr": cron_expr}
+        normalized = {"enabled": enabled, "cron_expr": cron_expr}
+        if "timezone" in value:
+            normalized["timezone"] = _normalize_schedule_timezone(value["timezone"])
+        return normalized
     if raw_mode not in SCHEDULE_MODES:
         raise ValidationError({"schedule": "mode is invalid."})
 

--- a/src/backend/apps/protection/services/policy_execution.py
+++ b/src/backend/apps/protection/services/policy_execution.py
@@ -76,7 +76,7 @@ def _aware_minute(now=None):
     return current.replace(second=0, microsecond=0)
 
 
-def _schedule_timezone(timezone_name: str | None) -> ZoneInfo:
+def _policy_timezone(timezone_name: str | None) -> ZoneInfo:
     try:
         return ZoneInfo(str(timezone_name or "UTC"))
     except (ZoneInfoNotFoundError, ValueError):
@@ -84,11 +84,11 @@ def _schedule_timezone(timezone_name: str | None) -> ZoneInfo:
 
 
 def _schedule_local_minute(schedule: dict, *, now=None):
-    return _aware_minute(now).astimezone(_schedule_timezone(schedule.get("timezone")))
+    return _aware_minute(now).astimezone(_policy_timezone(schedule.get("timezone")))
 
 
 def cron_matches_now(cron_expr: str, *, now=None, timezone_name: str = "UTC") -> bool:
-    current = _aware_minute(now).astimezone(_schedule_timezone(timezone_name))
+    current = _aware_minute(now).astimezone(_policy_timezone(timezone_name))
     fields = str(cron_expr or "").split()
     if len(fields) != 5:
         return False
@@ -133,7 +133,7 @@ def _schedule_start_instant(schedule: dict) -> datetime | None:
     if starts_at is None:
         return None
     return starts_at.replace(
-        tzinfo=_schedule_timezone(schedule.get("timezone"))
+        tzinfo=_policy_timezone(schedule.get("timezone"))
     ).astimezone(UTC)
 
 
@@ -158,7 +158,11 @@ def schedule_matches_now(schedule: dict, *, now=None) -> bool:
         return False
     mode = str(schedule.get("mode") or "").strip().lower()
     if not mode:
-        return cron_matches_now(str(schedule.get("cron_expr") or ""), now=now)
+        return cron_matches_now(
+            str(schedule.get("cron_expr") or ""),
+            now=now,
+            timezone_name=str(schedule.get("timezone") or "UTC"),
+        )
 
     current = _schedule_local_minute(schedule, now=now)
     if not _schedule_has_started(schedule, current):
@@ -211,7 +215,7 @@ def schedule_matches_now(schedule: dict, *, now=None) -> bool:
 
 
 def _schedule_fire_key(schedule: dict, *, now=None) -> str:
-    if schedule.get("mode") and schedule.get("mode") != "interval":
+    if schedule.get("mode") != "interval":
         current = _schedule_local_minute(schedule, now=now)
     else:
         current = _aware_minute(now).astimezone(ZoneInfo("UTC"))
@@ -270,8 +274,8 @@ def _snapshot_time(snapshot: BackupSourceSnapshot):
     return snapshot.finished_at or snapshot.started_at or snapshot.created_at
 
 
-def _bucket_key(snapshot: BackupSourceSnapshot, unit: str):
-    value = timezone.localtime(_snapshot_time(snapshot))
+def _bucket_key(snapshot: BackupSourceSnapshot, unit: str, policy_timezone: ZoneInfo):
+    value = _snapshot_time(snapshot).astimezone(policy_timezone)
     if unit == "hour":
         return value.strftime("%Y%m%d%H")
     if unit == "day":
@@ -296,17 +300,19 @@ def _apply_bucket_retention(
     amount: int,
     unit: str,
     delta: timedelta,
+    policy_timezone: ZoneInfo,
 ) -> None:
     if not enabled or amount < 1:
         return
-    cutoff = now - delta
+    # Retention windows are elapsed durations, including across DST changes.
+    cutoff = now.astimezone(UTC) - delta
     seen: set[str] = set()
     for snapshot in snapshots:
         if int(snapshot.id) in protected_ids:
             continue
         if _snapshot_time(snapshot) < cutoff:
             continue
-        key = _bucket_key(snapshot, unit)
+        key = _bucket_key(snapshot, unit, policy_timezone)
         if key in seen:
             continue
         seen.add(key)
@@ -337,7 +343,9 @@ def retention_delete_candidates_for_config(
     )
     if len(snapshots) <= 1:
         return []
-    current = timezone.localtime(now or timezone.now())
+    current = now or timezone.now()
+    schedule = policy.schedule if isinstance(policy.schedule, dict) else {}
+    policy_timezone = _policy_timezone(schedule.get("timezone"))
     protected_ids = protected_snapshot_ids(snapshot.id for snapshot in snapshots)
     recent_points = max(1, int(retention.get("recent_points") or 1))
     # A temporary usage lease is a safety fence, not a retention point. Keep
@@ -354,6 +362,7 @@ def retention_delete_candidates_for_config(
         protected_ids=protected_ids,
         snapshots=snapshots,
         now=current,
+        policy_timezone=policy_timezone,
         enabled=bool(retention.get("hourly_enabled", False)),
         amount=int(retention.get("hourly_hours") or 0),
         unit="hour",
@@ -364,6 +373,7 @@ def retention_delete_candidates_for_config(
         protected_ids=protected_ids,
         snapshots=snapshots,
         now=current,
+        policy_timezone=policy_timezone,
         enabled=bool(retention.get("daily_enabled", False)),
         amount=int(retention.get("daily_days") or 0),
         unit="day",
@@ -374,6 +384,7 @@ def retention_delete_candidates_for_config(
         protected_ids=protected_ids,
         snapshots=snapshots,
         now=current,
+        policy_timezone=policy_timezone,
         enabled=bool(retention.get("weekly_enabled", False)),
         amount=int(retention.get("weekly_weeks") or 0),
         unit="week",
@@ -384,6 +395,7 @@ def retention_delete_candidates_for_config(
         protected_ids=protected_ids,
         snapshots=snapshots,
         now=current,
+        policy_timezone=policy_timezone,
         enabled=bool(retention.get("monthly_enabled", False)),
         amount=int(retention.get("monthly_months") or 0),
         unit="month",
@@ -394,6 +406,7 @@ def retention_delete_candidates_for_config(
         protected_ids=protected_ids,
         snapshots=snapshots,
         now=current,
+        policy_timezone=policy_timezone,
         enabled=bool(retention.get("annual_enabled", False)),
         amount=int(retention.get("annual_years") or 0),
         unit="year",

--- a/src/backend/apps/protection/tests/test_policy_api.py
+++ b/src/backend/apps/protection/tests/test_policy_api.py
@@ -92,6 +92,19 @@ class ProtectionPolicyApiTests(TestCase):
         self.assertIn(policy_id, [row["id"] for row in listing.data["results"]])
         self.assertEqual(policy_display_name(policy_id=policy_id, organization_id=self.org.id), "Daily production policy")
 
+    def test_legacy_retention_only_policy_preserves_and_validates_timezone(self):
+        payload = self._policy_payload("Retention timezone")
+        payload["schedule"] = {"enabled": False, "cron_expr": "0 0 * * *", "timezone": "Asia/Shanghai"}
+        response = self.client.post("/api/v1/protection/policies/", payload, format="json", **self._headers())
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        self.assertEqual(response.data["schedule"], payload["schedule"])
+        saved = BackupPolicy.objects.get(id=response.data["id"])
+        self.assertEqual(saved.schedule, payload["schedule"])
+        payload["name"] = "Invalid retention timezone"
+        payload["schedule"]["timezone"] = "Mars/Olympus"
+        response = self.client.post("/api/v1/protection/policies/", payload, format="json", **self._headers())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_structured_schedule_validates_and_round_trips(self):
         weekly = self._policy_payload("Shanghai weekdays")
         weekly["schedule"] = {

--- a/src/backend/apps/protection/tests/test_policy_execution.py
+++ b/src/backend/apps/protection/tests/test_policy_execution.py
@@ -257,6 +257,69 @@ class PolicyExecutionTests(TestCase):
             _schedule_fire_key(schedule, now=repeated),
         )
 
+    def test_legacy_cron_uses_explicit_timezone_and_preserves_utc_fallback(self):
+        schedule = {"enabled": True, "cron_expr": "30 0 * * *"}
+        now = datetime(2026, 9, 8, 16, 30, tzinfo=UTC)
+        self.assertFalse(schedule_matches_now(schedule, now=now))
+        self.assertEqual(_schedule_fire_key(schedule, now=now), "202609081630")
+        schedule["timezone"] = "Asia/Shanghai"
+        self.assertTrue(schedule_matches_now(schedule, now=now))
+        self.assertEqual(_schedule_fire_key(schedule, now=now), "202609090030")
+
+    def test_retention_uses_policy_calendar_boundaries_with_scheduling_disabled(self):
+        cases = [
+            ("day", "Asia/Shanghai", "2026-09-08T15:30:00+00:00", "2026-09-08T16:30:00+00:00"),
+            ("week", "Asia/Shanghai", "2026-09-06T15:30:00+00:00", "2026-09-06T16:30:00+00:00"),
+            ("month", "Asia/Shanghai", "2026-08-31T15:30:00+00:00", "2026-08-31T16:30:00+00:00"),
+            ("year", "Asia/Shanghai", "2025-12-31T15:30:00+00:00", "2025-12-31T16:30:00+00:00"),
+            ("hour", "Asia/Kathmandu", "2026-09-08T16:10:00+00:00", "2026-09-08T16:20:00+00:00"),
+        ]
+        fields = {"hour": ("hourly", "hours"), "day": ("daily", "days"),
+                  "week": ("weekly", "weeks"), "month": ("monthly", "months"),
+                  "year": ("annual", "years")}
+        for unit, zone, before, after in cases:
+            with self.subTest(unit=unit):
+                BackupSourceSnapshot.objects.all().delete()
+                old = self._snapshot(f"{unit}-before", datetime.fromisoformat(before))
+                latest = self._snapshot(f"{unit}-after", datetime.fromisoformat(after))
+                prefix, amount = fields[unit]
+                self.policy.retention = {"enabled": True, "recent_points": 1,
+                                         f"{prefix}_enabled": True, f"{prefix}_{amount}": 2}
+                self.policy.schedule = {"enabled": False, "timezone": zone}
+                now = latest.finished_at + timedelta(minutes=5)
+                with timezone.override("America/Los_Angeles"):
+                    self.assertEqual(retention_delete_candidates_for_config(
+                        config=self.config, policy=self.policy, now=now), [])
+                old.refresh_from_db()
+                self.assertEqual(old.finished_at, datetime.fromisoformat(before))
+                self.assertIsNone(old.deleted_at)
+                for fallback in ({}, {"timezone": "UTC"}, {"timezone": "Invalid/Zone"}):
+                    self.policy.schedule = fallback
+                    with timezone.override("Asia/Shanghai"):
+                        candidates = retention_delete_candidates_for_config(
+                            config=self.config, policy=self.policy, now=now)
+                    self.assertEqual([snapshot.id for snapshot in candidates], [old.id])
+
+    def test_retention_dst_window_is_elapsed_time_and_repeated_hour_is_one_bucket(self):
+        from zoneinfo import ZoneInfo
+
+        self.policy.schedule = {"enabled": False, "timezone": "America/New_York"}
+        self.policy.retention = {"enabled": True, "recent_points": 1,
+                                 "hourly_enabled": True, "hourly_hours": 2}
+        old = self._snapshot("dst-outside", datetime(2026, 3, 8, 6, 0, tzinfo=UTC))
+        kept = self._snapshot("dst-inside", datetime(2026, 3, 8, 6, 45, tzinfo=UTC))
+        self._snapshot("dst-latest", datetime(2026, 3, 8, 8, 0, tzinfo=UTC))
+        now = datetime(2026, 3, 8, 8, 30, tzinfo=UTC).astimezone(ZoneInfo("America/New_York"))
+        candidates = retention_delete_candidates_for_config(config=self.config, policy=self.policy, now=now)
+        self.assertEqual([snapshot.id for snapshot in candidates], [old.id])
+        self.assertNotIn(kept.id, [snapshot.id for snapshot in candidates])
+        BackupSourceSnapshot.objects.all().delete()
+        first = self._snapshot("dst-first", datetime(2026, 11, 1, 5, 30, tzinfo=UTC))
+        self._snapshot("dst-repeat", datetime(2026, 11, 1, 6, 30, tzinfo=UTC))
+        candidates = retention_delete_candidates_for_config(
+            config=self.config, policy=self.policy, now=datetime(2026, 11, 1, 6, 45, tzinfo=UTC))
+        self.assertEqual([snapshot.id for snapshot in candidates], [first.id])
+
     def test_retention_candidates_are_logical_snapshots(self):
         now = timezone.now()
         old = self._snapshot("old-logical", now - timedelta(days=3))

--- a/src/frontend/src/lib/protectionPolicyFormModel.test.ts
+++ b/src/frontend/src/lib/protectionPolicyFormModel.test.ts
@@ -248,3 +248,19 @@ describe('protection policy schedule mapping', () => {
     expect(policyFormToWritePayload(form).schedule.starts_at).toBe('2026-08-13T14:30:00')
   })
 })
+
+describe('shared policy timezone', () => {
+  it.each(['0 0 * * *', '30 9 * * 1-5'])('preserves a legacy timezone with scheduling disabled: %s', (cron) => {
+    const form = backupPolicyToForm(policyWithSchedule({ enabled: false, cron_expr: cron, timezone: 'Asia/Shanghai' }))
+    expect(form.scheduleTimezone).toBe('Asia/Shanghai')
+    expect(policyFormToWritePayload(form).schedule).toMatchObject({ enabled: false, timezone: 'Asia/Shanghai' })
+    expect(backupPolicyToForm(policyWithSchedule(policyFormToWritePayload(form).schedule)).scheduleTimezone).toBe('Asia/Shanghai')
+    form.scheduleTimezone = ''
+    expect(validateScheduleForm(form)).toBe('Select a time zone.')
+  })
+
+  it('keeps legacy policies without a timezone in UTC', () => {
+    const form = backupPolicyToForm(policyWithSchedule({ enabled: false, cron_expr: '0 0 * * *' }))
+    expect(form.scheduleTimezone).toBe('UTC')
+  })
+})

--- a/src/frontend/src/lib/protectionPolicyFormModel.ts
+++ b/src/frontend/src/lib/protectionPolicyFormModel.ts
@@ -1016,8 +1016,8 @@ export function quickScheduleToCron(policyForm: BackupPolicyForm): string {
 }
 
 export function validateScheduleForm(policyForm: BackupPolicyForm): string {
-  if (!policyForm.sectionScheduleEnabled) return ''
   if (!policyForm.scheduleTimezone.trim()) return 'Select a time zone.'
+  if (!policyForm.sectionScheduleEnabled) return ''
   if (policyForm.scheduleStartsAt && !isValidScheduleStart(policyForm.scheduleStartsAt)) {
     return 'Start time must be a valid date and time.'
   }
@@ -1119,7 +1119,7 @@ function applyScheduleFromApi(
       simpleIntervalUnit: parsed.unit,
       simpleIntervalValue: parsed.value,
       cronExpr: expr,
-      scheduleTimezone: 'UTC',
+      scheduleTimezone: schedule?.timezone || 'UTC',
       scheduleStartsAt: '',
       scheduleTime: base.scheduleTime,
       scheduleWeekdays: base.scheduleWeekdays,
@@ -1133,7 +1133,7 @@ function applyScheduleFromApi(
     simpleIntervalUnit: base.simpleIntervalUnit,
     simpleIntervalValue: base.simpleIntervalValue,
     cronExpr: expr || base.cronExpr,
-    scheduleTimezone: 'UTC',
+    scheduleTimezone: schedule?.timezone || 'UTC',
     scheduleStartsAt: '',
     scheduleTime: base.scheduleTime,
     scheduleWeekdays: base.scheduleWeekdays,

--- a/src/frontend/src/locales/enProtectionPages.ts
+++ b/src/frontend/src/locales/enProtectionPages.ts
@@ -1721,6 +1721,7 @@ export const enProtectionPages = {
     hintSimpleInterval: 'Configure a user-friendly interval or calendar schedule.',
     labelInterval: 'Repeat Every',
     scheduleTimezone: 'Time Zone',
+    policyTimezoneHint: 'This time zone applies to backup scheduling and retention. Changes affect future evaluations, including existing snapshots; completed tasks and timestamps stay unchanged.',
     scheduleTimezonePlaceholder: 'Select an IANA time zone',
     scheduleStartsAt: 'Start Time',
     scheduleStartsAtPlaceholder: 'Select the first eligible date and time',

--- a/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
+++ b/src/frontend/src/pages/protection/components/ProtectionPolicyEditorForm.vue
@@ -389,6 +389,34 @@ function toggleScheduleMonthDay(day: number) {
             </p>
           </div>
         </div>
+        <div class="policy-basic-row policy-basic-row--timezone">
+          <label
+            class="policy-basic-row__label"
+            for="policy-timezone-input"
+          >
+            {{ t('protection.policiesPage.scheduleTimezone') }}
+            <span class="policy-basic-row__required">*</span>
+          </label>
+          <div class="policy-basic-row__control">
+            <el-select
+              id="policy-timezone-input"
+              v-model="policyForm.scheduleTimezone"
+              filterable
+              class="schedule-context-control"
+              :placeholder="t('protection.policiesPage.scheduleTimezonePlaceholder')"
+            >
+              <el-option
+                v-for="timezone in scheduleTimezoneOptions"
+                :key="timezone.value"
+                :label="timezone.label"
+                :value="timezone.value"
+              />
+            </el-select>
+          </div>
+          <p class="schedule-context-hint policy-basic-row__hint">
+            {{ t('protection.policiesPage.policyTimezoneHint') }}
+          </p>
+        </div>
         <div class="policy-basic-row">
           <span class="policy-basic-row__label">{{ t('protection.policiesPage.labelPolicyEnabled') }}</span>
           <div class="policy-basic-row__control policy-basic-row__control--switch">
@@ -406,6 +434,12 @@ function toggleScheduleMonthDay(day: number) {
         <el-checkbox v-model="policyForm.sectionScheduleEnabled" />
         <span class="policy-section-head__title">{{ t('protection.policiesPage.sectionCheckSchedule') }}</span>
       </div>
+      <p
+        class="schedule-context-hint"
+        data-policy-timezone
+      >
+        {{ t('protection.policiesPage.scheduleTimezone') }}: {{ policyForm.scheduleTimezone || 'UTC' }}
+      </p>
       <p
         v-if="!policyForm.sectionScheduleEnabled"
         class="policy-section-off-hint"
@@ -434,24 +468,6 @@ function toggleScheduleMonthDay(day: number) {
           </el-radio>
         </el-radio-group>
         <div class="schedule-context-grid">
-          <ElFormItem
-            :label="t('protection.policiesPage.scheduleTimezone')"
-            class="!mb-0"
-          >
-            <el-select
-              v-model="policyForm.scheduleTimezone"
-              filterable
-              class="schedule-context-control"
-              :placeholder="t('protection.policiesPage.scheduleTimezonePlaceholder')"
-            >
-              <el-option
-                v-for="timezone in scheduleTimezoneOptions"
-                :key="timezone.value"
-                :label="timezone.label"
-                :value="timezone.value"
-              />
-            </el-select>
-          </ElFormItem>
           <ElFormItem
             :label="t('protection.policiesPage.scheduleStartsAt')"
             class="!mb-0"
@@ -666,6 +682,12 @@ function toggleScheduleMonthDay(day: number) {
         <el-checkbox v-model="policyForm.sectionRetentionEnabled" />
         <span class="policy-section-head__title">{{ t('protection.policiesPage.sectionCheckRetention') }}</span>
       </div>
+      <p
+        class="schedule-context-hint"
+        data-policy-timezone
+      >
+        {{ t('protection.policiesPage.scheduleTimezone') }}: {{ policyForm.scheduleTimezone || 'UTC' }}
+      </p>
       <p
         v-if="!policyForm.sectionRetentionEnabled"
         class="policy-section-off-hint"
@@ -1235,6 +1257,14 @@ function toggleScheduleMonthDay(day: number) {
   gap: 12px;
 }
 
+.policy-basic-row--timezone {
+  row-gap: 0;
+}
+
+.policy-basic-row__hint {
+  grid-column: 2;
+}
+
 .policy-basic-row__label {
   color: rgb(51 65 85);
   font-size: 13px;
@@ -1634,6 +1664,15 @@ function toggleScheduleMonthDay(day: number) {
   .policy-basic-row {
     grid-template-columns: 1fr;
     justify-items: stretch;
+  }
+
+  .policy-basic-row--timezone {
+    row-gap: 12px;
+  }
+
+  .policy-basic-row__hint {
+    grid-column: 1;
+    margin-top: -12px;
   }
 
   .policy-basic-row__control {

--- a/src/frontend/src/pages/protection/components/ProtectionPolicyScheduleEditor.test.ts
+++ b/src/frontend/src/pages/protection/components/ProtectionPolicyScheduleEditor.test.ts
@@ -45,3 +45,16 @@ describe('protection policy quick schedule editor', () => {
     expect(wizardSource).not.toContain('`*/${Math.max(1, Number(form.simpleIntervalValue)')
   })
 })
+
+describe('shared policy timezone placement', () => {
+  it('has one editable timezone in Basic Information and read-only context for both sections', () => {
+    const basic = editorSource.slice(editorSource.indexOf('<template>'), editorSource.indexOf('data-validation-field="schedule"'))
+    expect(basic).toContain('v-model="policyForm.scheduleTimezone"')
+    expect(editorSource.match(/v-model="policyForm.scheduleTimezone"/g)).toHaveLength(1)
+    expect(editorSource.match(/data-policy-timezone/g)).toHaveLength(2)
+    for (const section of ['schedule', 'retention']) {
+      const context = editorSource.slice(editorSource.indexOf(`data-validation-field="${section}"`))
+      expect(context.indexOf('data-policy-timezone')).toBeLessThan(context.indexOf('class="policy-section-off-hint"'))
+    }
+  })
+})


### PR DESCRIPTION
## Problem and root cause

Backup scheduling already accepted a policy timezone, while retention bucket grouping used the server's UTC timezone. The editor also presented the timezone inside the schedule section, leaving retention without an explicit timezone context.

## Solution

- Move the editable timezone control into Basic Information and show it read-only in both schedule and retention sections.
- Apply the policy timezone to calendar scheduling and retention buckets, including legacy cron policies and retention-only policies.
- Preserve UTC fallback for legacy data, elapsed interval semantics, existing task history, timestamps, and deletion safeguards.
- Add backend/frontend regression coverage and update language packs.

## Validation

- Manual testing: passed.
- Backend protection policy tests: 22 passed in isolated PostgreSQL/Redis.
- Frontend Host test suite: 277 files, 1663 tests passed.
- Targeted timezone tests: 30 passed.
- Ruff, ESLint, production build, language-pack build, translation contract tests, migration drift, English source boundary, and `git diff --check` passed.
- Complete Community backend suite was not run.

## Risks and compatibility

No database migration or historical data rewrite is required. Existing snapshots remain unchanged but are evaluated with the policy timezone during future retention runs. Invalid historical timezone values safely fall back to UTC.

Fixes #1043
