### PR TITLE
Harden installer lifecycle and simplify audit statistics

### DIFF
--- a/.github/workflows/release_pipeline.yml
+++ b/.github/workflows/release_pipeline.yml
@@ -444,6 +444,7 @@ jobs:
           ./tools/quality/test-docker-pull-retry.sh
           ./tools/quality/test-gh-release-upload-retry.sh
           ./tools/quality/test-offline-docker-package-plan.sh
+          ./tools/quality/test-online-confirm-retry.sh
           ./tools/quality/test-offline-nas-package-plan.sh
           ./tools/quality/test-upgrade-backup-retention.sh
           ./tools/quality/test-upgrade-transaction.sh

--- a/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
+++ b/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
@@ -26,6 +26,16 @@ hfl_warn() {
 	printf '  [WARN] %s\n' "$1" >&2
 }
 
+hfl_print_apt_repair_danger() {
+	# Keep the warning next to every host-APT failure. Operators must not copy
+	# APT's repair hint without reviewing changes to unrelated host packages.
+	hfl_warn "DANGER: HyperFileLens will not run apt --fix-broken or apt upgrade."
+	hfl_warn "Those commands can remove, downgrade, or replace critical host packages"
+	hfl_warn "(python3, cloud-init, networking tools, and others) and may break this"
+	hfl_warn "machine or remote access. Preview first with:"
+	hfl_warn "  apt-get --simulate --no-download --fix-broken install"
+}
+
 hfl_fail() {
 	printf '  [FAIL] %s\n' "$1" >&2
 	exit "${2:-1}"
@@ -282,12 +292,76 @@ select_offline_docker_debs() {
 		|| hfl_fail "Docker offline bundle has no packages left to install." 3
 }
 
+# Return non-zero when the host package database is inconsistent, without
+# changing any package state. Callers decide how to render the diagnostic.
+check_host_apt_health() {
+	local audit_out="" check_log="" check_status=0
+	if command -v dpkg >/dev/null 2>&1; then
+		audit_out="$(dpkg --audit 2>/dev/null || true)"
+		if [[ -n "${audit_out}" ]]; then
+			printf '%s\n' "${audit_out}" | sed 's/^/  /' >&2
+			return 1
+		fi
+	fi
+	command -v apt-get >/dev/null 2>&1 || return 2
+	check_log="$(mktemp /tmp/hfl-apt-check-XXXXXX.log)" || return 1
+	if env DEBIAN_FRONTEND=noninteractive apt-get --quiet=2 check >"${check_log}" 2>&1; then
+		rm -f "${check_log}"
+		return 0
+	else
+		check_status=$?
+	fi
+	if grep -Eqi 'could not get lock|unable to acquire .*lock|is another process using it' "${check_log}"; then
+		check_status=3
+	fi
+	sed 's/^/  /' "${check_log}" >&2 || true
+	rm -f "${check_log}"
+	return "${check_status}"
+}
+
+# Fail before downloading the offline Docker bundle when the host apt/dpkg
+# state cannot resolve dependencies. HyperFileLens never auto-repairs apt.
+assert_host_apt_healthy() {
+	local status=0
+	if check_host_apt_health; then
+		return 0
+	else
+		status=$?
+	fi
+	if [[ "${status}" -eq 2 ]]; then
+		hfl_fail "apt-get is required for the verified offline Docker install." 2
+	fi
+	if [[ "${status}" -eq 3 ]]; then
+		hfl_fail "The host package manager is busy. Stop other apt/dpkg operations and retry the Gateway installation." 3
+	fi
+	hfl_warn "Host apt/dpkg reported an inconsistent package state:"
+	hfl_print_apt_repair_danger
+	hfl_fail "Host package manager is not healthy enough for offline Docker install." 3
+}
+
 validate_offline_docker_plan() {
 	local apt_plan="$1"
 	shift
 	if ! apt-get --simulate --no-download --no-install-recommends install "$@" \
 		>"${apt_plan}" 2>&1; then
 		tail -n 12 "${apt_plan}" >&2 || true
+		# APT can print the generic "fix-broken" suggestion for a missing
+		# dependency in the offline bundle. Re-check the host independently so
+		# that only a real host inconsistency receives repair guidance.
+		local health_status=0
+		if check_host_apt_health >/dev/null 2>&1; then
+			health_status=0
+		else
+			health_status=$?
+		fi
+		if [[ "${health_status}" -eq 3 ]]; then
+			hfl_fail "The host package manager is busy. Stop other apt/dpkg operations and retry the Gateway installation." 3
+		fi
+		if [[ "${health_status}" -ne 0 ]]; then
+			hfl_warn "Docker offline package planning also found an inconsistent host apt/dpkg state."
+			hfl_print_apt_repair_danger
+			hfl_fail "Host package manager is not healthy enough for offline Docker install." 3
+		fi
 		hfl_fail "Docker offline package plan could not be resolved without downloads." 3
 	fi
 	if grep -Eq '^The following packages will be (REMOVED|upgraded):|^[1-9][0-9]* upgraded,' "${apt_plan}"; then
@@ -334,14 +408,9 @@ if [[ -e /var/lib/docker || -e /run/docker.sock ]]; then
 	hfl_fail "Docker state exists even though the docker command is unavailable. Refusing to overwrite a partial installation." 3
 fi
 
-if command -v dpkg >/dev/null 2>&1; then
-	audit_out="$(dpkg --audit 2>/dev/null || true)"
-	if [[ -n "${audit_out}" ]]; then
-		hfl_warn "dpkg reports broken packages on this host:"
-		printf '%s\n' "${audit_out}" | sed 's/^/  /' >&2
-		hfl_fail "Repair the host package state before installing Docker." 3
-	fi
-fi
+# Catch broken or inconsistent host apt state before downloading tens of MB of
+# Docker offline packages. HyperFileLens never auto-repairs apt on customer hosts.
+assert_host_apt_healthy
 
 if ! command -v curl >/dev/null 2>&1; then
 	hfl_fail "curl is required to download Docker offline packages." 2
@@ -389,8 +458,6 @@ for package in manifest.get("packages", []):
 PY
 
 hfl_step "Installing Docker CE from offline packages (${deb_count} debs)."
-command -v apt-get >/dev/null 2>&1 \
-	|| hfl_fail "apt-get is required for the verified offline Docker install." 2
 command -v dpkg-deb >/dev/null 2>&1 \
 	|| hfl_fail "dpkg-deb is required for the verified offline Docker install." 2
 select_offline_docker_debs "${work_dir}"

--- a/deploy/online/install.sh
+++ b/deploy/online/install.sh
@@ -1560,16 +1560,43 @@ PY
 }
 
 confirm_installation() {
-	local answer=""
+	local answer="" prompt="" tty_device="${HFL_CONFIRM_TTY:-/dev/tty}" confirm_fd
 	((ASSUME_YES == 1)) && return 0
-	[[ -r /dev/tty ]] \
+	[[ -r "${tty_device}" ]] \
 		|| fail "interactive confirmation requires a terminal; use --yes only for automation"
 	if [[ "${INSTALL_ACTION}" == "Upgrade" ]]; then
-		read -r -p 'Continue? [y/N] ' answer </dev/tty
+		prompt='Continue? [y/N] '
 	else
-		read -r -p "Proceed with the HyperFileLens Community ${TAG} installation? [y/N] " answer </dev/tty
+		prompt="Proceed with the HyperFileLens Community ${TAG} installation? [y/N] "
 	fi
-	case "${answer}" in y | Y | yes | YES | Yes) ;; *) fail "installation cancelled" ;; esac
+	# Open once so retries advance through the same tty/stream. Re-opening a
+	# redirected test file would otherwise reread the first line forever.
+	exec {confirm_fd}<"${tty_device}" \
+		|| fail "interactive confirmation requires a terminal; use --yes only for automation"
+	# Ctrl+C uses the process INT trap (exit 130) and must not be turned into a
+	# retry loop. Only blank / explicit no cancel; other input is re-prompted.
+	while true; do
+		if ! read -r -u "${confirm_fd}" -p "${prompt}" answer; then
+			exec {confirm_fd}<&-
+			fail "installation cancelled"
+		fi
+		answer="${answer%$'\r'}"
+		answer="${answer#"${answer%%[![:space:]]*}"}"
+		answer="${answer%"${answer##*[![:space:]]}"}"
+		case "${answer}" in
+		y | Y | yes | YES | Yes)
+			exec {confirm_fd}<&-
+			return 0
+			;;
+		"" | n | N | no | NO | No)
+			exec {confirm_fd}<&-
+			fail "installation cancelled"
+			;;
+		*)
+			printf '[WARN] Enter y or n (or press Enter to cancel).\n' >&2
+			;;
+		esac
+	done
 }
 
 run_fresh_community_install() {

--- a/language-packs/packs/es/frontend/messages.json
+++ b/language-packs/packs/es/frontend/messages.json
@@ -6583,8 +6583,6 @@
       "pageTitle": "Registros de auditoría",
       "statTotal": "Total de registros",
       "statToday": "Hoy",
-      "statSuccessRate": "Tasa de éxito",
-      "statFailures": "Fallos",
       "export": "Exportar",
       "advancedFilter": "Filtros avanzados",
       "cancelFilter": "Cancelar",

--- a/language-packs/packs/es/frontend/source-lock.json
+++ b/language-packs/packs/es/frontend/source-lock.json
@@ -6193,8 +6193,6 @@
   "ops.audit.pageTitle": "c8c084d30f194a9b6713aa700f259b280daa27fbec12826fb3a6826ab5397275",
   "ops.audit.statTotal": "b732de2603972ca32d1ae7244388c2f810ee21de0ec2cf825f33db01d74ecee4",
   "ops.audit.statToday": "5397d8be1e29249b78a1dad485a7dfc8cf9cbf685f8f7084a1dea271ab8dcd67",
-  "ops.audit.statSuccessRate": "4f75972cee840db612a4f8ede483f44abf9de6068b2d3b0c66987a787487bd6a",
-  "ops.audit.statFailures": "29e868b94fa63d6b484c9cbdd15a11f2389b5912a7935785bf24d8f61ee01234",
   "ops.audit.export": "99926cd22134f3db4c679056a93501a7ed9a27dd3028be1a72de2150fb7bce40",
   "ops.audit.advancedFilter": "e4695f710e4915aa1803b73e1b6251444f9dc9dfea4249127d579d9b7e013a47",
   "ops.audit.cancelFilter": "c0774c185060fc1366ab0c01488af84eb5e4e1f4f59229431e064de73e0de6c5",

--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -6513,8 +6513,6 @@
       "pageTitle": "操作审计",
       "statTotal": "总记录数",
       "statToday": "今日操作",
-      "statSuccessRate": "成功率",
-      "statFailures": "失败次数",
       "export": "导出",
       "advancedFilter": "高级筛选",
       "cancelFilter": "取消",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -6178,8 +6178,6 @@
   "ops.audit.pageTitle": "c8c084d30f194a9b6713aa700f259b280daa27fbec12826fb3a6826ab5397275",
   "ops.audit.statTotal": "b732de2603972ca32d1ae7244388c2f810ee21de0ec2cf825f33db01d74ecee4",
   "ops.audit.statToday": "5397d8be1e29249b78a1dad485a7dfc8cf9cbf685f8f7084a1dea271ab8dcd67",
-  "ops.audit.statSuccessRate": "4f75972cee840db612a4f8ede483f44abf9de6068b2d3b0c66987a787487bd6a",
-  "ops.audit.statFailures": "29e868b94fa63d6b484c9cbdd15a11f2389b5912a7935785bf24d8f61ee01234",
   "ops.audit.export": "99926cd22134f3db4c679056a93501a7ed9a27dd3028be1a72de2150fb7bce40",
   "ops.audit.advancedFilter": "e4695f710e4915aa1803b73e1b6251444f9dc9dfea4249127d579d9b7e013a47",
   "ops.audit.cancelFilter": "c0774c185060fc1366ab0c01488af84eb5e4e1f4f59229431e064de73e0de6c5",

--- a/src/agent/cmd/enroll/main.go
+++ b/src/agent/cmd/enroll/main.go
@@ -31,6 +31,8 @@ func run() int {
 	defer stop()
 	switch os.Args[1] {
 	case "install":
+		restoreConsole := enroll.DisableConsoleQuickEdit()
+		defer restoreConsole()
 		stabilizeInstallWorkingDirectory()
 		opts := enroll.ParseInstallOptions(os.Args[2:])
 		if err := enroll.WithInstallLock(ctx, func() error {
@@ -40,6 +42,8 @@ func run() int {
 			return 1
 		}
 	case "gateway-install":
+		restoreConsole := enroll.DisableConsoleQuickEdit()
+		defer restoreConsole()
 		stabilizeInstallWorkingDirectory()
 		opts := enroll.ParseInstallOptions(os.Args[2:])
 		if err := enroll.WithInstallLock(ctx, func() error {

--- a/src/agent/internal/enroll/bundle.go
+++ b/src/agent/internal/enroll/bundle.go
@@ -178,6 +178,14 @@ func runStreamingCommand(cmd *exec.Cmd, action string) error {
 	var stderr bytes.Buffer
 	cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
 	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+	// Enrollment invokes installers non-interactively. Do not inherit the
+	// console input, otherwise a stray prompt can block the parent command.
+	null, err := os.Open(os.DevNull)
+	if err != nil {
+		return fmt.Errorf("%s input setup failed: %w", action, err)
+	}
+	cmd.Stdin = null
+	defer null.Close()
 	if err := cmd.Run(); err != nil {
 		captured := append(append([]byte{}, stdout.Bytes()...), stderr.Bytes()...)
 		return commandError(action, err, captured)
@@ -204,14 +212,15 @@ func extractLogDetail(out string) string {
 		if line == "" {
 			continue
 		}
-		if idx := strings.Index(line, "] "); idx >= 0 && strings.HasPrefix(line, "[") {
-			parts := strings.SplitN(line[idx+2:], "] ", 2)
-			if len(parts) == 2 {
-				return strings.TrimSpace(parts[1])
+		// Installer progress lines use markers such as "[FAIL] message".
+		// Keep the actual diagnostic while avoiding a nested marker in the
+		// parent HFL-INSTALL error summary.
+		if strings.HasPrefix(line, "[") {
+			if end := strings.IndexByte(line, ']'); end >= 0 {
+				if detail := strings.TrimSpace(line[end+1:]); detail != "" {
+					return detail
+				}
 			}
-		}
-		if strings.Contains(line, "[FAIL") {
-			return line
 		}
 		return line
 	}

--- a/src/agent/internal/enroll/bundle_test.go
+++ b/src/agent/internal/enroll/bundle_test.go
@@ -18,10 +18,24 @@ func TestRunStreamingCommandReturnsCapturedFailureDetail(t *testing.T) {
 	}
 }
 
+func TestExtractLogDetailRemovesProgressMarker(t *testing.T) {
+	if got := extractLogDetail("  [FAIL] Host package manager is not healthy.\n"); got != "Host package manager is not healthy." {
+		t.Fatalf("extractLogDetail() = %q", got)
+	}
+}
+
 func TestRunStreamingCommandReturnsSuccess(t *testing.T) {
 	t.Parallel()
 	cmd := exec.Command("sh", "-c", "printf 'streamed success\\n'")
 	if err := runStreamingCommand(cmd, "fixture install"); err != nil {
 		t.Fatalf("runStreamingCommand returned %v", err)
+	}
+}
+
+func TestRunStreamingCommandDoesNotInheritConsoleInput(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("sh", "-c", "if read value; then exit 1; fi")
+	if err := runStreamingCommand(cmd, "non-interactive fixture"); err != nil {
+		t.Fatalf("runStreamingCommand unexpectedly inherited input: %v", err)
 	}
 }

--- a/src/agent/internal/enroll/console_stub.go
+++ b/src/agent/internal/enroll/console_stub.go
@@ -1,0 +1,6 @@
+//go:build !windows
+
+package enroll
+
+// DisableConsoleQuickEdit is a no-op outside Windows.
+func DisableConsoleQuickEdit() func() { return func() {} }

--- a/src/agent/internal/enroll/console_windows.go
+++ b/src/agent/internal/enroll/console_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package enroll
+
+import "golang.org/x/sys/windows"
+
+const (
+	enableQuickEditMode = 0x0040
+	enableExtendedFlags = 0x0080
+)
+
+// DisableConsoleQuickEdit prevents a click in a Windows console from
+// entering mark mode, which otherwise blocks writes until Enter or Escape.
+// It is intentionally best-effort because enrollment may run without a
+// console (for example from a scheduled task or redirected standard input).
+// The returned function restores the original mode for the caller's console.
+func DisableConsoleQuickEdit() func() {
+	handle, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE)
+	if err != nil || handle == 0 || handle == windows.InvalidHandle {
+		return func() {}
+	}
+	var mode uint32
+	if err := windows.GetConsoleMode(handle, &mode); err != nil {
+		return func() {}
+	}
+	originalMode := mode
+	mode &^= enableQuickEditMode
+	mode |= enableExtendedFlags
+	if err := windows.SetConsoleMode(handle, mode); err != nil {
+		return func() {}
+	}
+	return func() { _ = windows.SetConsoleMode(handle, originalMode) }
+}

--- a/src/agent/internal/enroll/gateway_install.go
+++ b/src/agent/internal/enroll/gateway_install.go
@@ -88,11 +88,11 @@ func RunGatewayInstall(ctx context.Context, opts InstallOptions) error {
 
 	if err := ensureGatewayDocker(ctx, cfg); err != nil {
 		_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "failed", err.Error())
-		logFail("Docker setup failed: "+err.Error(), 7)
+		abortInstall("Installing AI engine", "Docker setup failed: "+err.Error(), 7, "HFL-INSTALL-007")
 	}
 	if err := InstallLensSidecar(ctx, cfg, lensCfg); err != nil {
 		_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "failed", err.Error())
-		logFail("AI engine install failed: "+err.Error(), 7)
+		abortInstall("Installing AI engine", "AI engine install failed: "+err.Error(), 7, "HFL-INSTALL-007")
 	}
 	_ = ReportGatewayInstallStatus(ctx, cfg, nodeID, "success", "")
 	logOK("AI engine was installed successfully.")

--- a/src/agent/internal/enroll/install.go
+++ b/src/agent/internal/enroll/install.go
@@ -433,6 +433,11 @@ func finishEnrollment(
 		service = "active"
 	}
 	logOK(fmt.Sprintf("Agent service is %s.", service))
+	// Use the installed metadata for the final summary. The running-process
+	// identity is verified by StartInstalledService before this point.
+	if ver, verErr := InstalledAgentVersion(ctx); verErr == nil && ver != "" {
+		agentVer = ver
+	}
 	logStep("Waiting for the Agent to come online.")
 	if err := enrollmentclient.WaitNodeOnline(ctx, agentCfg, nodeID, 30*time.Second); err != nil {
 		abortInstall(

--- a/src/agent/internal/enroll/output.go
+++ b/src/agent/internal/enroll/output.go
@@ -204,6 +204,10 @@ func PrintCommandFailureFor(operation string, err error) {
 		title = "Installation completed, but verification failed"
 		systemChange = "Agent installed; verification requires attention"
 	}
+	if operation == "install" && failure.CodeKey == "HFL-INSTALL-007" &&
+		failure.Stage != "Preflight checks" && failure.Stage != "Initialization" {
+		systemChange = "Agent installed; Docker / AI engine were not completed"
+	}
 	printResultRule(os.Stderr, title, ansiRed)
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Failure")
@@ -220,6 +224,79 @@ func PrintCommandFailureFor(operation string, err error) {
 		fmt.Fprintln(os.Stderr, "  2. Confirm that any proxy supports WebSocket connections.")
 		fmt.Fprintln(os.Stderr, "  3. Review the Agent service log and run hfl-enroll status.")
 	}
+	if operation == "install" && failure.CodeKey == "HFL-INSTALL-007" &&
+		failure.Stage != "Preflight checks" && failure.Stage != "Initialization" {
+		if isHostAptBusyFailure(failure.Reason) {
+			printHostAptBusySuggestedActions()
+		} else if isHostAptUnhealthyFailure(failure.Reason) {
+			printHostAptUnhealthySuggestedActions()
+		} else {
+			printDockerOrAIEngineSuggestedActions()
+		}
+	}
+}
+
+func isHostAptBusyFailure(reason string) bool {
+	return strings.Contains(
+		strings.ToLower(reason),
+		"the host package manager is busy",
+	)
+}
+
+// isHostAptUnhealthyFailure detects Docker bootstrap failures caused by a
+// broken/inconsistent host apt state. HFL-INSTALL-007 also covers sidecar and
+// Docker runtime failures; those must not get apt --fix-broken advice.
+func isHostAptUnhealthyFailure(reason string) bool {
+	// Match only the installer-owned diagnostic. APT emits the same generic
+	// "fix-broken" hint when the offline bundle itself is incomplete, which is
+	// not evidence that unrelated host packages are corrupted.
+	return strings.Contains(
+		strings.ToLower(reason),
+		"host package manager is not healthy enough for offline docker install",
+	)
+}
+
+func printHostAptBusySuggestedActions() {
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Suggested actions:")
+	fmt.Fprintln(os.Stderr, "  1. Wait for the active apt/dpkg operation, such as unattended-upgrades, to finish.")
+	fmt.Fprintln(os.Stderr, "  2. Confirm that no apt or dpkg process is still running, then retry the Gateway installation.")
+	fmt.Fprintln(os.Stderr, "  3. Do not delete package-manager lock files while apt or dpkg is active.")
+}
+
+func printHostAptUnhealthySuggestedActions() {
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Suggested actions:")
+	fmt.Fprintln(os.Stderr, "  1. This is usually a broken or inconsistent host apt state, not a")
+	fmt.Fprintln(os.Stderr, "     HyperFileLens download failure. HyperFileLens will not repair apt")
+	fmt.Fprintln(os.Stderr, "     automatically.")
+	fmt.Fprintln(os.Stderr, "  2. Inspect only:")
+	fmt.Fprintln(os.Stderr, "       apt-get check")
+	fmt.Fprintln(os.Stderr, "       dpkg --audit")
+	fmt.Fprintln(os.Stderr, "       dpkg -l 'libpython3*'")
+	fmt.Fprintln(os.Stderr, "       apt-get --simulate --no-download --fix-broken install")
+	fmt.Fprintln(os.Stderr, "  3. DANGER: do not run apt-get --fix-broken install (or apt upgrade)")
+	fmt.Fprintln(os.Stderr, "     unless you understand and accept the package changes. That command")
+	fmt.Fprintln(os.Stderr, "     can remove, downgrade, or replace critical host packages (python3,")
+	fmt.Fprintln(os.Stderr, "     cloud-init, networking tools, and others) and may break this machine")
+	fmt.Fprintln(os.Stderr, "     or remote access. Always review --simulate output first.")
+	fmt.Fprintln(os.Stderr, "  4. Safer options: install Docker yourself (engine >= 24.0, Compose v2")
+	fmt.Fprintln(os.Stderr, "     >= 2.20) and re-run the Gateway command, or use a clean Ubuntu")
+	fmt.Fprintln(os.Stderr, "     20.04 / 22.04 / 24.04 amd64 host.")
+	fmt.Fprintln(os.Stderr, "  5. The Agent may already be registered; repair or rebuild carefully")
+	fmt.Fprintln(os.Stderr, "     before retrying enrollment.")
+}
+
+func printDockerOrAIEngineSuggestedActions() {
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Suggested actions:")
+	fmt.Fprintln(os.Stderr, "  1. Review the Docker / AI engine messages above for the concrete failure.")
+	fmt.Fprintln(os.Stderr, "  2. If Docker is already installed, confirm engine >= 24.0, Compose v2")
+	fmt.Fprintln(os.Stderr, "     >= 2.20, and that the daemon is reachable (`docker info`).")
+	fmt.Fprintln(os.Stderr, "  3. Safer options: install or repair Docker yourself and re-run the")
+	fmt.Fprintln(os.Stderr, "     Gateway command, or use a clean Ubuntu 20.04 / 22.04 / 24.04 amd64 host.")
+	fmt.Fprintln(os.Stderr, "  4. The Agent may already be registered; repair or rebuild carefully")
+	fmt.Fprintln(os.Stderr, "     before retrying enrollment.")
 }
 
 func normalizeFailureOperation(operation string) string {

--- a/src/agent/internal/enroll/output_test.go
+++ b/src/agent/internal/enroll/output_test.go
@@ -162,6 +162,52 @@ func TestPrintCommandFailureForUninstall(t *testing.T) {
 	}
 }
 
+func TestIsHostAptUnhealthyFailureUsesInstallerMarker(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		reason string
+		want   bool
+	}{
+		{
+			name:   "package manager busy",
+			reason: "Docker setup failed: docker install script: The host package manager is busy. Stop other apt/dpkg operations and retry the Gateway installation.",
+			want:   false,
+		},
+		{
+			name:   "installer marker",
+			reason: "Docker setup failed: docker install script: [FAIL] Host package manager is not healthy enough for offline Docker install.",
+			want:   true,
+		},
+		{
+			name:   "offline dependency closure",
+			reason: "Docker setup failed: docker install script: E: Unmet dependencies. Try apt --fix-broken install.",
+			want:   false,
+		},
+		{
+			name:   "sidecar readiness",
+			reason: "AI engine install failed: sidecar container failed readiness check",
+			want:   false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isHostAptUnhealthyFailure(test.reason); got != test.want {
+				t.Fatalf("isHostAptUnhealthyFailure(%q)=%v, want %v", test.reason, got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsHostAptBusyFailureUsesRetryMarker(t *testing.T) {
+	if !isHostAptBusyFailure("The host package manager is busy. Stop other apt/dpkg operations and retry the Gateway installation.") {
+		t.Fatal("expected package-manager busy diagnostic")
+	}
+	if isHostAptBusyFailure("Host package manager is not healthy enough for offline Docker install.") {
+		t.Fatal("host corruption diagnostic must not be classified as busy")
+	}
+}
+
 func TestPrintCommandFailureForKeepsJSONResultTypeCompatible(t *testing.T) {
 	t.Setenv("HFL_OUTPUT", "json")
 	previousStderr := os.Stderr

--- a/src/agent/internal/enroll/service_unix.go
+++ b/src/agent/internal/enroll/service_unix.go
@@ -19,7 +19,11 @@ import (
 // StartInstalledService enables and starts the platform service after enrollment.
 func StartInstalledService(ctx context.Context) error {
 	if runtime.GOOS == "darwin" {
-		return startUnixScript(ctx, "start")
+		action := enrollmentServiceAction(isServiceMayHaveProcess(serviceState(ctx)), false)
+		if err := startUnixScript(ctx, action); err != nil {
+			return err
+		}
+		return verifyRunningAgentMatchesInstall(ctx)
 	}
 	return startSystemd(ctx)
 }
@@ -55,14 +59,18 @@ func startSystemd(ctx context.Context) error {
 	// then commits the retained rollback transaction.
 	statePath := install.LifecycleUpgradeStatePath(vfs.DefaultAgentDataDir())
 	if _, err := os.Stat(statePath); err == nil {
-		return startUnixScript(ctx, "start")
+		if err := startUnixScript(ctx, "start"); err != nil {
+			return err
+		}
+		return verifyRunningAgentMatchesInstall(ctx)
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("inspect pending upgrade state: %w", err)
 	}
+	action := enrollmentServiceAction(isServiceMayHaveProcess(serviceState(ctx)), false)
 	for _, args := range [][]string{
 		{"daemon-reload"},
 		{"enable", "hyperfilelens-agent.service"},
-		{"start", "hyperfilelens-agent.service"},
+		{action, "hyperfilelens-agent.service"},
 	} {
 		if installIsUserLevel() {
 			args = append([]string{"--user"}, args...)
@@ -78,9 +86,18 @@ func startSystemd(ctx context.Context) error {
 	}
 	active, _ := exec.CommandContext(ctx, "systemctl", activeArgs...).Output()
 	if strings.TrimSpace(string(active)) != "active" {
-		return fmt.Errorf("service not active after start")
+		return fmt.Errorf("service not active after %s", action)
 	}
-	return nil
+	return verifyRunningAgentMatchesInstall(ctx)
+}
+
+func isServiceMayHaveProcess(service string) bool {
+	switch strings.ToLower(strings.TrimSpace(service)) {
+	case "active", "activating", "deactivating", "running", "loaded":
+		return true
+	default:
+		return false
+	}
 }
 
 func installIsUserLevel() bool {

--- a/src/agent/internal/enroll/service_verify_unix.go
+++ b/src/agent/internal/enroll/service_verify_unix.go
@@ -1,0 +1,122 @@
+//go:build !windows
+
+package enroll
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"hyperfilelens/agent/internal/platform/install"
+)
+
+// verifyRunningAgentMatchesInstall confirms that a Linux systemd service is
+// executing the binary that was just installed. A routable WebSocket alone is
+// insufficient because an older process can remain online after an in-place
+// binary replacement.
+func verifyRunningAgentMatchesInstall(ctx context.Context) error {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return nil
+	}
+	bin := filepath.Join(install.DefaultInstallDir(), agentBinaryName())
+	if _, err := os.Stat(bin); err != nil {
+		if legacy := legacyAgentBinaryPath(); legacy != "" {
+			if _, legacyErr := os.Stat(legacy); legacyErr == nil {
+				bin = legacy
+			}
+		}
+	}
+	if _, err := os.Stat(bin); err != nil {
+		return fmt.Errorf("installed Agent binary is missing at %s", bin)
+	}
+	want, err := filepath.EvalSymlinks(bin)
+	if err != nil {
+		want = filepath.Clean(bin)
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	var lastErr error
+	for {
+		pid, err := systemdAgentMainPID(ctx)
+		if err != nil {
+			lastErr = err
+		} else if pid <= 0 {
+			lastErr = fmt.Errorf("Agent service has no MainPID")
+		} else {
+			rawExe, readErr := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+			if readErr != nil {
+				lastErr = fmt.Errorf("inspect running Agent process %d: %w", pid, readErr)
+			} else if runningExecutableMatches(rawExe, want) {
+				return nil
+			} else {
+				lastErr = fmt.Errorf("running Agent process %d does not execute the installed binary (%s)", pid, rawExe)
+			}
+		}
+		if time.Now().After(deadline) {
+			if lastErr == nil {
+				lastErr = fmt.Errorf("running Agent process could not be verified")
+			}
+			return lastErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+// runningExecutableMatches rejects the kernel's "(deleted)" marker. It means
+// the process still has an old unlinked inode open after an atomic replacement.
+func runningExecutableMatches(rawExe, installedExe string) bool {
+	if strings.HasSuffix(rawExe, " (deleted)") {
+		return false
+	}
+	running, err := filepath.EvalSymlinks(rawExe)
+	if err != nil {
+		running = filepath.Clean(rawExe)
+	}
+	return filepath.Clean(running) == filepath.Clean(installedExe)
+}
+
+func systemdAgentMainPID(ctx context.Context) (int, error) {
+	args := []string{"show", "hyperfilelens-agent.service", "-p", "MainPID"}
+	if installIsUserLevel() {
+		args = append([]string{"--user"}, args...)
+	}
+	out, err := exec.CommandContext(ctx, "systemctl", args...).CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("systemctl show MainPID: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "MainPID=") {
+			raw := strings.TrimSpace(strings.TrimPrefix(line, "MainPID="))
+			if raw == "" || raw == "0" {
+				return 0, nil
+			}
+			var pid int
+			if _, err := fmt.Sscanf(raw, "%d", &pid); err != nil {
+				return 0, fmt.Errorf("parse MainPID %q: %w", raw, err)
+			}
+			return pid, nil
+		}
+	}
+	return 0, fmt.Errorf("systemctl show MainPID returned no MainPID")
+}
+
+func enrollmentServiceAction(serviceMayHaveProcess, pendingUpgrade bool) string {
+	if pendingUpgrade {
+		return "start"
+	}
+	if serviceMayHaveProcess {
+		return "restart"
+	}
+	return "start"
+}

--- a/src/agent/internal/enroll/service_verify_unix_test.go
+++ b/src/agent/internal/enroll/service_verify_unix_test.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package enroll
+
+import "testing"
+
+func TestRunningExecutableMatchesRejectsDeletedProcess(t *testing.T) {
+	if runningExecutableMatches("/opt/hyperfilelens-agent/bin/hfl-agent (deleted)", "/opt/hyperfilelens-agent/bin/hfl-agent") {
+		t.Fatal("a deleted executable must not be accepted as the installed Agent")
+	}
+}
+
+func TestRunningExecutableMatchesAcceptsExactPath(t *testing.T) {
+	if !runningExecutableMatches("/opt/hyperfilelens-agent/bin/hfl-agent", "/opt/hyperfilelens-agent/bin/hfl-agent") {
+		t.Fatal("the exact installed executable should be accepted")
+	}
+}
+
+func TestEnrollmentServiceAction(t *testing.T) {
+	cases := []struct {
+		name, want                     string
+		mayHaveProcess, pendingUpgrade bool
+	}{
+		{name: "inactive", want: "start"},
+		{name: "active", mayHaveProcess: true, want: "restart"},
+		{name: "pending upgrade", pendingUpgrade: true, want: "start"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := enrollmentServiceAction(tc.mayHaveProcess, tc.pendingUpgrade); got != tc.want {
+				t.Fatalf("enrollmentServiceAction() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/src/agent/internal/enroll/sidecar_install_unix.go
+++ b/src/agent/internal/enroll/sidecar_install_unix.go
@@ -347,9 +347,15 @@ func ensureGatewayDocker(ctx context.Context, cfg Config) error {
 		"HFL_DOCKER_MIN_ENGINE="+gatewayMinDockerEngine,
 		"HFL_COMPOSE_MIN_VERSION="+gatewayMinDockerCompose,
 	)
+	var stderr bytes.Buffer
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	// Keep live bootstrap output while retaining the installer-owned failure
+	// marker for the final HFL-INSTALL-007 summary.
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
 	if err := cmd.Run(); err != nil {
+		if detail := extractLogDetail(stderr.String()); detail != "" {
+			return fmt.Errorf("docker install script: %s", detail)
+		}
 		return fmt.Errorf("docker install script: %w", err)
 	}
 	if !dockerRuntimeReady() {

--- a/src/agent/internal/platform/install/install_ps1_test.go
+++ b/src/agent/internal/platform/install/install_ps1_test.go
@@ -23,6 +23,40 @@ func TestInstallPs1CompleteRemovalDoesNotRecreateDataLogDirectory(t *testing.T) 
 	}
 }
 
+func TestInstallPs1RestartsManagedAgentBeforeVerification(t *testing.T) {
+	source := readPackagingInstallScript(t)
+	for _, want := range []string{
+		`Stop-ScheduledTask -TaskName $TaskName -ErrorAction Stop`,
+		`$task.State -in @('Running', 'Queued')`,
+		`Scheduled task $TaskName did not stop before restart.`,
+		`points to a different Agent executable; reinstall the managed task before starting it.`,
+		`Get-CimInstance Win32_Service -Filter`,
+		`Service $ServiceName points to a different Agent executable; reinstall the managed service before starting it.`,
+		`Restart-Service -Name $ServiceName -Force -ErrorAction Stop`,
+		`Start-Service -Name $ServiceName -ErrorAction Stop`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("install.ps1 is missing stale-process protection %q", want)
+		}
+	}
+}
+
+func TestInstallPs1NonInteractiveEnrollmentCannotPromptOrLookFrozen(t *testing.T) {
+	source := readPackagingInstallScript(t)
+	for _, want := range []string{
+		`if ($QuietFooter -or -not [string]::IsNullOrWhiteSpace($RunAsUser))`,
+		`elseif ([Environment]::UserInteractive)`,
+		`QuietFooter only suppresses banners/sections/footers/summaries`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("install.ps1 is missing non-interactive enrollment protection %q", want)
+		}
+	}
+	if strings.Contains(source, `if ((-not $QuietFooter) -or ($Level -eq 'FAIL '))`) {
+		t.Fatal("QuietFooter must not hide deploy progress lines")
+	}
+}
+
 func TestInstallPs1DoesNotRemoveInstallParent(t *testing.T) {
 	source := readPackagingInstallScript(t)
 	for _, forbidden := range []string{

--- a/src/agent/internal/platform/install/install_sh_test.go
+++ b/src/agent/internal/platform/install/install_sh_test.go
@@ -336,6 +336,15 @@ func TestInstallShellUpgradeKeepsRollbackUntilLocalHealth(t *testing.T) {
 	if !strings.Contains(startOnlyBody, "hfl_systemctl daemon-reload") {
 		t.Fatal("install.sh start_service_only must reload systemd before starting a rewritten unit")
 	}
+	for _, want := range []string{
+		`hfl_systemctl is-active hyperfilelens-agent.service`,
+		`hfl_systemctl restart hyperfilelens-agent.service`,
+		`Stopping leftover hyperfilelens-agent.service before installing.`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("install.sh is missing stale-process protection %q", want)
+		}
+	}
 	if !strings.Contains(body, `if [[ -f "${state_file}" ]]; then`) {
 		t.Fatal("install.sh lifecycle commands must recover an existing state file even when its phase is unreadable")
 	}

--- a/src/agent/packaging/install/install.ps1
+++ b/src/agent/packaging/install/install.ps1
@@ -276,8 +276,16 @@ function Assert-HflInstallationIdentity {
   }
   if ($InstallationMode -eq "account" -and $Command -eq "install") {
     $defaultRunAsUser = if ([string]::IsNullOrWhiteSpace($RunAsUser)) { $CurrentWindowsIdentity } else { $RunAsUser }
-    $selectedRunAsUser = Read-Host "Enter the existing Windows account to protect (default: $defaultRunAsUser)"
-    $RunAsUser = if ([string]::IsNullOrWhiteSpace($selectedRunAsUser)) { $defaultRunAsUser } else { $selectedRunAsUser.Trim() }
+    if ($QuietFooter -or -not [string]::IsNullOrWhiteSpace($RunAsUser)) {
+      $RunAsUser = $defaultRunAsUser
+    }
+    elseif ([Environment]::UserInteractive) {
+      $selectedRunAsUser = Read-Host "Enter the existing Windows account to protect (default: $defaultRunAsUser)"
+      $RunAsUser = if ([string]::IsNullOrWhiteSpace($selectedRunAsUser)) { $defaultRunAsUser } else { $selectedRunAsUser.Trim() }
+    }
+    else {
+      $RunAsUser = $defaultRunAsUser
+    }
   }
 }
 
@@ -498,18 +506,16 @@ function Write-HflLog {
     default { 'INFO' }
   }
   $displayLine = "  [$status] $messageText"
-  # QuietFooter suppresses duplicate inner lifecycle output, but the outer
-  # enrollment command still needs the concrete failure reason.
-  if ((-not $QuietFooter) -or ($Level -eq 'FAIL ')) {
-    if ($Level -eq 'WARN ') {
-      Write-Host $displayLine -ForegroundColor Yellow
-    }
-    elseif ($Level -eq 'FAIL ') {
-      Write-Host $displayLine -ForegroundColor Red
-    }
-    else {
-      Write-Host $displayLine
-    }
+  # QuietFooter only suppresses banners/sections/footers/summaries. Keep
+  # lifecycle lines visible so a long binary copy does not look frozen.
+  if ($Level -eq 'WARN ') {
+    Write-Host $displayLine -ForegroundColor Yellow
+  }
+  elseif ($Level -eq 'FAIL ') {
+    Write-Host $displayLine -ForegroundColor Red
+  }
+  else {
+    Write-Host $displayLine
   }
   Write-HflInstallLogLine $line
 }
@@ -1880,7 +1886,32 @@ function Start-HflServiceOnly {
         -DataRoot (Get-ResolvedDataRoot -Override "")
       return
     }
-    Start-ScheduledTask -TaskName $TaskName
+    $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction Stop
+    $expectedExecutable = if ($InstallationMode -eq "user") {
+      Join-Path $InstallRoot "hfl-agent-user-launcher.exe"
+    }
+    else {
+      Join-Path $InstallRoot "hfl-agent.exe"
+    }
+    $taskAction = ($task.Actions | Select-Object -First 1).Execute
+    if ([string]::IsNullOrWhiteSpace($taskAction) -or
+        -not ([System.IO.Path]::GetFullPath($taskAction).Equals(
+          [System.IO.Path]::GetFullPath($expectedExecutable),
+          [System.StringComparison]::OrdinalIgnoreCase))) {
+      throw "Scheduled task $TaskName points to a different Agent executable; reinstall the managed task before starting it."
+    }
+    if ($task.State -in @('Running', 'Queued')) {
+      Stop-ScheduledTask -TaskName $TaskName -ErrorAction Stop
+      $deadline = (Get-Date).AddSeconds(30)
+      do {
+        Start-Sleep -Milliseconds 500
+        $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction Stop
+      } while ($task.State -in @('Running', 'Queued') -and (Get-Date) -lt $deadline)
+      if ($task.State -in @('Running', 'Queued')) {
+        throw "Scheduled task $TaskName did not stop before restart."
+      }
+    }
+    Start-ScheduledTask -TaskName $TaskName -ErrorAction Stop
     Write-HflOk "started $LifecycleLabel $TaskName ($(Get-HflServiceStatusLine))"
     return
   }
@@ -1891,7 +1922,18 @@ function Start-HflServiceOnly {
       -DataRoot (Get-ResolvedDataRoot -Override "")
     return
   }
-  Start-Service -Name $ServiceName
+  $serviceInfo = Get-CimInstance Win32_Service -Filter "Name='$ServiceName'" -ErrorAction Stop
+  $expectedExecutable = [System.IO.Path]::GetFullPath((Join-Path $InstallRoot "hfl-agent.exe"))
+  if ($null -eq $serviceInfo -or [string]::IsNullOrWhiteSpace($serviceInfo.PathName) -or
+      $serviceInfo.PathName.IndexOf($expectedExecutable, [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
+    throw "Service $ServiceName points to a different Agent executable; reinstall the managed service before starting it."
+  }
+  if ($svc.Status -eq "Running") {
+    Restart-Service -Name $ServiceName -Force -ErrorAction Stop
+  }
+  else {
+    Start-Service -Name $ServiceName -ErrorAction Stop
+  }
   Write-HflOk "started service $ServiceName ($(Get-HflServiceStatusLine))"
 }
 

--- a/src/agent/packaging/install/install.sh
+++ b/src/agent/packaging/install/install.sh
@@ -2424,7 +2424,7 @@ gateway_resource_preflight() {
 stop_service() {
 	if agent_uses_launchd; then
 		stop_launchd_service
-		return 0
+		return $?
 	fi
 	if ! command -v systemctl >/dev/null 2>&1; then
 		log_skip "stop hyperfilelens-agent.service (systemctl not found)"
@@ -2545,7 +2545,16 @@ start_service_only() {
 	# previous running state. Reload systemd explicitly so start never uses a
 	# stale unit definition from its manager cache.
 	hfl_systemctl daemon-reload
-	hfl_systemctl start hyperfilelens-agent.service
+	local state
+	state="$(hfl_systemctl is-active hyperfilelens-agent.service 2>/dev/null || echo inactive)"
+	case "${state}" in
+		active|activating|deactivating)
+			hfl_systemctl restart hyperfilelens-agent.service
+			;;
+		*)
+			hfl_systemctl start hyperfilelens-agent.service
+			;;
+	esac
 	log_ok "started service hyperfilelens-agent.service ($(service_status_line))"
 }
 
@@ -2585,6 +2594,23 @@ cmd_install() {
 		local command_prefix=""
 		[[ "${INSTALLATION_MODE}" == "system" ]] && command_prefix="sudo "
 		log_fail "The agent is already installed. Run ${command_prefix}./install.sh upgrade --from <package.tar.gz> instead." 2
+	fi
+
+	# A stale managed service may survive after an interrupted or manually
+	# removed installation. Stop it before replacing binaries so an old process
+	# cannot remain online while the new package is reported as installed.
+	if agent_manages_service && agent_uses_systemd; then
+		local leftover
+		leftover="$(hfl_systemctl is-active hyperfilelens-agent.service 2>/dev/null || echo inactive)"
+		case "${leftover}" in
+			active|activating|deactivating)
+				log_warn "Stopping leftover hyperfilelens-agent.service before installing."
+				stop_service
+				;;
+		esac
+	elif agent_uses_launchd && launchctl print "${LAUNCHD_DOMAIN}/${LAUNCHD_LABEL}" >/dev/null 2>&1; then
+		log_warn "Stopping leftover ${LAUNCHD_LABEL} before installing."
+		stop_service
 	fi
 
 	DATA_DIR="${DATA_DIR:-$DEFAULT_DATA}"

--- a/src/backend/apps/audit/selectors/interface.py
+++ b/src/backend/apps/audit/selectors/interface.py
@@ -4,7 +4,7 @@ Audit read facade — cross-app callers should use this module only.
 
 from __future__ import annotations
 
-from django.db.models import Count, QuerySet
+from django.db.models import QuerySet
 from django.utils import timezone
 
 from apps.audit.models import AuditLog
@@ -53,31 +53,7 @@ def audit_statistics(*, org_key: str | None) -> dict:
     total = qs.count()
     today = timezone.now().date()
     today_count = qs.filter(created_at__date=today).count()
-    success = qs.filter(result="success").count()
-    failure = qs.filter(result="failure").count()
-    partial = qs.filter(result="partial").count()
-    action_stats = {
-        row["action"]: row["count"]
-        for row in qs.values("action").annotate(count=Count("id")).order_by("-count")[:50]
-    }
-    resource_stats = {
-        row["resource_type"]: row["count"]
-        for row in qs.exclude(resource_type="")
-        .values("resource_type")
-        .annotate(count=Count("id"))
-        .order_by("-count")[:50]
-    }
     return {
         "total_count": total,
         "today_count": today_count,
-        "success_rate": round((success / total) * 100, 2) if total else 0,
-        "failure_count": failure,
-        "partial_count": partial,
-        "action_stats": action_stats,
-        "resource_stats": resource_stats,
-        "result_stats": {
-            "success": success,
-            "failure": failure,
-            "partial": partial,
-        },
     }

--- a/src/backend/apps/audit/tests/test_api.py
+++ b/src/backend/apps/audit/tests/test_api.py
@@ -85,8 +85,8 @@ class AuditApiTests(TestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertGreaterEqual(resp.data["total_count"], 2)
-        self.assertIn("success_rate", resp.data)
-        self.assertGreaterEqual(resp.data["failure_count"], 1)
+        self.assertGreaterEqual(resp.data["today_count"], 2)
+        self.assertEqual(set(resp.data), {"total_count", "today_count"})
 
     def test_search_by_ip(self):
         resp = self.client.get(

--- a/src/frontend/src/lib/auditApi.ts
+++ b/src/frontend/src/lib/auditApi.ts
@@ -66,11 +66,6 @@ export async function auditStatistics() {
   return unwrapApiPayload<{
     total_count: number
     today_count: number
-    success_rate: number
-    failure_count: number
-    action_stats: Record<string, number>
-    resource_stats: Record<string, number>
-    result_stats: Record<string, number>
   }>(await api<unknown>(`${base}/statistics/`))
 }
 

--- a/src/frontend/src/lib/dashboardApi.ts
+++ b/src/frontend/src/lib/dashboardApi.ts
@@ -139,8 +139,6 @@ export type DashboardOverview = {
   audit: {
     todayCount: number
     totalCount: number
-    successRate: number
-    failureCount: number
   }
   nodesOnline: number
   nodesTotal: number
@@ -547,11 +545,6 @@ export async function loadDashboardOverview(
     auditStatistics().catch(() => ({
       total_count: 0,
       today_count: 0,
-      success_rate: 0,
-      failure_count: 0,
-      action_stats: {},
-      resource_stats: {},
-      result_stats: {},
     })),
     api<unknown>('/api/v1/protection/policies/?page_size=200').then((raw) => asList<ApiPolicy>(raw)).catch(() => []),
     api<unknown>('/api/v1/notifications/logs/stats/').then((raw) => unwrapApiPayload<{ failed?: number }>(raw)).catch(() => ({ failed: 0 })),
@@ -661,8 +654,6 @@ export async function loadDashboardOverview(
     audit: {
       todayCount: auditStats.today_count,
       totalCount: auditStats.total_count,
-      successRate: auditStats.success_rate,
-      failureCount: auditStats.failure_count,
     },
     nodesOnline: nodeAvailability.online,
     nodesTotal,

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -4307,8 +4307,6 @@ export const en = {
       pageTitle: 'Audit Logs',
       statTotal: 'Total Records',
       statToday: 'Today',
-      statSuccessRate: 'Success Rate',
-      statFailures: 'Failures',
       export: 'Export',
       advancedFilter: 'Advanced Filters',
       cancelFilter: 'Cancel',

--- a/src/frontend/src/pages/ops/Audit.vue
+++ b/src/frontend/src/pages/ops/Audit.vue
@@ -32,8 +32,6 @@ const rows = ref<AuditLogRow[]>([])
 const stats = ref({
   total_count: 0,
   today_count: 0,
-  success_rate: 0,
-  failure_count: 0,
 })
 const loading = ref(false)
 const exportMenuOpen = ref(false)
@@ -268,9 +266,13 @@ function buildParams(): Record<string, string | number> {
 
 async function fetchStats() {
   try {
-    stats.value = await auditStatistics()
+    const data = await auditStatistics()
+    stats.value = {
+      total_count: data.total_count,
+      today_count: data.today_count,
+    }
   } catch {
-    stats.value = { total_count: 0, today_count: 0, success_rate: 0, failure_count: 0 }
+    stats.value = { total_count: 0, today_count: 0 }
   }
 }
 
@@ -418,7 +420,7 @@ watch(
     body-fill
   >
     <div class="hfl-ops-page hfl-ops-page--fill">
-      <div class="hfl-ops-stats-grid hfl-ops-stats-grid--4">
+      <div class="hfl-ops-stats-grid hfl-ops-stats-grid--2">
         <OpsStatCard
           :label="t('ops.audit.statTotal')"
           :value="stats.total_count"
@@ -429,18 +431,6 @@ watch(
           :label="t('ops.audit.statToday')"
           :value="stats.today_count"
           tone="info"
-          accent-side="left"
-        />
-        <OpsStatCard
-          :label="t('ops.audit.statFailures')"
-          :value="stats.failure_count"
-          tone="danger"
-          accent-side="left"
-        />
-        <OpsStatCard
-          :label="t('ops.audit.statSuccessRate')"
-          :value="`${stats.success_rate}%`"
-          tone="success"
           accent-side="left"
         />
       </div>

--- a/tools/quality/check-release-contracts.sh
+++ b/tools/quality/check-release-contracts.sh
@@ -52,6 +52,10 @@ grep -F './tools/quality/test-docker-image-digest-alias.sh' \
 	"${ROOT}/.github/workflows/release_pipeline.yml" >/dev/null
 grep -F './tools/quality/test-offline-docker-package-plan.sh' \
 	"${ROOT}/.github/workflows/release_pipeline.yml" >/dev/null
+grep -F './tools/quality/test-online-confirm-retry.sh' \
+	"${ROOT}/.github/workflows/release_pipeline.yml" >/dev/null
+grep -F 'Enter y or n (or press Enter to cancel).' "${online_installer}" >/dev/null
+grep -F 'HFL_CONFIRM_TTY' "${online_installer}" >/dev/null
 grep -F './tools/quality/test-language-pack-runtime-index.sh' \
 	"${ROOT}/.github/workflows/release_pipeline.yml" >/dev/null
 grep -F './tools/quality/test-bundled-language-pack-lifecycle.sh' \

--- a/tools/quality/test-offline-docker-package-plan.sh
+++ b/tools/quality/test-offline-docker-package-plan.sh
@@ -33,8 +33,22 @@ SH
 cat >"${tmp}/bin/apt-get" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+for arg in "$@"; do
+	if [[ "${arg}" == "check" ]]; then
+		if [[ "${HFL_FAKE_APT_CHECK:-ok}" == "busy" ]]; then
+			printf 'E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 42.\n' >&2
+			exit 100
+		fi
+		if [[ "${HFL_FAKE_APT_CHECK:-ok}" == "broken" ]]; then
+			printf 'E: Unmet dependencies. Try apt --fix-broken install.\n' >&2
+			exit 100
+		fi
+		exit 0
+	fi
+done
 if [[ "${HFL_FAKE_APT_RESULT:-ok}" == "unresolved" ]]; then
 	printf 'docker-ce: Depends: nftables (>= 9.9) but 1.0 is installed\n' >&2
+	printf "E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).\n" >&2
 	exit 100
 fi
 printf '0 upgraded, 4 newly installed, 0 to remove and 0 not upgraded.\n'
@@ -42,6 +56,13 @@ SH
 cat >"${tmp}/bin/dpkg" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ "${1:-}" == "--audit" ]]; then
+	if [[ "${HFL_FAKE_DPKG_AUDIT:-ok}" == "broken" ]]; then
+		printf 'The following packages have been unpacked but not configured:\n  libpython3.10-stdlib\n' >&2
+		printf 'libpython3.10-stdlib\n'
+	fi
+	exit 0
+fi
 [[ "${1:-}" == "--install" ]]
 printf '%s\n' "${@:2}" >"${HFL_DOCKER_TEST_STATE}/installed"
 SH
@@ -63,6 +84,34 @@ export HFL_DOCKER_TEST_STATE="${tmp}"
 # shellcheck source=../../deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh
 source "${ROOT}/deploy/bootstrap/gateway-install-docker-ubuntu-amd64.sh"
 
+assert_host_apt_healthy
+
+set +e
+broken_out="$(HFL_FAKE_APT_CHECK=broken assert_host_apt_healthy 2>&1)"
+broken_status=$?
+set -e
+[[ "${broken_status}" -eq 3 ]]
+grep -F 'Host package manager is not healthy enough for offline Docker install.' <<<"${broken_out}" >/dev/null
+grep -F 'DANGER: HyperFileLens will not run apt --fix-broken' <<<"${broken_out}" >/dev/null
+
+set +e
+dpkg_broken_out="$(HFL_FAKE_DPKG_AUDIT=broken assert_host_apt_healthy 2>&1)"
+dpkg_broken_status=$?
+set -e
+[[ "${dpkg_broken_status}" -eq 3 ]]
+grep -F 'Host package manager is not healthy enough for offline Docker install.' <<<"${dpkg_broken_out}" >/dev/null
+
+set +e
+busy_out="$(HFL_FAKE_APT_CHECK=busy assert_host_apt_healthy 2>&1)"
+busy_status=$?
+set -e
+[[ "${busy_status}" -eq 3 ]]
+grep -F 'The host package manager is busy.' <<<"${busy_out}" >/dev/null
+if grep -F 'DANGER: HyperFileLens will not run apt --fix-broken' <<<"${busy_out}" >/dev/null; then
+	echo "busy apt state was misclassified as host apt corruption" >&2
+	exit 1
+fi
+
 select_offline_docker_debs "${tmp}/debs"
 [[ "${#deb_files[@]}" -eq 4 ]]
 for deb in "${deb_files[@]}"; do
@@ -80,12 +129,43 @@ install_offline_docker_debs "${tmp}/install.log" "${deb_files[@]}"
 grep -F '/docker-ce_5_29.2.1_amd64.deb' "${tmp}/installed" >/dev/null
 
 set +e
-(
+unresolved_out="$(
 	HFL_FAKE_APT_RESULT=unresolved \
-		validate_offline_docker_plan "${tmp}/unsafe-plan.log" "${deb_files[@]}"
-) >/dev/null 2>&1
+	validate_offline_docker_plan "${tmp}/unsafe-plan.log" "${deb_files[@]}" 2>&1
+)"
 status=$?
 set -e
 [[ "${status}" -eq 3 ]]
+grep -F 'Docker offline package plan could not be resolved without downloads.' <<<"${unresolved_out}" >/dev/null
+if grep -F 'Host package manager is not healthy enough for offline Docker install.' <<<"${unresolved_out}" >/dev/null; then
+	echo "offline bundle failure was misclassified as host apt unhealthy" >&2
+	exit 1
+fi
+
+# If the independent host check fails too, retain the actionable host-APT
+# classification even when the simulation emits generic offline dependency text.
+set +e
+host_broken_out="$(
+	HFL_FAKE_APT_RESULT=unresolved HFL_FAKE_APT_CHECK=broken \
+	validate_offline_docker_plan "${tmp}/host-broken-plan.log" "${deb_files[@]}" 2>&1
+)"
+host_broken_status=$?
+set -e
+[[ "${host_broken_status}" -eq 3 ]]
+grep -F 'Host package manager is not healthy enough for offline Docker install.' <<<"${host_broken_out}" >/dev/null
+
+set +e
+host_busy_out="$(
+	HFL_FAKE_APT_RESULT=unresolved HFL_FAKE_APT_CHECK=busy \
+	validate_offline_docker_plan "${tmp}/host-busy-plan.log" "${deb_files[@]}" 2>&1
+)"
+host_busy_status=$?
+set -e
+[[ "${host_busy_status}" -eq 3 ]]
+grep -F 'The host package manager is busy.' <<<"${host_busy_out}" >/dev/null
+if grep -F 'DANGER: HyperFileLens will not run apt --fix-broken' <<<"${host_busy_out}" >/dev/null; then
+	echo "busy apt plan was misclassified as host apt corruption" >&2
+	exit 1
+fi
 
 printf 'Offline Docker package plan checks passed.\n'

--- a/tools/quality/test-online-confirm-retry.sh
+++ b/tools/quality/test-online-confirm-retry.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Verify online installer confirmation re-prompts on invalid input and still
+# cancels on blank / explicit no. Ctrl+C remains the process INT trap (exit 130).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+installer="${ROOT}/deploy/online/install.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+grep -F 'Enter y or n (or press Enter to cancel).' "${installer}" >/dev/null
+grep -F 'HFL_CONFIRM_TTY' "${installer}" >/dev/null
+
+# Extract fail + confirm_installation into an isolated harness.
+python3 - "${installer}" "${tmp}/confirm.sh" <<'PY'
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+target = Path(sys.argv[2])
+
+
+def extract_function(name: str) -> str:
+    marker = f"\n{name}() {{"
+    start = source.index(marker) + 1
+    depth = 0
+    for index in range(start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise SystemExit(f"unterminated function {name}")
+
+
+fragment = extract_function("fail") + "\n\n" + extract_function("confirm_installation") + "\n"
+target.write_text(
+    "#!/usr/bin/env bash\nset -euo pipefail\n"
+    "ASSUME_YES=0\nINSTALL_ACTION=Install\nTAG=v0.0.0\n\n"
+    + fragment
+    + "\nconfirm_installation\n",
+    encoding="utf-8",
+)
+PY
+chmod +x "${tmp}/confirm.sh"
+
+# Invalid input matching the reported typo (t + backspace), then yes -> success.
+printf 't\010\ny\n' >"${tmp}/answers-yes"
+HFL_CONFIRM_TTY="${tmp}/answers-yes" bash "${tmp}/confirm.sh" >/dev/null 2>"${tmp}/warn-yes"
+grep -F '[WARN] Enter y or n (or press Enter to cancel).' "${tmp}/warn-yes" >/dev/null
+
+# Invalid input, then blank Enter -> cancelled.
+printf 'nope\n\n' >"${tmp}/answers-cancel"
+set +e
+HFL_CONFIRM_TTY="${tmp}/answers-cancel" bash "${tmp}/confirm.sh" >/dev/null 2>"${tmp}/warn-cancel"
+status=$?
+set -e
+[[ "${status}" -eq 1 ]]
+grep -F '[FAIL] installation cancelled' "${tmp}/warn-cancel" >/dev/null
+grep -F '[WARN] Enter y or n (or press Enter to cancel).' "${tmp}/warn-cancel" >/dev/null
+
+# Explicit n cancels without a retry warning.
+printf 'n\n' >"${tmp}/answers-n"
+set +e
+HFL_CONFIRM_TTY="${tmp}/answers-n" bash "${tmp}/confirm.sh" >/dev/null 2>"${tmp}/warn-n"
+status=$?
+set -e
+[[ "${status}" -eq 1 ]]
+grep -F '[FAIL] installation cancelled' "${tmp}/warn-n" >/dev/null
+if grep -F '[WARN] Enter y or n' "${tmp}/warn-n" >/dev/null; then
+	echo "explicit n should not warn about invalid input" >&2
+	exit 1
+fi
+
+printf 'Online installer confirmation retry checks passed.\n'


### PR DESCRIPTION
## Summary

- prevent stale Agent processes from surviving reinstall and upgrade flows
- improve Windows console and non-interactive installer behavior
- classify offline Gateway APT failures without unsafe automatic repairs
- improve Docker and AI engine failure diagnostics
- simplify Audit Logs statistics to total and today counts
- add regression and release-contract coverage

## Validation

- Shell syntax, offline Docker package, online confirmation, release-contract, and language-pack checks
- Ruff checks
- Frontend build, ESLint, and 1,679 Vitest tests
- Go tests require the Go 1.25 toolchain in CI

## Related issues

- Related to #1035
- Related to #1049
- Related to #1063
- Related to #1147
- Related to #1153