### PR TITLE
Standardize backup failure details and step statuses

### DIFF
--- a/src/backend/apps/protection/services/backup_orchestrator.py
+++ b/src/backend/apps/protection/services/backup_orchestrator.py
@@ -2320,14 +2320,36 @@ def advance_backup(
             error_code=error_code,
             error_message=error_message,
         )
+        bt = _bt()
+        bt._set_step_status(
+            task=task,
+            step_name=task.current_step or "kopia_snapshot",
+            status=TaskStep.Status.FAILED,
+            progress=BACKUP_PREPARE_END,
+            current_step=task.current_step,
+        )
+        bt._finalize_remaining_steps(task, failed_step=task.current_step or "kopia_snapshot")
+        diagnostic = error_message.lower()
+        category = "backup_precheck_failed"
+        if "agent source is offline" in diagnostic or "agent websocket is reconnecting" in diagnostic:
+            category = "backup_source_offline"
+        elif "agent source is busy" in diagnostic:
+            category = "backup_source_busy"
+        failure_metadata = {
+            "error_code": error_code,
+            "failure_details": {
+                "category": category,
+            },
+        }
         complete_task(
             task_uuid=task.task_uuid,
             organization_id=organization_id,
             status=Task.Status.FAILED,
             progress=BACKUP_PREPARE_END,
-            result_payload={"source_snapshot_id": source_snapshot.id},
+            result_payload={"source_snapshot_id": source_snapshot.id, **failure_metadata},
             error_code=error_code,
             error_message=error_message,
+            event_metadata={"failure_details": failure_metadata["failure_details"]},
         )
         return {
             "task_uuid": str(task.task_uuid),

--- a/src/backend/apps/task/services/interface.py
+++ b/src/backend/apps/task/services/interface.py
@@ -569,6 +569,7 @@ def complete_task(
     error_code: str = "",
     error_message: str = "",
     include_error_details_in_event: bool = True,
+    event_metadata: dict[str, Any] | None = None,
 ) -> Task:
     if status not in TERMINAL_STATUSES:
         raise ValidationError("complete_task requires a terminal status.")
@@ -611,9 +612,12 @@ def complete_task(
         level=level,
         message=f"Task finished with status {status}",
         metadata=(
-            {"error_code": error_code, "error_message": error_message}
-            if include_error_details_in_event
-            else None
+            {
+                **({"error_code": error_code, "error_message": error_message}
+                   if include_error_details_in_event else {}),
+                **(event_metadata or {}),
+            }
+            or None
         ),
     )
     task_updated.send(

--- a/src/frontend/src/lib/backupFailureDisplay.test.ts
+++ b/src/frontend/src/lib/backupFailureDisplay.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { backupFailureMetadata, backupFailurePresentation } from './backupFailureDisplay'
+
+describe('backup failure compatibility', () => {
+  it('recognizes legacy dictionaries without metadata and preserves the diagnostic', () => {
+    const input = { error_message: "{'source_ref_id': ['Agent source is offline.']}" }
+    expect(backupFailurePresentation(input)?.reason).toContain('was offline')
+    expect(backupFailureMetadata(input).error_message).toBe(input.error_message)
+  })
+  it('reads task result payloads when recent events are absent', () => {
+    expect(backupFailurePresentation({ result_payload: { failure_details: { category: 'backup_source_busy' } } })?.reason).toContain('was busy')
+  })
+  it('does not classify unrelated prechecks as offline', () => {
+    expect(backupFailurePresentation({ error_code: 'BACKUP_PRECHECK_FAILED', error_message: 'Missing directory' })?.reason).toContain('prerequisite')
+  })
+  it('preserves existing structured errors ahead of legacy text', () => {
+    expect(backupFailureMetadata({ failure_details: { category: 'permission_denied' }, error_message: 'Agent source is offline.' }).failure_details).toEqual({ category: 'permission_denied' })
+  })
+})

--- a/src/frontend/src/lib/backupFailureDisplay.ts
+++ b/src/frontend/src/lib/backupFailureDisplay.ts
@@ -1,0 +1,42 @@
+type RecordValue = Record<string, unknown>
+
+function record(value: unknown): RecordValue {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as RecordValue : {}
+}
+
+export const backupFailureCopy: Record<string, { reason: string; resolutions: string[] }> = {
+  backup_source_offline: {
+    reason: 'The backup source was offline or reconnecting when the backup failed.',
+    resolutions: ['Confirm that the backup source host is powered on and connected to the network.', 'Retry the backup after the source is online.'],
+  },
+  backup_source_busy: {
+    reason: 'The backup source was busy when the backup failed.',
+    resolutions: ['Wait for the active operations on the backup source to finish, then retry the backup.'],
+  },
+  backup_precheck_failed: {
+    reason: 'The backup could not pass its prerequisite checks.',
+    resolutions: ['Check the backup source, backup configuration, and target repository before retrying.', 'Review the original error for troubleshooting details.'],
+  },
+}
+
+/** Normalize event metadata and legacy task errors without changing stored data. */
+export function backupFailureMetadata(value: unknown): RecordValue {
+  const source = record(value)
+  const payload = record(source.result_payload)
+  const events = Array.isArray(source.recent_events) ? source.recent_events : []
+  const eventDetails = events.map(event => record(record(event).metadata).failure_details).find(detail => Object.keys(record(detail)).length)
+  const details = record(source.failure_details || payload.failure_details || eventDetails)
+  if (Object.keys(details).length) return { ...source, failure_details: details }
+  const code = String(source.error_code || '')
+  const message = String(source.error_message || '')
+  let category = ''
+  if (/agent source is offline|agent websocket is reconnecting/i.test(message)) category = 'backup_source_offline'
+  else if (/agent source is busy/i.test(message)) category = 'backup_source_busy'
+  else if (code === 'BACKUP_PRECHECK_FAILED') category = 'backup_precheck_failed'
+  return category ? { ...source, failure_details: { category } } : source
+}
+
+export function backupFailurePresentation(value: unknown) {
+  const details = record(backupFailureMetadata(value).failure_details)
+  return backupFailureCopy[String(details.category || '')]
+}

--- a/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/FlowBackupSourceDetailDrawer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { backupFailureMetadata } from '../../../lib/backupFailureDisplay'
 import { computed, nextTick, onUnmounted, reactive, ref, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
@@ -1500,10 +1501,8 @@ function stepDisplayName(stepName?: string | null, taskType?: string | null) {
   return te(key) ? t(key) : t('ops.task.unknownValue')
 }
 
-function taskEventMetadata(event: TaskEventRow) {
-  const metadata = event.metadata
-  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return {}
-  return metadata as Record<string, unknown>
+function taskEventMetadata(event: TaskEventRow): Record<string, unknown> {
+  return backupFailureMetadata(event.metadata)
 }
 
 function taskEventMetadataText(event: TaskEventRow, keys: string[]) {
@@ -5081,7 +5080,7 @@ function onClosed() {
                           v-if="eventErrorText(event)"
                           class="dp-task-detail__event-error"
                         >{{ eventErrorText(event) }}</span>
-                        <TaskEventFailureDetails :metadata="event.metadata" />
+                        <TaskEventFailureDetails :metadata="taskEventMetadata(event)" />
                       </div>
                       <span
                         class="dp-task-detail__event-time"
@@ -5147,7 +5146,7 @@ function onClosed() {
                           v-if="eventErrorText(event)"
                           class="dp-task-detail__event-error"
                         >{{ eventErrorText(event) }}</span>
-                        <TaskEventFailureDetails :metadata="event.metadata" />
+                        <TaskEventFailureDetails :metadata="taskEventMetadata(event)" />
                       </div>
                       <span class="dp-task-detail__event-time">#{{ event.seq }} · <span :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatNullableTime(event.created_at) }}</span></span>
                     </div>
@@ -5199,7 +5198,7 @@ function onClosed() {
                     v-if="eventErrorText(event)"
                     class="dp-task-detail__event-error"
                   >{{ eventErrorText(event) }}</span>
-                  <TaskEventFailureDetails :metadata="event.metadata" />
+                  <TaskEventFailureDetails :metadata="taskEventMetadata(event)" />
                 </div>
                 <span class="dp-task-detail__event-time">#{{ event.seq }} · <span :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatNullableTime(event.created_at) }}</span></span>
               </div>

--- a/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
+++ b/src/frontend/src/pages/protection/components/TaskDetailDrawer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { backupFailureMetadata } from '../../../lib/backupFailureDisplay'
 import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ElMessage } from 'element-plus'
@@ -321,7 +322,7 @@ function taskDuration(row: TaskRow) {
 }
 
 function taskEventMetadata(event: TaskEventRow): Record<string, unknown> {
-  return event.metadata && typeof event.metadata === 'object' ? event.metadata as Record<string, unknown> : {}
+  return backupFailureMetadata(event.metadata)
 }
 
 function hasEventDetailPanel(event: TaskEventRow) {
@@ -1052,7 +1053,7 @@ watch(
                           class="hfl-task-drawer__event-msg"
                           :class="eventMessageClass(event)"
                         >{{ eventDisplayMessage(event) }}</span>
-                        <RepositoryMaintenanceSummary :metadata="event.metadata" />
+                        <RepositoryMaintenanceSummary :metadata="taskEventMetadata(event)" />
                         <span
                           v-if="eventObjectText(event)"
                           class="hfl-task-drawer__event-object"
@@ -1061,7 +1062,7 @@ watch(
                           v-if="eventErrorText(event)"
                           class="hfl-task-drawer__event-error"
                         >{{ eventErrorText(event) }}</span>
-                        <TaskEventFailureDetails :metadata="event.metadata" />
+                        <TaskEventFailureDetails :metadata="taskEventMetadata(event)" />
                       </div>
                       <span
                         class="hfl-task-drawer__event-time"
@@ -1103,12 +1104,12 @@ watch(
                       class="hfl-task-drawer__event-msg"
                       :class="eventMessageClass(event)"
                     >{{ eventDisplayMessage(event) }}</span>
-                    <RepositoryMaintenanceSummary :metadata="event.metadata" />
+                    <RepositoryMaintenanceSummary :metadata="taskEventMetadata(event)" />
                     <span
                       v-if="eventErrorText(event)"
                       class="hfl-task-drawer__event-error"
                     >{{ eventErrorText(event) }}</span>
-                    <TaskEventFailureDetails :metadata="event.metadata" />
+                    <TaskEventFailureDetails :metadata="taskEventMetadata(event)" />
                   </div>
                   <span class="hfl-task-drawer__event-time">#{{ event.seq }} · <span :class="{ 'hfl-empty-mark': !event.created_at }">{{ formatTime(event.created_at) }}</span></span>
                 </div>

--- a/src/frontend/src/pages/protection/components/TaskEventFailureDetails.test.ts
+++ b/src/frontend/src/pages/protection/components/TaskEventFailureDetails.test.ts
@@ -7,6 +7,19 @@ import { en } from '../../../locales/en'
 import TaskEventFailureDetails from './TaskEventFailureDetails.vue'
 
 describe('TaskEventFailureDetails', () => {
+  it('renders legacy offline errors once with collapsed original details', () => {
+    const diagnostic = "{'source_ref_id': ['Agent source is offline.']}"
+    const wrapper = mount(TaskEventFailureDetails, {
+      props: { metadata: { error_code: 'BACKUP_PRECHECK_FAILED', error_message: diagnostic } },
+      global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+    })
+    expect(wrapper.findAll('.task-event-failure__remediation')).toHaveLength(1)
+    expect(wrapper.get('.task-event-failure__summary').text()).toContain('was offline')
+    expect(wrapper.get('details').attributes('open')).toBeUndefined()
+    expect(wrapper.get('details code').text()).toBe(diagnostic)
+    expect(wrapper.text()).not.toContain('Showing 0 of')
+  })
+
   it('shows actionable guidance and every structured failed file', async () => {
     const wrapper = mount(TaskEventFailureDetails, {
       props: {

--- a/src/frontend/src/pages/protection/components/TaskEventFailureDetails.vue
+++ b/src/frontend/src/pages/protection/components/TaskEventFailureDetails.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { backupFailureMetadata, backupFailurePresentation } from '../../../lib/backupFailureDisplay'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { AlertTriangle, ChevronRight, Lightbulb, LockKeyhole } from 'lucide-vue-next'
@@ -20,10 +21,8 @@ const MAX_SKIPPED_ITEMS = 10
 
 const { t } = useI18n()
 
-const metadataRecord = computed<Record<string, unknown>>(() => {
-  if (!props.metadata || typeof props.metadata !== 'object' || Array.isArray(props.metadata)) return {}
-  return props.metadata as Record<string, unknown>
-})
+const metadataRecord = computed(() => backupFailureMetadata(props.metadata))
+const backupFailure = computed(() => backupFailurePresentation(metadataRecord.value))
 
 const failureDetails = computed<Record<string, unknown>>(() => {
   const value = metadataRecord.value.failure_details
@@ -56,6 +55,7 @@ const failedDirectories = computed(() => {
 })
 
 const category = computed(() => String(failureDetails.value.category || 'source_read_failed'))
+const backupSourceOffline = computed(() => Boolean(backupFailure.value))
 const sourcePath = computed(() => String(metadataRecord.value.source_path || '').trim())
 const errorCode = computed(() => String(metadataRecord.value.error_code || '').trim())
 const restorePermissionDenied = computed(() => errorCode.value === 'RESTORE_TARGET_PERMISSION_DENIED')
@@ -64,6 +64,7 @@ const restorePermissionRemediation = computed(() => t('ops.task.failureDetails.r
 const restorePermissionRemediationItems = computed(() => restorePermissionRemediation.value.split('\n').map(item => item.replace(/^\d+\.\s*/, '').trim()).filter(Boolean))
 const restoreTargetPath = computed(() => String(metadataRecord.value.target_path || '').trim())
 const errorDiagnostic = computed(() => String(metadataRecord.value.error_diagnostic || '').trim())
+const originalError = computed(() => String(metadataRecord.value.error_message || '').trim())
 const items = computed<FailureItem[]>(() => {
   const value = failureDetails.value.items
   if (!Array.isArray(value)) return []
@@ -176,6 +177,7 @@ const hasDetails = computed(() => (
   || restorePermissionDenied.value
   || Boolean(summarySnapshotId.value && failedDirectories.value.length)
   || Boolean(summaryRestoreRecordId.value && failedDirectories.value.length)
+  || backupSourceOffline.value
 ))
 
 function fullPath(path: string) {
@@ -212,6 +214,31 @@ function remediationText(code: string) {
     class="task-event-failure"
     :class="{ 'task-event-failure--warning': hasSkippedDetails && !items.length }"
   >
+    <template v-if="backupSourceOffline">
+      <div class="task-event-failure__summary">
+        <AlertTriangle :size="15" />
+        <span>{{ backupFailure?.reason }}</span>
+      </div>
+      <div class="task-event-failure__remediation">
+        <div class="task-event-failure__label">
+          <Lightbulb :size="14" />
+          {{ t('ops.task.failureDetails.howToResolve') }}
+        </div>
+        <ol class="task-event-failure__remediation-list">
+          <li v-for="resolution in backupFailure?.resolutions" :key="resolution">{{ resolution }}</li>
+        </ol>
+      </div>
+      <details
+        v-if="originalError"
+        class="task-event-failure__files"
+      >
+        <summary>
+          <ChevronRight :size="14" />
+          {{ t('ops.task.failureDetails.technicalDetails') }}
+        </summary>
+        <code>{{ originalError }}</code>
+      </details>
+    </template>
     <template v-if="(summarySnapshotId || summaryRestoreRecordId) && failedDirectories.length">
       <div class="task-event-failure__summary task-event-failure__summary--neutral">
         <span>{{ t(summaryRestoreRecordId ? 'ops.task.failureDetails.restoreRecordId' : 'ops.task.failureDetails.snapshotId') }}:</span>
@@ -300,7 +327,7 @@ function remediationText(code: string) {
         <code>{{ errorDiagnostic }}</code>
       </details>
     </template>
-    <template v-if="failureCount > 0 || causes.length">
+    <template v-if="!backupSourceOffline && (failureCount > 0 || causes.length)">
       <div class="task-event-failure__summary">
         <LockKeyhole
           v-if="category === 'source_file_locked'"

--- a/src/frontend/src/pages/protection/components/TaskTerminalOutcomeCell.vue
+++ b/src/frontend/src/pages/protection/components/TaskTerminalOutcomeCell.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { backupFailurePresentation } from '../../../lib/backupFailureDisplay'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -12,6 +13,7 @@ type TaskOutcomeSource = {
   finished_at?: string | null
   started_at?: string | null
   created_at?: string | null
+  result_payload?: unknown
   recent_events?: Array<{ metadata?: unknown }>
 }
 
@@ -70,10 +72,11 @@ const outcome = computed(() => {
   const structuredReason = details && Number.isFinite(detailCount) && detailCount > 0 && te(detailKey)
     ? t(detailKey, { count: detailCount })
     : ''
-  const displayReason = structuredReason || reason
+  const friendly = backupFailurePresentation(source) || backupFailurePresentation(diagnosticFallback)
+  const displayReason = friendly?.reason || structuredReason || (/agent|source_ref_id|^\s*(?:\[|\{)/i.test(reason) ? 'The task failed. Open task details for troubleshooting.' : reason)
   const showDiagnostic = diagnosticStatuses.has(status) && Boolean(code || displayReason)
   const diagnostic = showDiagnostic
-    ? [code ? `[${code}]` : '', displayReason].filter(Boolean).join(' ')
+    ? [code && !friendly ? `[${code}]` : '', displayReason].filter(Boolean).join(' ')
     : ''
   const rawTimestamp = source.finished_at
     || source.started_at
@@ -89,7 +92,7 @@ const outcome = computed(() => {
     tone: taskStatusTone(status),
     label: t(`ops.task.status.${status}`),
     timestamp,
-    code,
+    code: friendly ? '' : code,
     reason: displayReason,
     diagnostic,
     showDiagnostic,


### PR DESCRIPTION
## Problem and root cause

Backup precheck failures left the current step in `Running` and later steps in `Queued`, while task lists and details exposed raw backend diagnostics. The failure event and task outcome did not share a consistent structured failure representation.

## Solution

- Mark the active backup step as failed and remaining steps as skipped on precheck failure.
- Store structured failure details in the task result and terminal event metadata.
- Add shared frontend parsing for event metadata, task payloads, and legacy error messages.
- Show concise user facing failure text in task lists and the standard cause, resolution, and expandable original error sections in task details.
- Keep internal terms and raw dictionaries out of the primary user facing message.

## Validation

- Manual testing: passed.
- Frontend targeted tests: 25 passed.
- Frontend production build: passed.
- Python compilation and `git diff --check`: passed.
- Backend test suite was not run because `uv` and `pytest` are unavailable in the local environment.

## Risks and compatibility

Legacy tasks remain compatible through frontend fallback parsing. Existing structured failure details take precedence over legacy diagnostics. No schema or migration changes are required.

Fixes #1166
