### PR TITLE
feat: add clear all backup paths action

### DIFF
--- a/src/frontend/src/pages/protection/BackupCreateWizard.vue
+++ b/src/frontend/src/pages/protection/BackupCreateWizard.vue
@@ -13,7 +13,6 @@ import {
   RefreshCw,
   ChevronDown,
   CloudUpload,
-  Trash2,
   Search,
   HardDrive,
   Filter,
@@ -4328,6 +4327,12 @@ function removeWizardDirEntry(key: string) {
   }
 }
 
+function clearWizardDirEntries(sourceId: string) {
+  wizardDirEntries.value = wizardDirEntries.value.filter((entry) => entry.sourceId !== sourceId)
+  createSourceDirKeysBySource[sourceId] = []
+  nextTick(() => refreshCreateSourceTreeBlockedState(sourceId))
+}
+
 watch(
   wizardDirEntries,
   (entries) => {
@@ -6254,6 +6259,15 @@ function preserveShallowestPathOrder(paths: string[]) {
                         <div class="text-xs text-slate-500">
                           {{ t('protection.backupsPage.addedCount', { n: sourceSelectedCount(row.id) }) }}
                         </div>
+                        <button
+                          v-if="sourceSelectedEntries(row.id).length"
+                          type="button"
+                          :aria-label="t('protection.backupsPage.snapshotBrowserClearSelection')"
+                          class="create-dir-clear-button"
+                          @click="clearWizardDirEntries(row.id)"
+                        >
+                          {{ t('protection.backupsPage.snapshotBrowserClearSelection') }}
+                        </button>
                       </div>
                     </div>
                     <div
@@ -10972,6 +10986,31 @@ function preserveShallowestPathOrder(paths: string[]) {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.create-dir-clear-button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font: inherit;
+  font-size: 12px;
+  line-height: 18px;
+  cursor: pointer;
+  color: #475569 !important;
+  border: 1px solid #cbd5e1 !important;
+  background: #fff !important;
+}
+
+.create-dir-clear-button:hover,
+.create-dir-clear-button:focus-visible,
+.create-dir-clear-button:active {
+  color: #dc2626 !important;
+  border-color: #fca5a5 !important;
+  background: #fef2f2 !important;
 }
 
 .create-source-config-detail__title-row .el-checkbox {


### PR DESCRIPTION
## Problem and root cause

Editing backup paths required removing each selected path individually.

## Solution

Add a compact Clear Selection button to each source's selected-path list. It clears that source's paths and pending tree selection, then refreshes tree availability. Other sources retain their selections. The button uses a neutral border with red interaction states and no hover tooltip.

## Validation

- Manual testing: passed
- ESLint: passed
- Existing BackupCreateWizardSmbFilenameEncoding tests: 2 passed
- git diff --check: passed

The existing automated tests do not directly exercise the new clear action; its behavior and appearance were verified manually.

## Risks and compatibility

Frontend-only change using an existing translation key. Clearing affects the editable path selection; it does not delete backed-up data. Existing save validation remains in effect.

Fixes #1169
