### PR TITLE
Clarify unavailable S3 bucket name errors

### DIFF
--- a/language-packs/packs/es/frontend/messages.json
+++ b/language-packs/packs/es/frontend/messages.json
@@ -82,7 +82,7 @@
       "storageS3BucketAccessDenied": "Las credenciales no pueden leer y escribir el bucket seleccionado. Conceda los permisos requeridos del bucket, luego inténtelo de nuevo.",
       "storageS3BucketNotFound": "No se encontró el bucket. Revise su nombre, el endpoint y la región, y vuelva a intentarlo.",
       "storageS3BucketNameInvalid": "El nombre del bucket no es válido para este proveedor de almacenamiento de objetos. Revise las reglas de nombres e intente de nuevo.",
-      "storageS3BucketNameUnavailable": "El nombre del bucket ya está en uso. Si el bucket pertenece a esta cuenta, seleccione el bucket existente; de lo contrario elija otro nombre.",
+      "storageS3BucketNameUnavailable": "Este nombre de bucket no está disponible. Puede que pertenezca a otra cuenta o que ya exista en su cuenta. Si es suyo, seleccione el bucket existente; de lo contrario, elija otro nombre.",
       "storageS3ConfigurationInvalid": "La configuración de conexión del almacenamiento de objetos no es válida. Compruebe el endpoint, la región, el formato de URL y TLS, y vuelva a intentarlo.",
       "storageS3NetworkUnavailable": "No se pudo acceder al endpoint de almacenamiento de objetos. Compruebe el endpoint y la conectividad de red, y vuelva a intentarlo.",
       "storageS3Timeout": "La solicitud al almacenamiento de objetos agotó el tiempo de espera. Compruebe el endpoint y la conectividad de red, y vuelva a intentarlo.",

--- a/language-packs/packs/es/frontend/source-lock.json
+++ b/language-packs/packs/es/frontend/source-lock.json
@@ -66,7 +66,7 @@
   "errors.codes.storageS3BucketAccessDenied": "e5b0740716485042efd90fd53eca0e212061b969bddeba08bb1819609f5f25d4",
   "errors.codes.storageS3BucketNotFound": "34b12ba24382ce891a014d692aa13b7c5b045ff957dc47f8275ef4ea237d7d53",
   "errors.codes.storageS3BucketNameInvalid": "04a3555c1c86bcf810059dc769436746152584c11152a4ddb223e67232927bc9",
-  "errors.codes.storageS3BucketNameUnavailable": "29b11943c843b50fdf7a17513dbffe1f426f1e16891019e2c3d5fbe8530ae2b2",
+  "errors.codes.storageS3BucketNameUnavailable": "210873ca7e53476cc8fd1ce09a3a6a9c35c91e1ee98710343ee68dfe201e1180",
   "errors.codes.storageS3ConfigurationInvalid": "378d1c72da9aace33958f515439e6301e8262e2c6897ddcc27b662acae167efb",
   "errors.codes.storageS3NetworkUnavailable": "83381dd77ca3e04c9c9955881bd2098223be727ba7ba7f312f8942224885623f",
   "errors.codes.storageS3Timeout": "e5b9cd92c67a4ea79a7f26fe897b98be8d8c61fffe67bf88012388306bc45ebe",

--- a/language-packs/packs/zh-hans/frontend/messages.json
+++ b/language-packs/packs/zh-hans/frontend/messages.json
@@ -80,7 +80,7 @@
       "storageS3BucketAccessDenied": "凭据无法读取和写入所选存储桶。授予所需的存储桶权限，然后重试。",
       "storageS3BucketNotFound": "未找到存储桶。请检查存储桶名称、端点和区域后重试。",
       "storageS3BucketNameInvalid": "存储桶名称不符合当前对象存储服务商的规则。请检查命名规则后重试。",
-      "storageS3BucketNameUnavailable": "该存储桶名称已被占用。如果存储桶属于当前账户，请选择已有存储桶；否则请更换名称。",
+      "storageS3BucketNameUnavailable": "该存储桶名称不可用。它可能已被其他账户占用，也可能已存在于当前账户。如果您拥有该存储桶，请选择已有存储桶；否则请更换名称。",
       "storageS3ConfigurationInvalid": "对象存储连接设置无效。检查端点、区域、URL 样式和 TLS 设置，然后重试。",
       "storageS3NetworkUnavailable": "无法到达对象存储端点。检查端点和网络连接，然后重试。",
       "storageS3Timeout": "对象存储请求超时。检查端点和网络连接，然后重试。",

--- a/language-packs/packs/zh-hans/frontend/source-lock.json
+++ b/language-packs/packs/zh-hans/frontend/source-lock.json
@@ -66,7 +66,7 @@
   "errors.codes.storageS3BucketAccessDenied": "e5b0740716485042efd90fd53eca0e212061b969bddeba08bb1819609f5f25d4",
   "errors.codes.storageS3BucketNotFound": "34b12ba24382ce891a014d692aa13b7c5b045ff957dc47f8275ef4ea237d7d53",
   "errors.codes.storageS3BucketNameInvalid": "04a3555c1c86bcf810059dc769436746152584c11152a4ddb223e67232927bc9",
-  "errors.codes.storageS3BucketNameUnavailable": "29b11943c843b50fdf7a17513dbffe1f426f1e16891019e2c3d5fbe8530ae2b2",
+  "errors.codes.storageS3BucketNameUnavailable": "210873ca7e53476cc8fd1ce09a3a6a9c35c91e1ee98710343ee68dfe201e1180",
   "errors.codes.storageS3ConfigurationInvalid": "378d1c72da9aace33958f515439e6301e8262e2c6897ddcc27b662acae167efb",
   "errors.codes.storageS3NetworkUnavailable": "83381dd77ca3e04c9c9955881bd2098223be727ba7ba7f312f8942224885623f",
   "errors.codes.storageS3Timeout": "e5b9cd92c67a4ea79a7f26fe897b98be8d8c61fffe67bf88012388306bc45ebe",

--- a/src/backend/apps/storage/services/internal/s3_validation_errors.py
+++ b/src/backend/apps/storage/services/internal/s3_validation_errors.py
@@ -114,7 +114,7 @@ def classify_s3_validation_error(
     if error_code in _BUCKET_NAME_UNAVAILABLE_CODES:
         return S3ValidationFailure(
             "STORAGE.S3_BUCKET_NAME_UNAVAILABLE",
-            "The bucket name is already in use. If the bucket belongs to this account, select Existing Bucket; otherwise choose another name.",
+            "This bucket name is unavailable. It may already be owned by another account or already exist in your account. If you own it, select Existing Bucket; otherwise choose a different name.",
         )
     if error_code in _PERMISSION_CODES:
         if operation == "bucket_access":

--- a/src/backend/apps/storage/tests/test_s3_validation_errors.py
+++ b/src/backend/apps/storage/tests/test_s3_validation_errors.py
@@ -88,6 +88,8 @@ class S3ValidationErrorTests(SimpleTestCase):
         self.assertEqual(unavailable.code, "STORAGE.S3_BUCKET_NAME_UNAVAILABLE")
         self.assertEqual(owned.code, "STORAGE.S3_BUCKET_NAME_UNAVAILABLE")
         self.assertIn("Existing Bucket", unavailable.message)
+        self.assertIn("another account", unavailable.message)
+        self.assertIn("already exist in your account", unavailable.message)
         self.assertNotIn("unsafe provider detail", invalid.message)
 
     def test_clock_skew_is_distinct_and_retryable(self):

--- a/src/frontend/src/lib/errors/registry.ts
+++ b/src/frontend/src/lib/errors/registry.ts
@@ -76,7 +76,7 @@ export const ERROR_CODE_FALLBACK_EN: Record<string, string> = {
   'STORAGE.S3_BUCKET_ACCESS_DENIED': 'The credentials cannot read and write the selected bucket. Grant the required bucket permissions, then try again.',
   'STORAGE.S3_BUCKET_NOT_FOUND': 'The bucket was not found. Check the bucket name, endpoint, and Region, then try again.',
   'STORAGE.S3_BUCKET_NAME_INVALID': 'The bucket name is not valid for this object storage provider. Check the naming rules and try again.',
-  'STORAGE.S3_BUCKET_NAME_UNAVAILABLE': 'The bucket name is already in use. If the bucket belongs to this account, select Existing Bucket; otherwise choose another name.',
+  'STORAGE.S3_BUCKET_NAME_UNAVAILABLE': 'This bucket name is unavailable. It may already be owned by another account or already exist in your account. If you own it, select Existing Bucket; otherwise choose a different name.',
   'STORAGE.S3_CONFIGURATION_INVALID': 'The object storage connection settings are invalid. Check the endpoint, Region, URL style, and TLS setting, then try again.',
   'STORAGE.S3_NETWORK_UNAVAILABLE': 'The object storage endpoint could not be reached. Check the endpoint and network connectivity, then try again.',
   'STORAGE.S3_TIMEOUT': 'The object storage request timed out. Check the endpoint and network connectivity, then try again.',

--- a/src/frontend/src/locales/en.ts
+++ b/src/frontend/src/locales/en.ts
@@ -90,7 +90,7 @@ export const en = {
       storageS3BucketAccessDenied: 'The credentials cannot read and write the selected bucket. Grant the required bucket permissions, then try again.',
       storageS3BucketNotFound: 'The bucket was not found. Check the bucket name, endpoint, and Region, then try again.',
       storageS3BucketNameInvalid: 'The bucket name is not valid for this object storage provider. Check the naming rules and try again.',
-      storageS3BucketNameUnavailable: 'The bucket name is already in use. If the bucket belongs to this account, select Existing Bucket; otherwise choose another name.',
+      storageS3BucketNameUnavailable: 'This bucket name is unavailable. It may already be owned by another account or already exist in your account. If you own it, select Existing Bucket; otherwise choose a different name.',
       storageS3ConfigurationInvalid: 'The object storage connection settings are invalid. Check the endpoint, Region, URL style, and TLS setting, then try again.',
       storageS3NetworkUnavailable: 'The object storage endpoint could not be reached. Check the endpoint and network connectivity, then try again.',
       storageS3Timeout: 'The object storage request timed out. Check the endpoint and network connectivity, then try again.',


### PR DESCRIPTION
## Summary

- clarify that an unavailable S3 bucket name may belong to another account or already exist in the current account
- preserve the Existing Bucket guidance and stable STORAGE.S3_BUCKET_NAME_UNAVAILABLE error code
- update English, Simplified Chinese, and Spanish translations with language-pack source locks

## Validation

- S3 validation error tests
- frontend API tests
- Chinese and Spanish language-pack frontend contract builds
- git diff --check

Related to #882