### PR TITLE
Fix deregistration table tooltips

### DIFF
--- a/src/frontend/src/components/BackupSourceUnregisterDialogBody.vue
+++ b/src/frontend/src/components/BackupSourceUnregisterDialogBody.vue
@@ -177,7 +177,7 @@ function reasonLabel(reason: Parameters<typeof unregisterReasonLabel>[0]) {
                 <span class="hfl-flow-action-dialog__source-name">{{ row.name }}</span>
                 <span class="hfl-flow-action-dialog__source-meta-row">
                   <span
-                    class="backup-source-type-tag"
+                    class="backup-source-type-tag hfl-table-no-tooltip"
                     :class="`backup-source-type-tag--${sourceTypeKind(row)}`"
                   >
                     <component

--- a/src/frontend/src/directives/tableOverflowTitle.test.ts
+++ b/src/frontend/src/directives/tableOverflowTitle.test.ts
@@ -290,6 +290,22 @@ describe('tableOverflowTitle', () => {
     expect(tooltip?.textContent).toBe('Transferred: 900 MB')
   })
 
+  it('hides an open tooltip when the table scrolls', () => {
+    Object.defineProperty(content, 'clientWidth', { configurable: true, value: 80 })
+    Object.defineProperty(content, 'scrollWidth', { configurable: true, value: 200 })
+    content.dataset.tableOverflowTitle = 'Transferred: 900 MB'
+
+    content.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
+    vi.advanceTimersByTime(300)
+    const tooltip = document.querySelector<HTMLElement>('#hfl-table-overflow-tooltip')
+    expect(tooltip?.style.display).toBe('block')
+
+    window.dispatchEvent(new Event('scroll'))
+
+    expect(tooltip?.style.display).toBe('none')
+    delete content.dataset.tableOverflowTitle
+  })
+
   it('disconnects the active content observer when the directive is unmounted', () => {
     content.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }))
     vi.advanceTimersByTime(300)

--- a/src/frontend/src/directives/tableOverflowTitle.ts
+++ b/src/frontend/src/directives/tableOverflowTitle.ts
@@ -398,7 +398,10 @@ function installWithResolvers(
     },
     onScroll: () => {
       clearPendingTooltip(state)
-      if (state.active) positionTooltip(state.active)
+      // A table can contain its own scroll viewport. Once the row moves, the
+      // fixed tooltip is no longer anchored to visible content and may cover
+      // unrelated dialog sections, so hide it until the pointer re-enters.
+      if (state.active) clearTooltip(state)
     },
     onResize: () => {
       clearPendingTooltip(state)


### PR DESCRIPTION
## Summary

- Suppress generic overflow tooltips for fixed `Source Host` and NAS type badges in the deregistration table.
- Close active table overflow tooltips when the table scrolls so they cannot cover unrelated dialog content.
- Preserve overflow tooltips for genuinely truncated backup-source names.

Closes #1174

## Testing

- `npm test -- --run src/directives/tableOverflowTitle.test.ts src/components/BackupSourceUnregisterDialogBody.test.ts src/directives/tableOverflowCoverage.test.ts`
- 3 test files passed, 24 tests passed.
