### PR TITLE
fix(frontend): preserve backup repository metadata

### DIFF
--- a/src/frontend/src/pages/protection/BackupConfigurationFastTransition.test.ts
+++ b/src/frontend/src/pages/protection/BackupConfigurationFastTransition.test.ts
@@ -24,7 +24,7 @@ describe('backup configuration fast transition', () => {
     const normalLoad = vi.fn().mockResolvedValue(undefined)
     const activeStep = { value: 2 }
     const initialLoad = { value: true }
-    const source = sourceBetween(page, 'let createdBackupRefresh:', 'function finishCreateAndGoToStep3')
+    const source = sourceBetween(page, 'let createdBackupRefresh:', 'async function finishCreateAndGoToStep3')
     const createHarness = new Function(
       'refreshStep3AfterMoreAction', 'refreshFlowStepData', 'flowMainStep',
       'step3InitialLoadPending', 'pageRequests', 'showApiError',
@@ -136,5 +136,22 @@ describe('backup configuration fast transition', () => {
     expect(page).toContain('if (step3SelectableRows.value.length === 0)')
     expect(page).toContain('await loadStep3Selectable({ signal })')
     expect(page).toContain('syncStep3AutoRefresh()')
+  })
+
+  it('does not erase repository metadata when an auxiliary refresh fails', () => {
+    const refresh = sourceBetween(page, 'async function refreshBackupConfigs(', 'function displayNameForSource')
+
+    expect(refresh).toContain('return null')
+    expect(refresh).toContain('if (repositories)')
+    expect(page).toContain('refreshBackupConfigs(signal, { preserveOnError: true })')
+  })
+
+  it('waits for created repository metadata before entering Step 3', () => {
+    const merge = sourceBetween(page, 'async function mergeCreatedBackupConfigs', 'let createdBackupRefresh')
+    const finish = sourceBetween(page, 'async function finishCreateAndGoToStep3', 'function onCreateBackupPartial')
+
+    expect(merge).toContain('await hydrateCreatedConfigRepositories(items)')
+    expect(finish).toContain('const sourceIds = await mergeCreatedBackupConfigs(payload)')
+    expect(finish.indexOf('enterStartBackupStep')).toBeGreaterThan(finish.indexOf('await mergeCreatedBackupConfigs'))
   })
 })

--- a/src/frontend/src/pages/protection/DataProtection.vue
+++ b/src/frontend/src/pages/protection/DataProtection.vue
@@ -302,7 +302,7 @@ const lifecycleOps = useNodeLifecycleOps({
     await Promise.all([
       loadBackupSelectable({ silent: true }),
       refreshPipelineCounts(),
-      refreshBackupConfigs(),
+      refreshBackupConfigs(undefined, { preserveOnError: true }),
     ])
     if (flowMainStep.value === 1) {
       await refreshFlowStepData(1, { showLoading: false })
@@ -507,7 +507,10 @@ async function refreshBackupConfigs(
       Promise.all(result.results.map((config) => getBackupConfig(config.id, { signal }))),
       listAllStorageRepositories({ page_size: 10 }, { signal }).catch((e) => {
         if (pageRequests.isAbortError(e)) throw e
-        return [] as StorageRepository[]
+        // Keep the last known repository details when this auxiliary request
+        // fails. Replacing the cache with an empty list makes valid targets
+        // render as #<id>/Unknown until the user reloads the page.
+        return null
       }),
       listBackupPolicies({ page: 1, page_size: 500 }, { signal }).catch((e) => {
         if (pageRequests.isAbortError(e)) throw e
@@ -548,7 +551,9 @@ async function refreshBackupConfigs(
       }),
     ])
     backupConfigDetailById.value = new Map(details.map((config) => [config.id, config]))
-    repositoryById.value = new Map(repositories.map((repo) => [repo.id, repo]))
+    if (repositories) {
+      repositoryById.value = new Map(repositories.map((repo) => [repo.id, repo]))
+    }
     backupPolicyById.value = new Map(policies.results.map((policy) => [policy.id, policy]))
     fileFilterById.value = new Map(filters.results.map((rule) => [rule.id, rule]))
     backupSnapshotRows.value = snapshots.results
@@ -2300,13 +2305,15 @@ type BackupCreateResultPayload = {
   items: Array<{ sourceId: string; config: BackupConfigDetail }>
 }
 
-function hydrateCreatedConfigRepositories(items: BackupCreateResultPayload['items']) {
-  void ensureRepositoryDetailsForConfigs(items.map((item) => item.config)).catch((err) => {
+async function hydrateCreatedConfigRepositories(items: BackupCreateResultPayload['items']) {
+  try {
+    await ensureRepositoryDetailsForConfigs(items.map((item) => item.config))
+  } catch (err) {
     if (!pageRequests.isAbortError(err)) showApiError(err)
-  })
+  }
 }
 
-function mergeCreatedBackupConfigs({ items }: BackupCreateResultPayload) {
+async function mergeCreatedBackupConfigs({ items }: BackupCreateResultPayload) {
   if (!items.length) return []
   const sourceIds = normalizeSourceIdList(items.map((item) => item.sourceId))
   const newlyConfiguredIds = sourceIds.filter((id) => !backupConfigSourceIds.value.has(id))
@@ -2327,9 +2334,9 @@ function mergeCreatedBackupConfigs({ items }: BackupCreateResultPayload) {
   pipelineStep2Count.value = Math.max(0, pipelineStep2Count.value - newlyConfiguredIds.length)
   pipelineStep3Count.value += newlyConfiguredIds.length
   syncRealBackupConfigsToDemoStore(items.map((item) => item.config), backupSnapshotRows.value)
-  // The create response only contains repository_id. Hydrate missing repository
-  // metadata independently so the fast Step 3 transition never falls back to #ID.
-  hydrateCreatedConfigRepositories(items)
+  // Hydrate repository metadata before the fast Step 3 transition so a valid
+  // target is not briefly rendered as its numeric fallback ID.
+  await hydrateCreatedConfigRepositories(items)
   return sourceIds
 }
 
@@ -2357,8 +2364,8 @@ function reconcileCreatedBackupConfigs(sourceIds: string[]) {
   createdBackupRefresh = request
 }
 
-function finishCreateAndGoToStep3(payload: BackupCreateResultPayload) {
-  const sourceIds = mergeCreatedBackupConfigs(payload)
+async function finishCreateAndGoToStep3(payload: BackupCreateResultPayload) {
+  const sourceIds = await mergeCreatedBackupConfigs(payload)
   closeCreate()
   const idSet = new Set(sourceIds)
   step1Selection.value = step1Selection.value.filter((id) => !idSet.has(id))
@@ -2367,7 +2374,7 @@ function finishCreateAndGoToStep3(payload: BackupCreateResultPayload) {
 }
 
 function onCreateBackupPartial(payload: BackupCreateResultPayload) {
-  mergeCreatedBackupConfigs(payload)
+  void mergeCreatedBackupConfigs(payload)
   void refreshPipelineCounts().catch(showApiError)
 }
 
@@ -4449,7 +4456,7 @@ async function refreshStep3SourceList() {
     await refreshStep3RuntimeRows(signal)
     const provisionTracked = step3SourceList.value.some((row) => Boolean(sourceProvisionState(row.id)))
     if (!resetTrackedIds.length && !provisionTracked) return
-    const configsLoaded = await refreshBackupConfigs(signal)
+    const configsLoaded = await refreshBackupConfigs(signal, { preserveOnError: true })
     if (!pageRequests.isCurrentSignal(scope, signal)) return
     // Soft-failure clears config/task rows; do not treat empty reset state as success.
     if (!configsLoaded) return

--- a/src/frontend/src/pages/protection/DataProtectionResetBackupConfigList.test.ts
+++ b/src/frontend/src/pages/protection/DataProtectionResetBackupConfigList.test.ts
@@ -61,7 +61,9 @@ describe('backup wizard reset → Backup Configuration list (#362)', () => {
       'function syncStep3AutoRefresh()',
     )
     expect(refreshStep3).toContain('const resetTrackedIds = collectResetTrackedIds()')
-    expect(refreshStep3).toContain('const configsLoaded = await refreshBackupConfigs(signal)')
+    expect(refreshStep3).toContain(
+      'const configsLoaded = await refreshBackupConfigs(signal, { preserveOnError: true })',
+    )
     expect(refreshStep3).toContain('if (!configsLoaded) return')
     expect(refreshStep3).toContain('selectFinishedResetSourceIds(')
     expect(refreshStep3).toContain('selectTerminalFailedResetSourceIds(')


### PR DESCRIPTION
## Problem

After creating or refreshing backup configurations, Step 3 could briefly show
valid targets as `#<repository id>`, `Unknown`, or `—`. Backup paths and other
configuration details could also disappear until the page was refreshed.

## Root cause

The page rendered source rows before repository metadata was hydrated. A failed
auxiliary repository request was converted to an empty result and replaced the
known repository cache. Background refresh failures could also clear the
configuration cache.

## Solution

- Preserve repository metadata when the auxiliary repository request fails.
- Preserve configuration rows during background Step 3 refresh failures.
- Await repository hydration before entering Step 3 after configuration creation.
- Add regression coverage for the fast transition and cache-preservation paths.

## Validation

- `npm run test:ci -- src/pages/protection/BackupConfigurationFastTransition.test.ts`
- `npx eslint src/pages/protection/DataProtection.vue src/pages/protection/BackupConfigurationFastTransition.test.ts`
- `npm run build`
- `git diff --check`
- `python3 tools/quality/check-english-source.py`
- Manual testing: passed

Related to #1155

Fixes #1149
