### PR TITLE
Add selection calculation loading feedback

### DIFF
--- a/src/frontend/src/composables/useCopilotSelectionPreview.ts
+++ b/src/frontend/src/composables/useCopilotSelectionPreview.ts
@@ -36,6 +36,7 @@ type PreviewOptions = {
   gatewayMode: Ref<'auto' | 'manual'>
   scopes: ComputedRef<CopilotSelectionScope[]>
   translate?: (key: string) => string
+  mockMode?: 'calculating' | 'waiting' | 'error' | 'ready'
 }
 
 // Check once immediately after dispatch, then use a short bounded backoff.
@@ -146,6 +147,8 @@ export function useCopilotSelectionPreview(options: PreviewOptions) {
 
   const canonical = computed(() => canonicalCopilotScopes(options.scopes.value))
   const totals = computed(() => {
+    if (options.mockMode === 'ready') return { fileCount: 1284, sizeBytes: 26_600_000_000 }
+    if (options.mockMode) return null
     let fileCount = 0
     let sizeBytes = 0
     for (const scope of canonical.value.scopes) {
@@ -158,6 +161,7 @@ export function useCopilotSelectionPreview(options: PreviewOptions) {
   })
 
   const calculationStatus = computed<'idle' | 'calculating' | 'waiting' | 'error' | 'ready'>(() => {
+    if (options.mockMode) return options.mockMode
     if (!canonical.value.scopes.length) return 'idle'
     const states = canonical.value.scopes.map((scope) => scopeStates.value[scope.key] || emptyState())
     if (states.some((state) => state.status === 'error')) return 'error'
@@ -646,6 +650,11 @@ export function useCopilotSelectionPreview(options: PreviewOptions) {
   })
 
   function stateForScope(key: string): CopilotSelectionScopeState {
+    if (options.mockMode) return {
+      ...emptyState(),
+      status: options.mockMode,
+      error: options.mockMode === 'error' ? translate('insight.copilot.selectionUnavailable') : '',
+    }
     return scopeStates.value[key] || emptyState()
   }
 

--- a/src/frontend/src/composables/useCopilotSelectionPreview.ts
+++ b/src/frontend/src/composables/useCopilotSelectionPreview.ts
@@ -36,7 +36,6 @@ type PreviewOptions = {
   gatewayMode: Ref<'auto' | 'manual'>
   scopes: ComputedRef<CopilotSelectionScope[]>
   translate?: (key: string) => string
-  mockMode?: 'calculating' | 'waiting' | 'error' | 'ready'
 }
 
 // Check once immediately after dispatch, then use a short bounded backoff.
@@ -147,8 +146,6 @@ export function useCopilotSelectionPreview(options: PreviewOptions) {
 
   const canonical = computed(() => canonicalCopilotScopes(options.scopes.value))
   const totals = computed(() => {
-    if (options.mockMode === 'ready') return { fileCount: 1284, sizeBytes: 26_600_000_000 }
-    if (options.mockMode) return null
     let fileCount = 0
     let sizeBytes = 0
     for (const scope of canonical.value.scopes) {
@@ -161,7 +158,6 @@ export function useCopilotSelectionPreview(options: PreviewOptions) {
   })
 
   const calculationStatus = computed<'idle' | 'calculating' | 'waiting' | 'error' | 'ready'>(() => {
-    if (options.mockMode) return options.mockMode
     if (!canonical.value.scopes.length) return 'idle'
     const states = canonical.value.scopes.map((scope) => scopeStates.value[scope.key] || emptyState())
     if (states.some((state) => state.status === 'error')) return 'error'
@@ -650,11 +646,6 @@ export function useCopilotSelectionPreview(options: PreviewOptions) {
   })
 
   function stateForScope(key: string): CopilotSelectionScopeState {
-    if (options.mockMode) return {
-      ...emptyState(),
-      status: options.mockMode,
-      error: options.mockMode === 'error' ? translate('insight.copilot.selectionUnavailable') : '',
-    }
     return scopeStates.value[key] || emptyState()
   }
 

--- a/src/frontend/src/composables/useKnowledgeSourceForm.ts
+++ b/src/frontend/src/composables/useKnowledgeSourceForm.ts
@@ -90,7 +90,7 @@ function createBackupScopeEntry(): BackupScopeEntry {
 export function useKnowledgeSourceForm(
   editingId: Ref<number | null>,
   sourceType: Ref<KnowledgeSourceType> = ref('backup_source'),
-  options: { snapshotGatewayLinkId?: Ref<number | null>; mockMode?: string } = {},
+  options: { snapshotGatewayLinkId?: Ref<number | null> } = {},
 ) {
   const { t } = useI18n()
 
@@ -128,25 +128,6 @@ export function useKnowledgeSourceForm(
   const scanEnabled = ref(true)
   const ingestPolicy = ref<LensIngestPolicy>(defaultIngestPolicy())
 
-  if (options.mockMode) {
-    const now = new Date().toISOString()
-    snapshots.value = [{
-      id: 9112, snapshot_uid: 'mock-1112', source_type: 'agent', source_ref_id: 1112,
-      source_display_name: 'ray-dev (mock)', backup_config_id: 9112, backup_config_name: 'ray-dev',
-      repository_id: 9112, repository_display_name: 'Mock repository', repository_endpoint_type: 'internal',
-      repository_endpoint: 'mock://ray-dev', task_id: 9112, task_uuid: 'mock-task-1112', trigger_type: 'manual',
-      status: 'completed', started_at: now, finished_at: now, created_at: now, directory_count: 1,
-      successful_directory_count: 1, failed_directory_count: 0, kopia_snapshot_count: 1,
-      total_size_bytes: 26600000000, recoverable_size_bytes: 26600000000, directories: [{
-        id: 9112, backup_config_dir_id: 9112, source_path: '/home/ubuntu/.local', path_type: 'directory',
-        display_name: '/home/ubuntu/.local', repository_id: 9112, status: 'completed', created_at: now,
-        size_bytes: 26600000000, file_count: 1284, dir_count: 42,
-      }],
-    } as never]
-    selectedBackupConfigId.value = 9112
-    backupScopeEntries.value = [{ ...backupScopeEntries.value[0], path: '/home/ubuntu/.local', directoryId: 9112, pathType: 'dir' }]
-    snapshotDetail.value = snapshots.value[0] as never
-  }
 
   const readOnlyGatewayName = ref('')
   const readOnlySourcePath = ref('')
@@ -406,7 +387,6 @@ export function useKnowledgeSourceForm(
   }
 
   async function loadSnapshotDetail(id: number) {
-    if (options.mockMode) return
     snapshotDetail.value = await getBackupSourceSnapshot(id)
     resetBackupScopeState()
   }
@@ -896,7 +876,7 @@ export function useKnowledgeSourceForm(
       if (isEditing.value && editingId.value != null) {
         const row = await fetchKnowledgeSource(editingId.value)
         await hydrateEditForm(row)
-      } else if (!options.mockMode) {
+      } else {
         await Promise.all([loadGateways(), loadSnapshots()])
       }
     } catch (err) {

--- a/src/frontend/src/composables/useKnowledgeSourceForm.ts
+++ b/src/frontend/src/composables/useKnowledgeSourceForm.ts
@@ -90,7 +90,7 @@ function createBackupScopeEntry(): BackupScopeEntry {
 export function useKnowledgeSourceForm(
   editingId: Ref<number | null>,
   sourceType: Ref<KnowledgeSourceType> = ref('backup_source'),
-  options: { snapshotGatewayLinkId?: Ref<number | null> } = {},
+  options: { snapshotGatewayLinkId?: Ref<number | null>; mockMode?: string } = {},
 ) {
   const { t } = useI18n()
 
@@ -127,6 +127,25 @@ export function useKnowledgeSourceForm(
   const gatewayDirTreeRevision = ref(0)
   const scanEnabled = ref(true)
   const ingestPolicy = ref<LensIngestPolicy>(defaultIngestPolicy())
+
+  if (options.mockMode) {
+    const now = new Date().toISOString()
+    snapshots.value = [{
+      id: 9112, snapshot_uid: 'mock-1112', source_type: 'agent', source_ref_id: 1112,
+      source_display_name: 'ray-dev (mock)', backup_config_id: 9112, backup_config_name: 'ray-dev',
+      repository_id: 9112, repository_display_name: 'Mock repository', repository_endpoint_type: 'internal',
+      repository_endpoint: 'mock://ray-dev', task_id: 9112, task_uuid: 'mock-task-1112', trigger_type: 'manual',
+      status: 'completed', started_at: now, finished_at: now, created_at: now, directory_count: 1,
+      successful_directory_count: 1, failed_directory_count: 0, kopia_snapshot_count: 1,
+      total_size_bytes: 26600000000, recoverable_size_bytes: 26600000000, directories: [{
+        id: 9112, backup_config_dir_id: 9112, source_path: '/home/ubuntu/.local', path_type: 'directory',
+        display_name: '/home/ubuntu/.local', repository_id: 9112, status: 'completed', created_at: now,
+        size_bytes: 26600000000, file_count: 1284, dir_count: 42,
+      }],
+    } as never]
+    selectedBackupConfigId.value = 9112
+    backupScopeEntries.value = [{ ...backupScopeEntries.value[0], path: '/home/ubuntu/.local', directoryId: 9112, pathType: 'dir' }]
+  }
 
   const readOnlyGatewayName = ref('')
   const readOnlySourcePath = ref('')

--- a/src/frontend/src/composables/useKnowledgeSourceForm.ts
+++ b/src/frontend/src/composables/useKnowledgeSourceForm.ts
@@ -145,6 +145,7 @@ export function useKnowledgeSourceForm(
     } as never]
     selectedBackupConfigId.value = 9112
     backupScopeEntries.value = [{ ...backupScopeEntries.value[0], path: '/home/ubuntu/.local', directoryId: 9112, pathType: 'dir' }]
+    snapshotDetail.value = snapshots.value[0] as never
   }
 
   const readOnlyGatewayName = ref('')
@@ -405,6 +406,7 @@ export function useKnowledgeSourceForm(
   }
 
   async function loadSnapshotDetail(id: number) {
+    if (options.mockMode) return
     snapshotDetail.value = await getBackupSourceSnapshot(id)
     resetBackupScopeState()
   }
@@ -894,7 +896,7 @@ export function useKnowledgeSourceForm(
       if (isEditing.value && editingId.value != null) {
         const row = await fetchKnowledgeSource(editingId.value)
         await hydrateEditForm(row)
-      } else {
+      } else if (!options.mockMode) {
         await Promise.all([loadGateways(), loadSnapshots()])
       }
     } catch (err) {

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -1043,7 +1043,7 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
 .new-chat-scope-row { border-top: 1px solid #f2f3f5; }
 .new-chat-scope-row__index { color: #86909c; font-size: 12px; font-weight: 700; text-align: center; }
 .new-chat-scope-row__summary { min-width: 0; overflow: hidden; color: #4e5969; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
-.new-chat-scope-row__summary.is-waiting { color: #86909c; }
+.new-chat-scope-row__summary.is-waiting { color: var(--el-color-primary, #409eff); }
 .new-chat-loading-icon {
   display: inline-block;
   margin-right: 5px;
@@ -1052,7 +1052,7 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
   animation: new-chat-loading-spin .9s linear infinite;
 }
 .new-chat-loading-icon.is-waiting {
-  color: #7892b8;
+  color: var(--el-color-primary, #409eff);
 }
 .new-chat-scope-row__summary.is-error { color: var(--color-danger-text, #c45656); }
 .new-chat-scope-row__remove { width: 34px; height: 34px; padding: 0; justify-self: center; }

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -7,6 +7,7 @@ import {
   CirclePlus,
   File,
   FolderOpen,
+  LoaderCircle,
   MessageSquare,
   Plus,
   RefreshCw,
@@ -34,6 +35,10 @@ import {
 
 const router = useRouter()
 const { n, t } = useI18n()
+const mockSelection = new URLSearchParams(window.location.search).get('mockSelection')
+const mockSelectionMode = ['calculating', 'waiting', 'error', 'ready'].includes(mockSelection || '')
+  ? mockSelection as 'calculating' | 'waiting' | 'error' | 'ready'
+  : undefined
 
 type SubmitBlockCode =
   | 'agent_model'
@@ -113,7 +118,7 @@ const {
   validateBackupScopeEntryOnBlur,
   validateAllBackupScopeEntries,
   pickBackupScopeForEntry,
-} = useKnowledgeSourceForm(editingId, sourceType, { snapshotGatewayLinkId })
+} = useKnowledgeSourceForm(editingId, sourceType, { snapshotGatewayLinkId, mockMode: mockSelectionMode })
 
 const sourceScopes = computed(() => backupScopeEntries.value
   .filter((row) => row.path.trim() && row.directoryId)
@@ -147,6 +152,7 @@ const {
   gatewayMode,
   scopes: previewScopes,
   translate: t,
+  mockMode: mockSelectionMode,
 })
 const agentModelReady = computed(() => Boolean(readiness.value?.default_agent_model_ref))
 const visualModelReady = computed(() => Boolean(readiness.value?.default_multimodal_model_ref))
@@ -653,7 +659,7 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
                           'is-waiting': ['calculating', 'waiting'].includes(selectionStateForScope(scopeEntry.id).status),
                           'is-error': selectionStateForScope(scopeEntry.id).status === 'error',
                         }"
-                      >{{ scopeDataSummary(scopeEntry.id) }}</span>
+                      ><LoaderCircle v-if="['calculating', 'waiting'].includes(selectionStateForScope(scopeEntry.id).status)" class="new-chat-loading-icon" :class="{ 'is-waiting': selectionStateForScope(scopeEntry.id).status === 'waiting' }" :size="13" aria-hidden="true" />{{ scopeDataSummary(scopeEntry.id) }}</span>
                       <ElButton
                         type="danger"
                         class="new-chat-scope-row__remove"
@@ -711,14 +717,14 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
                       <div>
                         <dt>{{ t('insight.copilot.files') }}</dt>
                         <dd>
-                          {{ selectionTotals ? n(selectionTotals.fileCount) : t('insight.copilot.calculating') }}
+                          {{ selectionTotals ? n(selectionTotals.fileCount) : (selectionCalculationStatus === 'error' ? t('insight.copilot.unavailable') : t('insight.copilot.calculating')) }}
                           / {{ quotaCount(selectionAdmission?.selection_limits.max_files) }}
                         </dd>
                       </div>
                       <div>
                         <dt>{{ t('insight.copilot.selectedSize') }}</dt>
                         <dd>
-                          {{ selectionTotals ? formatBytes(selectionTotals.sizeBytes) : t('insight.copilot.calculating') }}
+                          {{ selectionTotals ? formatBytes(selectionTotals.sizeBytes) : (selectionCalculationStatus === 'error' ? t('insight.copilot.unavailable') : t('insight.copilot.calculating')) }}
                           / {{ quotaBytes(selectionAdmission?.selection_limits.max_bytes) }}
                         </dd>
                       </div>
@@ -751,7 +757,9 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
                       v-if="submitBlocker?.code === 'selection_preview'"
                       class="new-chat-selection-summary__status"
                       :class="{ 'is-error': selectionCalculationStatus === 'error' || Boolean(selectionAdmissionError) || Boolean(selectionAdmission?.admission.reasons.length) }"
+                      aria-live="polite"
                     >
+                      <LoaderCircle v-if="['calculating', 'waiting'].includes(selectionCalculationStatus) || selectionAdmissionLoading" class="new-chat-loading-icon" :class="{ 'is-waiting': selectionCalculationStatus === 'waiting' }" :size="14" aria-hidden="true" />
                       {{ submitBlocker.message }}
                     </p>
                   </div>
@@ -1030,6 +1038,15 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
 .new-chat-scope-row__index { color: #86909c; font-size: 12px; font-weight: 700; text-align: center; }
 .new-chat-scope-row__summary { min-width: 0; overflow: hidden; color: #4e5969; font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
 .new-chat-scope-row__summary.is-waiting { color: #86909c; }
+.new-chat-loading-icon {
+  display: inline-block;
+  margin-right: 5px;
+  vertical-align: -2px;
+  animation: new-chat-loading-spin .9s linear infinite;
+}
+.new-chat-loading-icon.is-waiting {
+  opacity: .7;
+}
 .new-chat-scope-row__summary.is-error { color: var(--color-danger-text, #c45656); }
 .new-chat-scope-row__remove { width: 34px; height: 34px; padding: 0; justify-self: center; }
 .new-chat-scope-tree { min-width: 100%; }
@@ -1048,6 +1065,16 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
 .new-chat-selection-summary dd { margin: 0; overflow: hidden; color: #1d2129; font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
 .new-chat-selection-summary__status { margin: 10px 0 0; color: #4e5969; font-size: 12px; line-height: 1.5; }
 .new-chat-selection-summary__status.is-error { color: var(--color-danger-text, #c45656); }
+@keyframes new-chat-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .new-chat-loading-icon {
+    animation: none;
+  }
+}
 .new-chat-hint { margin: 10px 0 0; color: #86909c; font-size: 12px; line-height: 1.5; }
 .new-chat-hint--warn { color: #d46b08; }
 .new-chat-gateway-warning { display: flex; width: 100%; box-sizing: border-box; align-items: flex-start; gap: 8px; margin-top: 10px; padding: 10px 12px; border: 1px solid color-mix(in srgb, var(--color-warning) 35%, var(--color-card-bg)); border-radius: 8px; background: color-mix(in srgb, var(--color-warning) 10%, var(--color-card-bg)); color: var(--color-warning-text); font-size: 12px; line-height: 1.5; }

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -1048,10 +1048,11 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
   display: inline-block;
   margin-right: 5px;
   vertical-align: -2px;
+  color: var(--el-color-primary, #409eff);
   animation: new-chat-loading-spin .9s linear infinite;
 }
 .new-chat-loading-icon.is-waiting {
-  opacity: .7;
+  color: #7892b8;
 }
 .new-chat-scope-row__summary.is-error { color: var(--color-danger-text, #c45656); }
 .new-chat-scope-row__remove { width: 34px; height: 34px; padding: 0; justify-self: center; }

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -762,7 +762,7 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
                     <p
                       v-if="submitBlocker?.code === 'selection_preview'"
                       class="new-chat-selection-summary__status"
-                      :class="{ 'is-error': selectionCalculationStatus === 'error' || Boolean(selectionAdmissionError) || Boolean(selectionAdmission?.admission.reasons.length) }"
+                      :class="{ 'is-error': selectionCalculationStatus === 'error' || Boolean(selectionAdmissionError) || Boolean(selectionAdmission?.admission.reasons.length), 'is-waiting': selectionCalculationStatus === 'waiting' }"
                       aria-live="polite"
                     >
                       <LoaderCircle v-if="['calculating', 'waiting'].includes(selectionCalculationStatus) || selectionAdmissionLoading" class="new-chat-loading-icon" :class="{ 'is-waiting': selectionCalculationStatus === 'waiting' }" :size="14" aria-hidden="true" />
@@ -1071,6 +1071,8 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
 .new-chat-selection-summary dt { color: #86909c; font-size: 12px; }
 .new-chat-selection-summary dd { margin: 0; overflow: hidden; color: #1d2129; font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
 .new-chat-selection-summary__status { margin: 10px 0 0; color: #4e5969; font-size: 12px; line-height: 1.5; }
+.new-chat-selection-summary__status:not(.is-error) { color: #315b9c; }
+.new-chat-selection-summary__status.is-waiting { color: #64748b; }
 .new-chat-selection-summary__status.is-error { color: var(--color-danger-text, #c45656); }
 @keyframes new-chat-loading-spin {
   to {

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -396,6 +396,12 @@ async function ensurePrivateGatewayVisible() {
 
 async function load() {
   try {
+    if (mockSelectionMode) {
+      gatewayOptions.value = [{ gateway_link_id: 9112, gateway_id: 9112, name: 'Mock Gateway', scope: 'platform', is_platform_default: true, sidecar_status: 'online', online: true, hfl_usable: true, copilot_eligible: true }]
+      gatewayOptionsResolved.value = true
+      readiness.value = { default_agent_model_ref: 'mock-agent', default_multimodal_model_ref: 'mock-vision' } as LensCopilotReadiness
+      return
+    }
     await Promise.all([
       loadSnapshots(),
       refreshGatewayOptions(false),

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -35,10 +35,6 @@ import {
 
 const router = useRouter()
 const { n, t } = useI18n()
-const mockSelection = new URLSearchParams(window.location.search).get('mockSelection')
-const mockSelectionMode = ['calculating', 'waiting', 'error', 'ready'].includes(mockSelection || '')
-  ? mockSelection as 'calculating' | 'waiting' | 'error' | 'ready'
-  : undefined
 
 type SubmitBlockCode =
   | 'agent_model'
@@ -118,7 +114,7 @@ const {
   validateBackupScopeEntryOnBlur,
   validateAllBackupScopeEntries,
   pickBackupScopeForEntry,
-} = useKnowledgeSourceForm(editingId, sourceType, { snapshotGatewayLinkId, mockMode: mockSelectionMode })
+} = useKnowledgeSourceForm(editingId, sourceType, { snapshotGatewayLinkId })
 
 const sourceScopes = computed(() => backupScopeEntries.value
   .filter((row) => row.path.trim() && row.directoryId)
@@ -152,7 +148,6 @@ const {
   gatewayMode,
   scopes: previewScopes,
   translate: t,
-  mockMode: mockSelectionMode,
 })
 const agentModelReady = computed(() => Boolean(readiness.value?.default_agent_model_ref))
 const visualModelReady = computed(() => Boolean(readiness.value?.default_multimodal_model_ref))
@@ -396,12 +391,6 @@ async function ensurePrivateGatewayVisible() {
 
 async function load() {
   try {
-    if (mockSelectionMode) {
-      gatewayOptions.value = [{ gateway_link_id: 9112, gateway_id: 9112, name: 'Mock Gateway', scope: 'platform', is_platform_default: true, sidecar_status: 'online', online: true, hfl_usable: true, copilot_eligible: true }]
-      gatewayOptionsResolved.value = true
-      readiness.value = { default_agent_model_ref: 'mock-agent', default_multimodal_model_ref: 'mock-vision' } as LensCopilotReadiness
-      return
-    }
     await Promise.all([
       loadSnapshots(),
       refreshGatewayOptions(false),
@@ -1071,7 +1060,9 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
 .new-chat-selection-summary dt { color: #86909c; font-size: 12px; }
 .new-chat-selection-summary dd { margin: 0; overflow: hidden; color: #1d2129; font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
 .new-chat-selection-summary__status { margin: 10px 0 0; color: #4e5969; font-size: 12px; line-height: 1.5; }
-.new-chat-selection-summary__status:not(.is-error) { color: #315b9c; }
+.new-chat-selection-summary__status:not(.is-error) {
+  color: var(--el-color-primary, #409eff);
+}
 .new-chat-selection-summary__status.is-error { color: var(--color-danger-text, #c45656); }
 @keyframes new-chat-loading-spin {
   to {

--- a/src/frontend/src/pages/insight/NewCopilotChat.vue
+++ b/src/frontend/src/pages/insight/NewCopilotChat.vue
@@ -1072,7 +1072,6 @@ onBeforeUnmount(() => backupScopeResizeObserver?.disconnect())
 .new-chat-selection-summary dd { margin: 0; overflow: hidden; color: #1d2129; font-size: 12px; font-weight: 600; font-variant-numeric: tabular-nums; text-overflow: ellipsis; white-space: nowrap; }
 .new-chat-selection-summary__status { margin: 10px 0 0; color: #4e5969; font-size: 12px; line-height: 1.5; }
 .new-chat-selection-summary__status:not(.is-error) { color: #315b9c; }
-.new-chat-selection-summary__status.is-waiting { color: #64748b; }
 .new-chat-selection-summary__status.is-error { color: var(--color-danger-text, #c45656); }
 @keyframes new-chat-loading-spin {
   to {


### PR DESCRIPTION
## Summary
- Add themed loading feedback for New Chat selection calculations
- Distinguish calculating, waiting, and error states while preserving accessibility feedback
- Respect reduced-motion preferences and remove temporary test data before submission

Closes #1112

## Testing
- Related New Chat and selection preview tests passed
- `git diff --check` passed